### PR TITLE
Modified: Added share speaker info intent

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/activities/SpeakersActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/activities/SpeakersActivity.java
@@ -11,6 +11,8 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.content.Intent;
+import android.support.v4.view.MenuItemCompat;
 
 import org.fossasia.openevent.R;
 import org.fossasia.openevent.adapters.SessionsListAdapter;
@@ -18,6 +20,7 @@ import org.fossasia.openevent.data.Session;
 import org.fossasia.openevent.data.Speaker;
 import org.fossasia.openevent.dbutils.DbSingleton;
 import org.fossasia.openevent.utils.SpeakerIntent;
+import org.fossasia.openevent.api.Urls;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -74,6 +77,28 @@ public class SpeakersActivity extends AppCompatActivity implements SearchView.On
             case android.R.id.home:
                 finish();
                 return true;
+            case R.id.share_speakers_url:
+                Intent sendIntent = new Intent();
+                sendIntent.setAction(Intent.ACTION_SEND);
+                sendIntent.putExtra(Intent.EXTRA_SUBJECT, getResources().getString(R.string.subject));
+                StringBuilder message = new StringBuilder();
+                message.append(String.format("%s %s %s %s\n\n",
+                        selectedSpeaker.getName(),
+                        getResources().getString(R.string.message_1),
+                        getResources().getString(R.string.app_name),
+                        getResources().getString(R.string.message_2)));
+                for (Session m : mSessions) {
+                    message.append(m.getTitle())
+                            .append(",");
+                }
+                message.append(String.format("\n\n%s (%s)\n%s",
+                        getResources().getString(R.string.message_3),
+                        Urls.APP_LINK,
+                        selectedSpeaker.getPhoto()));
+                sendIntent.putExtra(Intent.EXTRA_TEXT, message.toString());
+                sendIntent.setType("text/plain");
+                startActivity(Intent.createChooser(sendIntent, selectedSpeaker.getEmail()));
+
         }
         return super.onOptionsItemSelected(item);
     }
@@ -81,9 +106,9 @@ public class SpeakersActivity extends AppCompatActivity implements SearchView.On
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        getMenuInflater().inflate(R.menu.menu_speakers_activity, menu);
-        SearchView searchView =
-                (SearchView) menu.findItem(R.id.search_sessions).getActionView();
+        getMenuInflater().inflate(R.menu.menu_speakers, menu);
+        final MenuItem item = menu.findItem(R.id.action_search_speakers);
+        final SearchView searchView = (SearchView) MenuItemCompat.getActionView(item);
         searchView.setOnQueryTextListener(this);
         return true;
     }

--- a/app/src/main/java/org/fossasia/openevent/api/Urls.java
+++ b/app/src/main/java/org/fossasia/openevent/api/Urls.java
@@ -28,4 +28,5 @@ public abstract class Urls {
 
     public static final String BASE_GET_URL_ALT = "https://raw.githubusercontent.com/fossasia/open-event/master/testapi";
 
+    public static final String APP_LINK = "https://app_link_goes_here.com";
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,4 +76,9 @@
     <string name="bullet">"•"</string>
     <string name="bookmarks">Bookmarks</string>
 
+    <!--Speaker-->
+    <string name="subject">Speaker profile</string>
+    <string name="message_1"> is speaking at </string>
+    <string name="message_2"> on the topics: </string>
+    <string name="message_3"> For more information checkout this app on google play store: </string>
 </resources>


### PR DESCRIPTION
Following @creativepsyco 's suggestion of removing the email address as an entity which can be shared and modifying the content being shared to include: 
 * Speaker's Name
 *  Event Name 
 * Speaker's talk topic
 * Speaker's Picture
 * Link to Application 

I have scrapped-off the email from the content being shared and added place holders for the above mentioned. Here's how it looks: 
![ezgif com-video-to-gif](https://cloud.githubusercontent.com/assets/12641346/12508644/3ba382f0-c123-11e5-8437-5ab79f05c3ee.gif)

