### PR TITLE
bump version to 0.8.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,8 +22,8 @@ android {
         applicationId "org.fossasia.openevent"
         minSdkVersion 15
         targetSdkVersion 23
-        versionCode 1
-        versionName "0.1"
+        versionCode 80
+        versionName "0.8.0"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "GIT_SHA", "\"${gitSha}\""


### PR DESCRIPTION
two reasons -
 1. This will help test that the shipping branch works at it should
 2. We need to get from v0.1 to something larger than 0.7 because tags
    till 0.7 are already made
 3. Semantic versioning !


Signed-off-by: Arnav Gupta <championswimmer@gmail.com>