### PR TITLE
Added Missing Track Details in Session details

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/activities/LocationActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/activities/LocationActivity.java
@@ -15,6 +15,7 @@ import org.fossasia.openevent.R;
 import org.fossasia.openevent.adapters.SessionsListAdapter;
 import org.fossasia.openevent.data.Microlocation;
 import org.fossasia.openevent.data.Session;
+import org.fossasia.openevent.data.Track;
 import org.fossasia.openevent.dbutils.DbSingleton;
 import org.fossasia.openevent.utils.IntentStrings;
 
@@ -49,7 +50,7 @@ public class LocationActivity extends BaseActivity implements SearchView.OnQuery
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_locations);
-        DbSingleton dbSingleton = DbSingleton.getInstance();
+        final DbSingleton dbSingleton = DbSingleton.getInstance();
         location = getIntent().getStringExtra(IntentStrings.MICROLOCATIONS);
         final Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar_locations);
         setSupportActionBar(toolbar);
@@ -71,8 +72,11 @@ public class LocationActivity extends BaseActivity implements SearchView.OnQuery
 
                 Session model = (Session) sessionsListAdapter.getItem(position);
                 String sessionName = model.getTitle();
+                Track track = dbSingleton.getTrackbyId(model.getTrack());
+                String trackName = track.getName();
                 Intent intent = new Intent(getApplicationContext(), SessionDetailActivity.class);
                 intent.putExtra(IntentStrings.SESSION, sessionName);
+                intent.putExtra(IntentStrings.TRACK, trackName);
                 startActivity(intent);
             }
         });

--- a/app/src/main/java/org/fossasia/openevent/activities/SpeakersActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/activities/SpeakersActivity.java
@@ -23,6 +23,7 @@ import org.fossasia.openevent.adapters.SessionsListAdapter;
 import org.fossasia.openevent.api.Urls;
 import org.fossasia.openevent.data.Session;
 import org.fossasia.openevent.data.Speaker;
+import org.fossasia.openevent.data.Track;
 import org.fossasia.openevent.dbutils.DbSingleton;
 import org.fossasia.openevent.utils.CircleTransform;
 import org.fossasia.openevent.utils.IntentStrings;
@@ -58,7 +59,7 @@ public class SpeakersActivity extends AppCompatActivity implements SearchView.On
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_speakers);
-        DbSingleton dbSingleton = DbSingleton.getInstance();
+        final DbSingleton dbSingleton = DbSingleton.getInstance();
         speaker = getIntent().getStringExtra(Speaker.SPEAKER);
         final Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar_speakers);
         setSupportActionBar(toolbar);
@@ -134,8 +135,11 @@ public class SpeakersActivity extends AppCompatActivity implements SearchView.On
 
                 Session model = (Session) sessionsListAdapter.getItem(position);
                 String sessionName = model.getTitle();
+                Track track = dbSingleton.getTrackbyId(model.getTrack());
+                String trackName = track.getName();
                 Intent intent = new Intent(getApplicationContext(), SessionDetailActivity.class);
                 intent.putExtra(IntentStrings.SESSION, sessionName);
+                intent.putExtra(IntentStrings.TRACK, trackName);
                 startActivity(intent);
             }
         });

--- a/app/src/main/java/org/fossasia/openevent/dbutils/DatabaseOperations.java
+++ b/app/src/main/java/org/fossasia/openevent/dbutils/DatabaseOperations.java
@@ -435,6 +435,32 @@ public class DatabaseOperations {
 
     }
 
+    public Track getTracksbyTracksId(int id, SQLiteDatabase mDb) {
+        String tracksColumnSelection = DbContract.Tracks.ID + EQUAL + DatabaseUtils.sqlEscapeString(String.valueOf(id));
+
+        Cursor tracksCursor = mDb.query(
+                DbContract.Tracks.TABLE_NAME,
+                DbContract.Tracks.FULL_PROJECTION,
+                tracksColumnSelection,
+                null,
+                null,
+                null,
+                null
+        );
+
+        tracksCursor.moveToFirst();
+
+        Track selected = new Track(
+                tracksCursor.getInt(tracksCursor.getColumnIndex(DbContract.Tracks.ID)),
+                tracksCursor.getString(tracksCursor.getColumnIndex(DbContract.Tracks.NAME)),
+                tracksCursor.getString(tracksCursor.getColumnIndex(DbContract.Tracks.DESCRIPTION)),
+                tracksCursor.getString(tracksCursor.getColumnIndex(DbContract.Tracks.IMAGE))
+        );
+        tracksCursor.close();
+        return selected;
+
+    }
+
     public void insertQueries(ArrayList<String> queries, DbHelper mDbHelper) {
 
         try {

--- a/app/src/main/java/org/fossasia/openevent/dbutils/DbSingleton.java
+++ b/app/src/main/java/org/fossasia/openevent/dbutils/DbSingleton.java
@@ -150,6 +150,10 @@ public class DbSingleton {
         return databaseOperations.getTracksbyTracksname(trackName, mDb);
     }
 
+    public Track getTrackbyId(int id) {
+        return databaseOperations.getTracksbyTracksId(id, mDb);
+    }
+
     public Speaker getSpeakerbySpeakersname(String speakerName) {
         return databaseOperations.getSpeakerbySpeakersname(speakerName, mDb);
     }

--- a/app/src/main/java/org/fossasia/openevent/fragments/BookmarksFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/fragments/BookmarksFragment.java
@@ -19,6 +19,7 @@ import org.fossasia.openevent.activities.SessionDetailActivity;
 import org.fossasia.openevent.adapters.SessionsListAdapter;
 import org.fossasia.openevent.api.Urls;
 import org.fossasia.openevent.data.Session;
+import org.fossasia.openevent.data.Track;
 import org.fossasia.openevent.dbutils.DbSingleton;
 import org.fossasia.openevent.utils.IntentStrings;
 
@@ -75,7 +76,7 @@ public class BookmarksFragment extends Fragment {
         view = inflater.inflate(R.layout.fragment_bookmarks, container, false);
         noBookmarkView = (TextView) view.findViewById(R.id.txt_no_bookmarks);
         bookmarkedTracks = (RecyclerView) view.findViewById(R.id.list_bookmarks);
-        DbSingleton dbSingleton = DbSingleton.getInstance();
+        final DbSingleton dbSingleton = DbSingleton.getInstance();
 
         try {
             bookmarkedIds = dbSingleton.getBookmarkIds();
@@ -103,8 +104,11 @@ public class BookmarksFragment extends Fragment {
             public void onItemClick(int position, View view) {
                 Session model = (Session) sessionsListAdapter.getItem(position);
                 String sessionName = model.getTitle();
+                Track track = dbSingleton.getTrackbyId(model.getTrack());
+                String trackName = track.getName();
                 Intent intent = new Intent(getContext(), SessionDetailActivity.class);
                 intent.putExtra(IntentStrings.SESSION, sessionName);
+                intent.putExtra(IntentStrings.TRACK, trackName);
                 startActivity(intent);
             }
         });


### PR DESCRIPTION
Fixed #319 : When any Session Details is opened either through Bookmarks,Speakers,Location Fragment, **track details was missing.** 

![screenshot_20160401-150937](https://cloud.githubusercontent.com/assets/13851773/14204993/a4550c86-f825-11e5-93ec-0d5b3c415239.png)