### PR TITLE
Fixed Redundant empty Bookmarks Page

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
+++ b/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
@@ -255,9 +255,14 @@ public class MainActivity extends BaseActivity {
                 getSupportActionBar().setTitle(R.string.menu_tracks);
                 break;
             case R.id.nav_bookmarks:
-                fragmentManager.beginTransaction()
-                        .replace(R.id.content_frame, new BookmarksFragment(), FRAGMENT_TAG).commit();
-                getSupportActionBar().setTitle(R.string.menu_bookmarks);
+                DbSingleton dbSingleton = DbSingleton.getInstance();
+                if (!dbSingleton.isBookmarksTableEmpty()) {
+                    fragmentManager.beginTransaction()
+                            .replace(R.id.content_frame, new BookmarksFragment(), FRAGMENT_TAG).commit();
+                    getSupportActionBar().setTitle(R.string.menu_bookmarks);
+                } else {
+                    DialogFactory.createSimpleActionDialog(this, R.string.bookmarks, R.string.empty_list, null).show();
+                }
                 break;
             case R.id.nav_speakers:
                 fragmentManager.beginTransaction()

--- a/app/src/main/java/org/fossasia/openevent/dbutils/DatabaseOperations.java
+++ b/app/src/main/java/org/fossasia/openevent/dbutils/DatabaseOperations.java
@@ -840,6 +840,22 @@ public class DatabaseOperations {
         return number;
     }
 
+    public boolean isBookmarksTableEmpty(SQLiteDatabase db) {
+        boolean check = false;
+        Cursor c = null;
+        try {
+            c = db.rawQuery("select * from " + DbContract.Bookmarks.TABLE_NAME, null);
+            if (c.getCount() == 0){
+                check = true;
+            }
+        } catch (Exception e){
+            Timber.e("Parsing Error Occurred at DatabaseOperations::isBookmarksTableEmpty.");
+        } finally {
+            if (c != null) c.close();
+        }
+        return check;
+    }
+
     public Session getSessionbySessionname(String sessionName, SQLiteDatabase mDb) {
         String sessionColumnSelection = DbContract.Sessions.TITLE + EQUAL + DatabaseUtils.sqlEscapeString(sessionName);
         Cursor cursor = mDb.query(

--- a/app/src/main/java/org/fossasia/openevent/dbutils/DbSingleton.java
+++ b/app/src/main/java/org/fossasia/openevent/dbutils/DbSingleton.java
@@ -166,6 +166,9 @@ public class DbSingleton {
         return databaseOperations.isBookmarked(sessionId, mDb);
     }
 
+    public boolean isBookmarksTableEmpty() {
+        return databaseOperations.isBookmarksTableEmpty(mDb);
+    }
     public ArrayList<Integer> getBookmarkIds() throws ParseException {
 
         getReadOnlyDatabase();

--- a/app/src/main/java/org/fossasia/openevent/fragments/BookmarksFragment.java
+++ b/app/src/main/java/org/fossasia/openevent/fragments/BookmarksFragment.java
@@ -1,9 +1,12 @@
 package org.fossasia.openevent.fragments;
 
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentTransaction;
+import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -22,6 +25,7 @@ import org.fossasia.openevent.data.Session;
 import org.fossasia.openevent.data.Track;
 import org.fossasia.openevent.dbutils.DbSingleton;
 import org.fossasia.openevent.utils.IntentStrings;
+import org.fossasia.openevent.widget.DialogFactory;
 
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -33,10 +37,10 @@ import timber.log.Timber;
  * Date: 22-05-2015
  */
 public class BookmarksFragment extends Fragment {
-    SessionsListAdapter sessionsListAdapter;
 
+    private final String FRAGMENT_TAG = "FTAG";
+    SessionsListAdapter sessionsListAdapter;
     RecyclerView bookmarkedTracks;
-    TextView noBookmarkView;
     View view;
     ArrayList<Integer> bookmarkedIds;
 
@@ -60,10 +64,16 @@ public class BookmarksFragment extends Fragment {
             }
         }
         if (!bookmarkedIds.isEmpty()) {
-            noBookmarkView.setVisibility(View.GONE);
             bookmarkedTracks.setVisibility(View.VISIBLE);
         } else {
-            noBookmarkView.setVisibility(View.VISIBLE);
+            DialogFactory.createSimpleActionDialog(getActivity(), R.string.bookmarks, R.string.empty_list, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    FragmentTransaction fragmentTransaction = getFragmentManager().beginTransaction();
+                    fragmentTransaction.replace(R.id.content_frame, new TracksFragment(), FRAGMENT_TAG).commit();
+                    ((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(R.string.menu_tracks);
+                }
+            }).show();
             bookmarkedTracks.setVisibility(View.GONE);
         }
     }
@@ -74,7 +84,6 @@ public class BookmarksFragment extends Fragment {
         Timber.i("Bookmarks Fragment create view");
         setHasOptionsMenu(true);
         view = inflater.inflate(R.layout.fragment_bookmarks, container, false);
-        noBookmarkView = (TextView) view.findViewById(R.id.txt_no_bookmarks);
         bookmarkedTracks = (RecyclerView) view.findViewById(R.id.list_bookmarks);
         final DbSingleton dbSingleton = DbSingleton.getInstance();
 
@@ -84,13 +93,7 @@ public class BookmarksFragment extends Fragment {
         } catch (ParseException e) {
             Timber.e("Parsing Error Occurred at BookmarksFragment::onCreateView.");
         }
-        if (!bookmarkedIds.isEmpty()) {
-            noBookmarkView.setVisibility(View.GONE);
-            bookmarkedTracks.setVisibility(View.VISIBLE);
-        } else {
-            noBookmarkView.setVisibility(View.VISIBLE);
-            bookmarkedTracks.setVisibility(View.GONE);
-        }
+        bookmarkedTracks.setVisibility(View.VISIBLE);
         sessionsListAdapter = new SessionsListAdapter(new ArrayList<Session>());
         for (int i = 0; i < bookmarkedIds.size(); i++) {
             Integer id = bookmarkedIds.get(i);

--- a/app/src/main/res/layout/fragment_bookmarks.xml
+++ b/app/src/main/res/layout/fragment_bookmarks.xml
@@ -4,15 +4,6 @@
     android:layout_height="match_parent"
     android:padding="7dp">
 
-    <TextView
-        android:id="@+id/txt_no_bookmarks"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerHorizontal="true"
-        android:layout_centerVertical="true"
-        android:text="@string/noBookmark"
-        android:textAppearance="?android:attr/textAppearanceLarge" />
-
     <android.support.v7.widget.RecyclerView
         android:id="@+id/list_bookmarks"
         android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #338.

Added a simple check once the user presses the Bookmarks option on NavDrawer. If no bookmarks exist, it shows up a prompt rather than lead him to an empty screen, thus saving time of the user. So the BookmarksFragment gets loaded only when some sessions are bookmarked.

Also, if we un-bookmark a session and the Bookmarks list becomes empty again, it shows up the dialog on pressing the back button on that Session Detail, and clicking on OK loads the TracksFragment back again.

This also happens to be one of the layout changes suggested in [my proposal](https://docs.google.com/document/d/1P1-UE0PFEE6KAnYhrdkRBmqzgYoUnN1ZFWQeC_p_mh4/edit), to reduce the blankiness in the application.

@championswimmer @mananwason @juslee