### PR TITLE
added code to sign and send the signed release apk

### DIFF
--- a/apk-generator/scripts/buildApk.sh
+++ b/apk-generator/scripts/buildApk.sh
@@ -8,7 +8,9 @@ cd ./open-event-android/android
 echo "Start building apk"
 #chmod -R 777 $1/open-event-android/android/.gradle/2.11/ 
 export ANDROID_HOME=/var/www/android-sdk-linux/
-./gradlew assembleDebug --stacktrace
+./gradlew assembleRelease --info
+jarsigner -keystore <KeystorePath> -storepass <KeystorePass> <ApkPath> <key_alias>
+~/android-sdk-linux/build-tools/23.0.2/zipalign -v 4 app/build/outputs/apk/app-googleplay-release-unsigned.apk releaseapk.apk
 echo "done"
 
 


### PR DESCRIPTION
@the-dagger @mariobehling This commit adds the functionality to send the signed and zip aligned apk to organiser, so now the organiser just has to upload this apk on the play store account.