### PR TITLE
Speedup Travis CI build (Fixes #642)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ android:
   - build-tools-$ANDROID_BUILD_TOOLS_VERSION
   - "$ANDROID_TARGET"
   - android-24
-  - extra-google-google_play_services
-  - extra-android-support
   - extra-google-m2repository
   - extra-android-m2repository
   - sys-img-armeabi-v7a-$ANDROID_TARGET


### PR DESCRIPTION
The Android Support Library and Google Play Services Library are deprecated and use of the repositories is recommended. This project has both so this will save some time. Fixes #642.