### PR TITLE
fixes #649.

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
@@ -477,6 +477,7 @@ public class MainActivity extends BaseActivity {
             if (getSupportActionBar() != null) {
                 getSupportActionBar().setTitle(R.string.menu_tracks);
             }
+            navigationView.setCheckedItem(R.id.nav_tracks);
         }
     }
 


### PR DESCRIPTION
pressing back when any other screen except "tracks" is selected reverts view to tracks but navigation view is not getting updated properly.
fixes #649.