### PR TITLE
fix issue #720 #715 app crash when revisit any page: location, speaker, sp…

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/fragments/LocationsFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/fragments/LocationsFragment.java
@@ -165,6 +165,7 @@ public class LocationsFragment extends Fragment implements SearchView.OnQueryTex
     public void onDestroyView() {
         super.onDestroyView();
         unbinder.unbind();
+        OpenEventApp.getEventBus().unregister(this);
     }
 
     @Subscribe

--- a/android/app/src/main/java/org/fossasia/openevent/fragments/SpeakerFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/fragments/SpeakerFragment.java
@@ -125,6 +125,7 @@ public class SpeakerFragment extends Fragment implements SearchView.OnQueryTextL
     public void onDestroyView() {
         super.onDestroyView();
         unbinder.unbind();
+        OpenEventApp.getEventBus().unregister(this);
     }
 
     @Override

--- a/android/app/src/main/java/org/fossasia/openevent/fragments/SponsorsFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/fragments/SponsorsFragment.java
@@ -57,8 +57,7 @@ public class SponsorsFragment extends Fragment {
         final View view = inflater.inflate(R.layout.list_sponsors, container, false);
         unbinder = ButterKnife.bind(this,view);
 
-        Bus bus = OpenEventApp.getEventBus();
-        bus.register(this);
+        OpenEventApp.getEventBus().register(this);
         final DbSingleton dbSingleton = DbSingleton.getInstance();
 
         swipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
@@ -110,6 +109,7 @@ public class SponsorsFragment extends Fragment {
     public void onDestroyView() {
         super.onDestroyView();
         unbinder.unbind();
+        OpenEventApp.getEventBus().unregister(this);
     }
 
 

--- a/android/app/src/main/java/org/fossasia/openevent/fragments/TracksFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/fragments/TracksFragment.java
@@ -113,6 +113,7 @@ public class TracksFragment extends Fragment implements SearchView.OnQueryTextLi
     @Override
     public void onDestroyView() {
         super.onDestroyView();
+        OpenEventApp.getEventBus().unregister(this);
         unbinder.unbind();
     }
 


### PR DESCRIPTION
it's easy to reproduce. 
1. click track.
2. click speaker
3. click track. ====> crash. 
it's also happen with speaker, track, sponsors and location page when user revisit them.
Because OnDestroyView it unbind all view, but this instance still keep as handler event. 
So when swipe refresh, download data and call back handler event, Null pointer exception appear. 
We need to unRegister event in onDestroyView too.  
Please help me check it.