### PR TITLE
fixed #880 : Added background color to navigation header and changed twitter logo to fossasia logo

### DIFF
--- a/android/app/src/main/res/layout/nav_header.xml
+++ b/android/app/src/main/res/layout/nav_header.xml
@@ -5,6 +5,7 @@
     android:gravity="bottom"
     android:orientation="vertical"
     android:padding="4dp"
+    android:background="@color/color_primary"
     android:theme="@style/ThemeOverlay.AppCompat.Dark">
 
     <ImageView
@@ -12,6 +13,6 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
         android:contentDescription="@string/header_image"
-        android:src="@drawable/twitter" />
+        android:src="@mipmap/ic_launcher" />
 
 </LinearLayout>


### PR DESCRIPTION
fixes #880 : Added background color to navigation header and changed twitter logo to fossasia logo.           This was previous look:
![twitter_logo](https://cloud.githubusercontent.com/assets/9937007/21750717/9e02ea68-d5df-11e6-9c58-640275326c9d.jpg)                                                                                                              
 This is new look:
![fossasia_logo](https://cloud.githubusercontent.com/assets/9937007/21750721/b70e0d6c-d5df-11e6-9c12-791f3da92f2d.jpg)
