### PR TITLE
Location of every event displayed accurately on map

### DIFF
--- a/android/app/src/fdroid/java/org/fossasia/openevent/fragments/OSMapFragment.java
+++ b/android/app/src/fdroid/java/org/fossasia/openevent/fragments/OSMapFragment.java
@@ -1,10 +1,12 @@
 package org.fossasia.openevent.fragments;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
@@ -24,7 +26,10 @@ import org.fossasia.openevent.BuildConfig;
 import org.fossasia.openevent.R;
 import org.fossasia.openevent.api.Urls;
 import org.fossasia.openevent.data.Event;
+import org.fossasia.openevent.data.Microlocation;
+import org.fossasia.openevent.data.Session;
 import org.fossasia.openevent.dbutils.DbSingleton;
+import org.fossasia.openevent.utils.ConstantStrings;
 import org.osmdroid.DefaultResourceProxyImpl;
 import org.osmdroid.tileprovider.constants.OpenStreetMapTileProviderConstants;
 import org.osmdroid.util.GeoPoint;
@@ -49,11 +54,13 @@ public class OSMapFragment extends Fragment {
     private View rootView;
 
     private Snackbar snackbar;
+
+    private SharedPreferences sharedPreferences;
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         OpenStreetMapTileProviderConstants.setUserAgentValue(BuildConfig.APPLICATION_ID);
-
+        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getActivity().getApplicationContext());
         setHasOptionsMenu(true);
     }
 
@@ -79,10 +86,28 @@ public class OSMapFragment extends Fragment {
         }
         mapView.setBuiltInZoomControls(false);
         mapView.setMultiTouchControls(true);
-        Event event = DbSingleton.getInstance().getEventDetails();
-        setDestinationLatitude(event.getLatitude());
-        setDestinationLongitude(event.getLongitude());
-        setDestinationName(event.getLocationName());
+
+        try{
+            int id =sharedPreferences.getInt(ConstantStrings.SESSION_MAP_ID,-1);
+            if(id != -1){
+                Session session =  DbSingleton.getInstance().getSessionById(id);
+                int location_id = session.getMicrolocation().getId();
+                Microlocation microlocation =  DbSingleton.getInstance().getMicrolocationById(location_id);
+                setDestinationLatitude(microlocation.getLatitude());
+                setDestinationLongitude(microlocation.getLongitude());
+                setDestinationName(microlocation.getName());
+            }else{
+                Event event = DbSingleton.getInstance().getEventDetails();
+                setDestinationLatitude(event.getLatitude());
+                setDestinationLongitude(event.getLongitude());
+                setDestinationName(event.getLocationName());
+            }
+        }catch (Exception e) {
+            Event event = DbSingleton.getInstance().getEventDetails();
+            setDestinationLatitude(event.getLatitude());
+            setDestinationLongitude(event.getLongitude());
+            setDestinationName(event.getLocationName());
+        }
         GeoPoint geoPoint = new GeoPoint(getDestinationLatitude(), getDestinationLongitude());
         mapView.getController().setCenter(geoPoint);
         mapView.getController().setZoom(17);

--- a/android/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
@@ -186,7 +186,7 @@ public class MainActivity extends BaseActivity {
         eventsDone = 0;
         ButterKnife.setDebug(true);
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
-
+        sharedPreferences.edit().putInt(ConstantStrings.SESSION_MAP_ID, -1).apply();
         setTheme(R.style.AppTheme_NoActionBar_MainTheme);
         super.onCreate(savedInstanceState);
         setUpToolbar();

--- a/android/app/src/main/java/org/fossasia/openevent/activities/SessionDetailActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/SessionDetailActivity.java
@@ -91,6 +91,7 @@ public class SessionDetailActivity extends BaseActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
         DbSingleton dbSingleton = DbSingleton.getInstance();
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
@@ -104,8 +105,10 @@ public class SessionDetailActivity extends BaseActivity {
         final List<Speaker> speakers = dbSingleton.getSpeakersbySessionName(title);
         try {
             session = dbSingleton.getSessionById(id);
+            sharedPreferences.edit().putInt(ConstantStrings.SESSION_MAP_ID, id).apply();
         } catch (Exception e) {
             session = dbSingleton.getSessionbySessionname(title);
+            sharedPreferences.edit().putInt(ConstantStrings.SESSION_MAP_ID, -1).apply();
         }
 
         text_room1.setText((dbSingleton.getMicrolocationById(session.getMicrolocation().getId())).getName());

--- a/android/app/src/main/java/org/fossasia/openevent/utils/ConstantStrings.java
+++ b/android/app/src/main/java/org/fossasia/openevent/utils/ConstantStrings.java
@@ -42,4 +42,6 @@ public class ConstantStrings {
     public static final String IS_DOWNLOAD_DONE = "isDownloadDone";
 
     public static final String PREF_SORT = "sortType";
+
+    public static final String SESSION_MAP_ID = "sessionMapId";
 }


### PR DESCRIPTION
Fixes issue #1054

Location of every event is accurately displayed on map, by passing session id through shared preferences.