### PR TITLE
Bookmarks Item in navigation drawer remains clicked if no bookmarks p…

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
@@ -395,6 +395,12 @@ public class MainActivity extends BaseActivity {
                     public boolean onNavigationItemSelected(MenuItem menuItem) {
                         int id = menuItem.getItemId();
                         doMenuAction(id);
+
+                        DbSingleton dbSingleton = DbSingleton.getInstance();
+                        if (id == R.id.nav_bookmarks && dbSingleton.isBookmarksTableEmpty()){
+                            return false;
+                        }
+                        // to ensure bookmarks is not shown clicked if at all there are no bookmarks
                         return true;
                     }
                 });


### PR DESCRIPTION
…resent

Fixes #1174 

Changes: If bookmarks database is empty, it returns false so that item is not shown clicked and rest is unaffected. Therefore the usual dialog box appears for no bookmarks.
