### PR TITLE
Session Layout Fixed  Fix issue#1130

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/activities/SessionDetailActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/SessionDetailActivity.java
@@ -181,9 +181,10 @@ public class SessionDetailActivity extends BaseActivity implements AppBarLayout.
             text_end_time.setVisibility(View.GONE);
 
         } else {
-            text_start_time.setText(startTime);
-            text_end_time.setText(endTime);
-            text_date.setText(date);
+            text_start_time.setText(startTime.trim());
+            text_end_time.setText(endTime.trim());
+            text_date.setText(date.trim());
+            Timber.d(date+"\n"+endTime+"\n"+startTime);
 
         }
         summary.setText(session.getSummary());

--- a/android/app/src/main/res/layout/content_session_detail.xml
+++ b/android/app/src/main/res/layout/content_session_detail.xml
@@ -36,13 +36,14 @@
                     android:layout_marginBottom="@dimen/layout_margin_medium"
                     android:textColor="@color/primary_text"
                     android:text="Session Subtitle" />
-
-                <LinearLayout
+                <GridLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:rowCount="5"
+                    android:columnCount="2"
+                    android:layout_marginRight="@dimen/layout_margin_right"
                     android:layout_marginBottom="@dimen/layout_margin_medium"
                     android:orientation="horizontal">
-
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -57,16 +58,9 @@
                         android:id="@+id/track"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:layout_marginLeft="10dp"
                         android:textSize="@dimen/text_size"
                         android:textColor="@color/primary_text" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/layout_margin_medium"
-                    android:orientation="horizontal">
-
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -81,16 +75,9 @@
                         android:id="@+id/date_session"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:layout_marginLeft="10dp"
                         android:textSize="@dimen/text_size"
                         android:textColor="@color/primary_text" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/layout_margin_medium"
-                    android:orientation="horizontal">
-
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -106,14 +93,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:textSize="@dimen/text_size"
+                        android:layout_marginLeft="10dp"
                         android:textColor="@color/primary_text" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/layout_margin_medium"
-                    android:orientation="horizontal">
 
                     <TextView
                         android:layout_width="wrap_content"
@@ -129,15 +110,9 @@
                         android:id="@+id/end_time_session"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:layout_marginLeft="10dp"
                         android:textSize="@dimen/text_size"
                         android:textColor="@color/primary_text" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/layout_margin_medium"
-                    android:orientation="horizontal">
 
                     <TextView
                         android:layout_width="wrap_content"
@@ -153,9 +128,10 @@
                         android:id="@+id/tv_location"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:layout_marginLeft="10dp"
                         android:textSize="@dimen/text_size"
                         android:textColor="@color/primary_text" />
-                </LinearLayout>
+                </GridLayout>
                 <android.support.v7.widget.RecyclerView
                     android:id="@+id/list_speakerss"
                     android:layout_width="match_parent"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -140,7 +140,7 @@
     <string name="start_time">Start Time:</string>
     <string name="end_time">End Time:</string>
     <string name="location">Location:</string>
-    <string name="speakers">Speaker:</string>
+    <string name="speakers">Speaker</string>
 
     <!-- Sponsor types strings-->
     <string name="platinum">Platinum</string>


### PR DESCRIPTION
Fixes #1130 

- changed the content_session_detail (Added Grid layout).
- added trim() on date , endTime, startTime to remove trailing spaces. 

Screenshots for the change: 
![screenshot_2017-02-28-21-33-55_org fossasia openevent](https://cloud.githubusercontent.com/assets/9443348/23413165/e681c5e8-fdfd-11e6-8c9e-31afcaa3a4d9.png)
