### PR TITLE
Correctly parse HTML in the Speaker Detail Activity #1185

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/activities/SessionDetailActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/SessionDetailActivity.java
@@ -21,6 +21,7 @@ import android.support.v7.widget.Toolbar;
 import android.text.Html;
 import android.text.Spanned;
 import android.text.TextUtils;
+import android.text.method.LinkMovementMethod;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -29,7 +30,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import org.fossasia.openevent.OpenEventApp;
-
 import org.fossasia.openevent.R;
 import org.fossasia.openevent.adapters.SpeakersListAdapter;
 import org.fossasia.openevent.data.Session;
@@ -45,6 +45,8 @@ import java.util.List;
 
 import butterknife.BindView;
 import timber.log.Timber;
+
+import static android.text.Html.FROM_HTML_MODE_LEGACY;
 
 /**
  * User: MananWason
@@ -187,12 +189,16 @@ public class SessionDetailActivity extends BaseActivity implements AppBarLayout.
             Timber.d(date+"\n"+endTime+"\n"+startTime);
 
         }
-        summary.setText(session.getSummary());
+
+        summary.setMovementMethod(LinkMovementMethod.getInstance());
 
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
-            result = Html.fromHtml(session.getDescription(), Html.FROM_HTML_MODE_LEGACY);
+            result = Html.fromHtml(session.getDescription(), FROM_HTML_MODE_LEGACY);
+            summary.setText(Html.fromHtml(session.getSummary(), FROM_HTML_MODE_LEGACY));
         } else {
             result = Html.fromHtml(session.getDescription());
+            summary.setText(Html.fromHtml(session.getSummary()));
+
         }
         descrip.setText(result);
 


### PR DESCRIPTION
#1185 

Changes: In SessionDetailActivity summary is not correctly parsed. Also the link is not clickable.


Screenshots for the change: 

**## Before**

![screenshot_2017-03-02-02-20-15-188_org fossasia openevent](https://cloud.githubusercontent.com/assets/9361754/23482067/c35a4710-fef3-11e6-9e0d-8a7fb7878270.png)


**# After** 

![screenshot_2017-03-02-02-24-34-010_org fossasia openevent](https://cloud.githubusercontent.com/assets/9361754/23482082/cf04237e-fef3-11e6-93a6-145dc5850e07.png)
![screenshot_2017-03-02-02-24-47-762_android](https://cloud.githubusercontent.com/assets/9361754/23482083/cf070378-fef3-11e6-8856-b210588dab3a.png)


Please review this PR.

