### PR TITLE
Style: Minor update in ui of speakers fragment.

### DIFF
--- a/android/app/src/main/res/layout/item_speaker.xml
+++ b/android/app/src/main/res/layout/item_speaker.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/widget_default_height"
     android:foreground="?android:attr/selectableItemBackground"
-    tools:layout_width="@dimen/widget_default_height">
+    tools:layout_width="@dimen/widget_default_height"
+    android:orientation="vertical">
 
     <ImageView
         android:id="@+id/speakers_list_image"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
         android:contentDescription="@null"
         android:scaleType="centerCrop"
         tools:src="@drawable/ic_account_circle_grey_24dp" />
@@ -57,4 +59,4 @@
             tools:text="India" />
 
     </LinearLayout>
-</FrameLayout>
+</LinearLayout>


### PR DESCRIPTION
Fixes #1204 
Changes: Minor update in ui of speakers fragment. The name used to cover the complete picture of speaker.

Screenshots for the change: 
![screenshot_20170302-093057](https://cloud.githubusercontent.com/assets/16978820/23492756/a01e0ece-ff2c-11e6-8d8a-3e758a5b94c2.png)



