### PR TITLE
Fixes #1094: Reduces Size of Repository

### DIFF
--- a/upload-apk.sh
+++ b/upload-apk.sh
@@ -18,6 +18,18 @@ cp -Rf $HOME/daily/*  ./
 mv app-fdroid-debug.apk sample-apk-${TRAVIS_BRANCH}.apk
 echo $TRAVIS_COMMIT > meta/deployment/commit_hash
 echo $TRAVIS_BRANCH > meta/deployment/branch
+
+# Create a new branch that will contains only latest apk
+git checkout --orphan latest-apk-only
+
+# Add generated APKs.
 git add -f .
 git commit -m "Update Sample Apk generated from $TRAVIS_BRANCH branch."
-git push origin apk > /dev/null
+
+# Delete current apk branch
+git branch -D apk
+# Rename current branch to apk
+git branch -m apk
+
+# Force push to origin since histories are unrelated
+git push origin apk --force > /dev/null


### PR DESCRIPTION
Fixes #1094: Reduce Size of Repository by optimizing apk upload script.

Changes: The apk branch needs to maintain only the latest apk so maintaining all previous APKs doesn't make sense. After this, only latest APK will be maintained in APK branch. Same approach was used in Susi Android by me. 