### PR TITLE
Fix: Showing result based on query after refresh

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/fragments/DayScheduleFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/fragments/DayScheduleFragment.java
@@ -231,9 +231,13 @@ public class DayScheduleFragment extends BaseFragment implements SearchView.OnQu
 
         swipeRefreshLayout.setRefreshing(false);
         if (event.isState()) {
-            if (dayScheduleAdapter != null)
-                dayScheduleAdapter.refresh();
-
+            if (dayScheduleAdapter != null && searchView != null) {
+                if (!searchView.getQuery().toString().isEmpty() && !searchView.isIconified()) {
+                    dayScheduleAdapter.getFilter().filter(searchView.getQuery());
+                } else {
+                    dayScheduleAdapter.refresh();
+                }
+            }
         } else {
             if (getActivity() != null) {
                 Snackbar.make(getView(), getActivity().getString(R.string.refresh_failed), Snackbar.LENGTH_LONG).setAction(R.string.retry_download, new View.OnClickListener() {

--- a/android/app/src/main/java/org/fossasia/openevent/fragments/SpeakersListFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/fragments/SpeakersListFragment.java
@@ -215,7 +215,11 @@ public class SpeakersListFragment extends BaseFragment implements SearchView.OnQ
     public void speakerDownloadDone(SpeakerDownloadEvent event) {
         swipeRefreshLayout.setRefreshing(false);
         if (event.isState()) {
-            speakersListAdapter.refresh();
+            if (!searchView.getQuery().toString().isEmpty() && !searchView.isIconified()) {
+                speakersListAdapter.getFilter().filter(searchView.getQuery());
+            } else {
+                speakersListAdapter.refresh();
+            }
             Timber.i("Speaker download completed");
         } else {
             if (getActivity() != null) {

--- a/android/app/src/main/java/org/fossasia/openevent/fragments/TracksFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/fragments/TracksFragment.java
@@ -205,8 +205,11 @@ public class TracksFragment extends BaseFragment implements SearchView.OnQueryTe
         if(swipeRefreshLayout!=null)
             swipeRefreshLayout.setRefreshing(false);
         if (event.isState()) {
-            tracksListAdapter.refresh();
-
+            if (!searchView.getQuery().toString().isEmpty() && !searchView.isIconified()) {
+                tracksListAdapter.getFilter().filter(searchView.getQuery());
+            } else {
+                tracksListAdapter.refresh();
+            }
         } else {
             if (getActivity() != null) {
                 Snackbar.make(windowFrame, getActivity().getString(R.string.refresh_failed), Snackbar.LENGTH_LONG).setAction(R.string.retry_download, new View.OnClickListener() {


### PR DESCRIPTION
Fixes #1218 
Changes: Now when refreshed, only those items which matches with search query are displayed.
