### PR TITLE
fix: Fix Back Button in SessionDetailActivity

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/activities/SessionDetailActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/SessionDetailActivity.java
@@ -30,7 +30,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import org.fossasia.openevent.OpenEventApp;
-
 import org.fossasia.openevent.R;
 import org.fossasia.openevent.adapters.SpeakersListAdapter;
 import org.fossasia.openevent.data.Session;
@@ -51,7 +50,7 @@ import timber.log.Timber;
  * User: MananWason
  * Date: 08-07-2015
  */
-public class SessionDetailActivity extends BaseActivity implements AppBarLayout.OnOffsetChangedListener{
+public class SessionDetailActivity extends BaseActivity implements AppBarLayout.OnOffsetChangedListener {
     private static final String TAG = "Session Detail";
 
     private SpeakersListAdapter adapter;
@@ -129,7 +128,7 @@ public class SessionDetailActivity extends BaseActivity implements AppBarLayout.
         }
 
         String microlocationName = "Not decided yet";
-        if (dbSingleton.getMicrolocationById(session.getMicrolocation().getId()) != null){
+        if (dbSingleton.getMicrolocationById(session.getMicrolocation().getId()) != null) {
             // This function returns id=0 when microlocation is null in session JSON
             microlocationName = dbSingleton.getMicrolocationById(session.getMicrolocation().getId()).getName();
         }
@@ -151,7 +150,7 @@ public class SessionDetailActivity extends BaseActivity implements AppBarLayout.
                 if (dbSingleton.isBookmarked(session.getId())) {
                     Timber.tag(TAG).d("Bookmark Removed");
                     dbSingleton.deleteBookmarks(session.getId());
-                  
+
                     fabSessionBookmark.setImageResource(R.drawable.ic_bookmark_outline_white_24dp);
                     Snackbar.make(v, R.string.removed_bookmark, Snackbar.LENGTH_LONG)
                             .setAction(R.string.undo, new View.OnClickListener() {
@@ -189,7 +188,7 @@ public class SessionDetailActivity extends BaseActivity implements AppBarLayout.
             text_start_time.setText(startTime.trim());
             text_end_time.setText(endTime.trim());
             text_date.setText(date.trim());
-            Timber.d(date+"\n"+endTime+"\n"+startTime);
+            Timber.d(date + "\n" + endTime + "\n" + startTime);
 
         }
         summary.setText(session.getSummary());
@@ -226,7 +225,7 @@ public class SessionDetailActivity extends BaseActivity implements AppBarLayout.
 
     @Override
     public void onBackPressed() {
-        if (fabSessionBookmark.getVisibility() == View.GONE) {
+        if (mapFragment.getVisibility() == View.VISIBLE) {
             /** hide fragment again on back pressed and show session views **/
             mapFragment.setVisibility(View.GONE);
             fabSessionBookmark.setVisibility(View.VISIBLE);

--- a/android/app/src/main/res/layout/activity_sessions_detail.xml
+++ b/android/app/src/main/res/layout/activity_sessions_detail.xml
@@ -11,7 +11,8 @@
     <FrameLayout
         android:id="@+id/content_frame_session"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        android:visibility="gone" />
 
     <android.support.design.widget.AppBarLayout
         android:id="@+id/app_bar_session_detail"
@@ -40,12 +41,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="bottom"
-                app:layout_collapseMode="parallax"
                 android:layout_marginBottom="@dimen/layout_margin_bottom"
+                android:layout_marginEnd="@dimen/layout_margin_right"
                 android:layout_marginLeft="@dimen/layout_margin_left"
                 android:layout_marginRight="@dimen/layout_margin_right"
                 android:layout_marginStart="@dimen/layout_margin_left"
-                android:layout_marginEnd="@dimen/layout_margin_right">
+                app:layout_collapseMode="parallax">
 
                 <TextView
                     android:id="@+id/title_session"
@@ -67,11 +68,11 @@
         android:id="@+id/fab_session_bookmark"
         android:layout_width="@dimen/fab_width"
         android:layout_height="@dimen/fab_height"
+        android:layout_gravity="center_vertical|center_horizontal"
         android:layout_margin="@dimen/layout_margin_large"
         android:clickable="true"
         app:layout_anchor="@+id/app_bar_session_detail"
         app:layout_anchorGravity="bottom|right"
-        app:srcCompat="@drawable/ic_bookmark_outline_white_24dp"
-        android:layout_gravity="center_vertical|center_horizontal" />
+        app:srcCompat="@drawable/ic_bookmark_outline_white_24dp" />
 
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
Fixes #1224 

Changes: 

- Replaced `fabSessionBookmark.getVisibility() == View.GONE` with `mapFragment.getVisibility() == View.VISIBLE` in [SessionDetailActivity](https://github.com/fossasia/open-event-android/blob/development/android/app/src/main/java/org/fossasia/openevent/activities/SessionDetailActivity.java#L229).

- Added `android:visibilty="gone"` for MapFragment in [activity_sessions_detail.xml](https://github.com/fossasia/open-event-android/blob/development/android/app/src/main/res/layout/activity_sessions_detail.xml#L11-L14).

- Refactored code of changed files according to Android Guidelines.


