### PR TITLE
Fixes #1227: Mobile Data Download issue fixed.

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
@@ -205,7 +205,7 @@ public class MainActivity extends BaseActivity {
                                 DbSingleton.getInstance().clearDatabase();
                                 Boolean preference = sharedPreferences.getBoolean(getResources().getString(R.string.download_mode_key), true);
                                 if (preference) {
-                                    if (NetworkUtils.haveWifiConnection(MainActivity.this)) {
+                                    if (NetworkUtils.haveWifiConnection(MainActivity.this) || NetworkUtils.haveMobileConnection(MainActivity.this)) {
                                         OpenEventApp.postEventOnUIThread(new DataDownloadEvent());
                                         sharedPreferences.edit().putBoolean(ConstantStrings.IS_DOWNLOAD_DONE, true).apply();
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -126,7 +126,7 @@
     <string name="github_icon" translatable="false">Github Icon</string>
     <string name="web_icon" translatable="false">Web Icon</string>
     <string name="download_assets">Do you want to update to the latest schedule now?</string>
-    <string name="internet_preference_warning">Wifi Not available, do you want to display offline schedule? </string>
+    <string name="internet_preference_warning">Internet Not available, do you want to display offline schedule? </string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="noSessions">No Sessions yet!</string>


### PR DESCRIPTION
Fixes #1227: Data can now be downloaded over mobile network. 

Changes: Condition to check mobile data working and download over it was not correctly enforced. Fixed that. 

Screenshots for the change: N/A
