### PR TITLE
feat: modified manifest file to support deep links

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,10 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="http"
+                    android:host="@string/url"/>
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name" translatable="false">Open Event</string>
 
+    <string name="url">2017.fossasia.org</string>
     <string name="title_section_tracks">Tracks</string>
     <string name="title_section_speakerlist">Speakers</string>
     <string name="title_section_location">Locations</string>


### PR DESCRIPTION
Fixes #1195 

Changes:
Added support for the uri: http://2017.fossasia.org/tracks

Now whenever the user tries to open the uri sent through eg a messaging app, they will be prompted to view it via the app or the browser which was earlier happening only through the browser.

Screenshots for the change: 
-