### PR TITLE
spelling fixes

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
     <string name="session_bookmark_status">This image shows the session bookmark status.</string>
     <string name="session_speaker_icon">This is the speaker icon.</string>
     <string name="session_share_icon">This is the share icon.</string>
-    <string name="session_calender_icon">This is a calender icon.</string>
+    <string name="session_calender_icon">This is a calendar icon.</string>
     <string name="session_clock_icon">This is a clock icon.</string>
     <string name="session_location_icon">This is a location icon.</string>
 

--- a/apk-generator/v2/app/generator/generator.py
+++ b/apk-generator/v2/app/generator/generator.py
@@ -280,7 +280,7 @@ class Generator:
             self.update_status('Package signed.')
         elif 'zipaligning' in output_line:
             self.update_status('Verifying the package.')
-        elif 'Verification succesful' in output_line:
+        elif 'Verification successful' in output_line:
             self.update_status('Package verified.')
         elif output_line == 'done':
             self.update_status('Application has been generated. Please wait.')

--- a/docs/android-app-setup.md
+++ b/docs/android-app-setup.md
@@ -20,13 +20,13 @@ Before you begin, you should already have the Android Studio SDK downloaded and 
 
 4. Once this process is complete and Android Studio opens, check the Console for any build errors.
 
-  - _Note:_ If you recieve a Gradle sync error titled, "failed to find ...", you should click on the link below the error message (if avaliable) that says _Install missing platform(s) and sync project_ and allow Android studio to fetch you what is missing.
+  - _Note:_ If you receive a Gradle sync error titled, "failed to find ...", you should click on the link below the error message (if available) that says _Install missing platform(s) and sync project_ and allow Android studio to fetch you what is missing.
 
 5. Once all build errors have been resolved, you should be all set to build the app and test it.
 
 6. To Build the app, go to _Build>Make Project_ (or alternatively press the Make Project icon in the toolbar).
 
-7. If the app was built succesfully, you can test it by running it on either a real device or an emulated one by going to _Run>Run 'app'_ or presing the Run icon in the toolbar.
+7. If the app was built successfully, you can test it by running it on either a real device or an emulated one by going to _Run>Run 'app'_ or presing the Run icon in the toolbar.
 
 ### Configuring Google Maps
 

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -1,4 +1,4 @@
-* Get the latest version of docker. See the [offical site](https://docs.docker.com/engine/installation/) for installation info for your platform.
+* Get the latest version of docker. See the [official site](https://docs.docker.com/engine/installation/) for installation info for your platform.
 
 * Install the latest version of docker-compose. Windows and Mac users should have docker-compose by default as it is part of Docker toolbox. For Linux users, see the
 [official guide](https://docs.docker.com/compose/install/).


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.

one thing that makes me wonder:
( in open-event-android/apk-generator/v2/app/generator/generator.py )
-        elif 'Verification succesful' in output_line:
+        elif 'Verification successful' in output_line:
is this an local error (so this patch fixes it) or an upstream error ? if wrong, I can take it out...
