### PR TITLE
fix: bug in item selection in navigation drawer resolved

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
@@ -363,7 +363,17 @@ public class MainActivity extends BaseActivity {
             final ActionBar ab = getSupportActionBar();
             assert ab != null;
             smoothActionBarToggle = new SmoothActionBarDrawerToggle(this,
-                    drawerLayout, toolbar, R.string.navigation_drawer_open, R.string.navigation_drawer_close);
+                    drawerLayout, toolbar, R.string.navigation_drawer_open, R.string.navigation_drawer_close) {
+
+                @Override
+                public void onDrawerStateChanged(int newState) {
+                    super.onDrawerStateChanged(newState);
+
+                    if(toolbar.getTitle().equals(R.string.title_section_tracks)) {
+                        navigationView.setCheckedItem(R.id.nav_tracks);
+                    }
+                }
+            };
 
             drawerLayout.addDrawerListener(smoothActionBarToggle);
             ab.setDisplayHomeAsUpEnabled(true);


### PR DESCRIPTION
Fixes #1301 

Changes: 

Now when the user unbookmark all the bookmarked events and is taken to the tracks activity after that, the item selected in the navigation drawer would be of the "tracks" one.

Screenshots for the change: 

![17310405_10210741417206021_758063557_o](https://cloud.githubusercontent.com/assets/8268392/23908168/439b1878-08f9-11e7-93d2-690054e6b37f.png)
![17269399_10210741417246022_1769619286_o](https://cloud.githubusercontent.com/assets/8268392/23908180/4e350668-08f9-11e7-96a6-7f55c8b8ab9e.png)
![17273464_10210741417446027_1288272685_o](https://cloud.githubusercontent.com/assets/8268392/23908184/50f8c222-08f9-11e7-9253-8e2a81f50048.png)
