### PR TITLE
fix : search not working properly in track session activity

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/activities/TrackSessionsActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/TrackSessionsActivity.java
@@ -90,6 +90,10 @@ public class TrackSessionsActivity extends BaseActivity implements SearchView.On
         gridLayoutManager = new GridLayoutManager(this, spanCount);
         sessionsRecyclerView.setLayoutManager(gridLayoutManager);
         sessionsListAdapter = new SessionsListAdapter(this, mSessions, trackWiseSessionList);
+        if(searchText!=null){
+            sessionsListAdapter.setTrackName(track);
+            sessionsListAdapter.getFilter().filter(searchText);
+        }
         sessionsRecyclerView.setAdapter(sessionsListAdapter);
         sessionsRecyclerView.scrollToPosition(SessionsListAdapter.listPosition);
         sessionsRecyclerView.setItemAnimator(new DefaultItemAnimator());


### PR DESCRIPTION
Fixes #1423 

Changes:  When user return from session detail activity, onResume method get call. I added code for checking search text in onResume method.

Screenshots for the change: 
