### PR TITLE
Scrollable tab in schedule fragment

### DIFF
--- a/android/app/src/main/res/layout/fragment_schedule.xml
+++ b/android/app/src/main/res/layout/fragment_schedule.xml
@@ -18,7 +18,7 @@
         app:tabIndicatorHeight="3dp"
         app:tabMaxWidth="150dp"
         app:tabMinWidth="100dp"
-        app:tabMode="fixed"
+        app:tabMode="scrollable"
         app:tabSelectedTextColor="@android:color/white"
         tools:targetApi="lollipop" />
 


### PR DESCRIPTION
Fixes #1491

Changes: The tab layout was simply made of type "scrollable"

