### PR TITLE
DayScheduleFragment tabs not aligned properly.

### DIFF
--- a/android/app/src/main/res/layout/fragment_schedule.xml
+++ b/android/app/src/main/res/layout/fragment_schedule.xml
@@ -6,13 +6,14 @@
 
     <android.support.design.widget.TabLayout
         android:id="@+id/tabLayout"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
         android:background="?attr/selectableItemBackground"
         android:clipToPadding="false"
         android:elevation="8dp"
+        android:layout_gravity="center_horizontal"
         app:tabBackground="?attr/selectableItemBackground"
         app:tabGravity="center"
         app:tabIndicatorHeight="3dp"


### PR DESCRIPTION
Fixes #1528 

Screenshots for the change: 

![device-2017-05-10-160350](https://cloud.githubusercontent.com/assets/21010060/25895600/3000f176-359e-11e7-820a-e860fd8bce85.png)
