### PR TITLE
fix: speaker image placeholder problem resolved

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/adapters/SpeakersListAdapter.java
+++ b/android/app/src/main/java/org/fossasia/openevent/adapters/SpeakersListAdapter.java
@@ -124,6 +124,8 @@ public class SpeakersListAdapter extends BaseRVAdapter<Speaker, SpeakersListAdap
                     .load(Uri.parse(thumbnail))
                     .placeholder(VectorDrawableCompat.create(context.getResources(), R.drawable.ic_account_circle_grey_24dp, null))
                     .into(holder.speakerImage);
+        } else {
+            holder.speakerImage.setImageDrawable(context.getResources().getDrawable(R.drawable.ic_account_circle_grey_24dp));
         }
 
         String name = current.getName();


### PR DESCRIPTION
Fixes #1646 

Changes:
Speaker image placeholder is displayed even if the internet is off and the user has opened the app for the first time.

Screenshots for the change: 

![18836269_10211470216785555_1442982982_o](https://cloud.githubusercontent.com/assets/8268392/26755472/8eb83e7a-48ab-11e7-9d5c-e3a376b7ac6e.png)
