### PR TITLE
Updated sponsor's sort

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/dbutils/RealmDataRepository.java
+++ b/android/app/src/main/java/org/fossasia/openevent/dbutils/RealmDataRepository.java
@@ -446,7 +446,7 @@ public class RealmDataRepository {
     }
 
     public RealmResults<Sponsor> getSponsors() {
-        return realm.where(Sponsor.class).findAllSortedAsync("level", Sort.DESCENDING, "name", Sort.ASCENDING);
+        return realm.where(Sponsor.class).findAllSortedAsync("level", Sort.ASCENDING, "name", Sort.ASCENDING);
     }
 
     // Location Section


### PR DESCRIPTION
Fixes #1670 

Changes: The sponsors are sorted by ascending order of "level" in JSON, so that the sponsor with level:"1" comes at the top of the sponsors recycler view.


