### PR TITLE
fix: format date and time correctly everywhere

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/about/AboutEventActivity.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/about/AboutEventActivity.kt
@@ -67,16 +67,15 @@ class AboutEventActivity : AppCompatActivity(), AppBarLayout.OnOffsetChangedList
                     .append(" at ")
                     .append(EventUtils.getFormattedTime(endsAt))
                     .append(" ")
-                    .append(EventUtils.getFormattedTimeZone(endsAt))
+                    .append(EventUtils.getFormattedTimeZoneWithBrackets(endsAt))
         } else {
             aboutEventDetails.text = dateString.append(EventUtils.getFormattedDate(startsAt))
                     .append(" from ")
                     .append(EventUtils.getFormattedTime(startsAt))
                     .append(" to ")
                     .append(EventUtils.getFormattedTime(endsAt))
-                    .append(" (")
-                    .append(EventUtils.getFormattedTimeZone(endsAt))
-                    .append(")")
+                    .append(" ")
+                    .append(EventUtils.getFormattedTimeZoneWithBrackets(endsAt))
         }
 
         eventName.text = event.name

--- a/app/src/main/java/org/fossasia/openevent/general/about/AboutEventActivity.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/about/AboutEventActivity.kt
@@ -55,28 +55,9 @@ class AboutEventActivity : AppCompatActivity(), AppBarLayout.OnOffsetChangedList
     private fun loadEvent(event: Event){
         eventExtra = event
         aboutEventContent.text = event.description
-        val dateString = StringBuilder()
         val startsAt = EventUtils.getLocalizedDateTime(event.startsAt)
         val endsAt = EventUtils.getLocalizedDateTime(event.endsAt)
-        if (EventUtils.getFormattedDate(startsAt) != EventUtils.getFormattedDate(endsAt)) {
-            aboutEventDetails.text = dateString.append(EventUtils.getFormattedDate(startsAt))
-                    .append(" at ")
-                    .append(EventUtils.getFormattedTime(startsAt))
-                    .append(" - ")
-                    .append(EventUtils.getFormattedDate(endsAt))
-                    .append(" at ")
-                    .append(EventUtils.getFormattedTime(endsAt))
-                    .append(" ")
-                    .append(EventUtils.getFormattedTimeZoneWithBrackets(endsAt))
-        } else {
-            aboutEventDetails.text = dateString.append(EventUtils.getFormattedDate(startsAt))
-                    .append(" from ")
-                    .append(EventUtils.getFormattedTime(startsAt))
-                    .append(" to ")
-                    .append(EventUtils.getFormattedTime(endsAt))
-                    .append(" ")
-                    .append(EventUtils.getFormattedTimeZoneWithBrackets(endsAt))
-        }
+        aboutEventDetails.text = EventUtils.getFormattedDateTimeRangeDetailed(startsAt, endsAt)
 
         eventName.text = event.name
     }

--- a/app/src/main/java/org/fossasia/openevent/general/about/AboutEventActivity.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/about/AboutEventActivity.kt
@@ -58,11 +58,26 @@ class AboutEventActivity : AppCompatActivity(), AppBarLayout.OnOffsetChangedList
         val dateString = StringBuilder()
         val startsAt = EventUtils.getLocalizedDateTime(event.startsAt)
         val endsAt = EventUtils.getLocalizedDateTime(event.endsAt)
-        aboutEventDetails.text = dateString.append(EventUtils.getFormattedDate(startsAt))
-                                           .append(" - ")
-                                           .append(EventUtils.getFormattedDate(endsAt))
-                                           .append(" • ")
-                                           .append(EventUtils.getFormattedTime(startsAt))
+        if (EventUtils.getFormattedDate(startsAt) != EventUtils.getFormattedDate(endsAt)) {
+            aboutEventDetails.text = dateString.append(EventUtils.getFormattedDate(startsAt))
+                    .append(" at ")
+                    .append(EventUtils.getFormattedTime(startsAt))
+                    .append(" - ")
+                    .append(EventUtils.getFormattedDate(endsAt))
+                    .append(" at ")
+                    .append(EventUtils.getFormattedTime(endsAt))
+                    .append(" ")
+                    .append(EventUtils.getFormattedTimeZone(endsAt))
+        } else {
+            aboutEventDetails.text = dateString.append(EventUtils.getFormattedDate(startsAt))
+                    .append(" from ")
+                    .append(EventUtils.getFormattedTime(startsAt))
+                    .append(" to ")
+                    .append(EventUtils.getFormattedTime(endsAt))
+                    .append(" (")
+                    .append(EventUtils.getFormattedTimeZone(endsAt))
+                    .append(")")
+        }
 
         eventName.text = event.name
     }

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -162,8 +162,13 @@ class EventDetailsFragment : Fragment() {
         }
 
         //Date and Time section
-        rootView.startsOn.text = EventUtils.getFormattedDate(startsAt)
-        rootView.endsOn.text = EventUtils.getFormattedDate(endsAt)
+        if (EventUtils.getFormattedDate(startsAt) != EventUtils.getFormattedDate(endsAt)) {
+            rootView.eventDateDetailsFirst.text = "${EventUtils.getFormattedDateShort(startsAt)} ${EventUtils.getFormattedTime(startsAt)}"
+            rootView.eventDateDetailsSecond.text = "- ${EventUtils.getFormattedDateShort(endsAt)} ${EventUtils.getFormattedTime(endsAt)} ${EventUtils.getFormattedTimeZone(endsAt)}"
+        } else {
+            rootView.eventDateDetailsFirst.text = EventUtils.getFormattedDateWithoutYear(startsAt)
+            rootView.eventDateDetailsSecond.text = "${EventUtils.getFormattedTime(startsAt)} - ${EventUtils.getFormattedTime(endsAt)} ${EventUtils.getFormattedTimeZone(endsAt)}"
+        }
 
         //Similar Events Section
         if (event.eventTopic != null) {
@@ -181,8 +186,8 @@ class EventDetailsFragment : Fragment() {
 
         //Add event to Calendar
         val dateClickListener = View.OnClickListener { startCalendar(event) }
-        rootView.startsOn.setOnClickListener(dateClickListener)
-        rootView.endsOn.setOnClickListener(dateClickListener)
+        rootView.eventDateDetailsFirst.setOnClickListener(dateClickListener)
+        rootView.eventDateDetailsSecond.setOnClickListener(dateClickListener)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -162,13 +162,8 @@ class EventDetailsFragment : Fragment() {
         }
 
         //Date and Time section
-        if (EventUtils.getFormattedDate(startsAt) != EventUtils.getFormattedDate(endsAt)) {
-            rootView.eventDateDetailsFirst.text = "${EventUtils.getFormattedDateShort(startsAt)} ${EventUtils.getFormattedTime(startsAt)}"
-            rootView.eventDateDetailsSecond.text = "- ${EventUtils.getFormattedDateShort(endsAt)} ${EventUtils.getFormattedTime(endsAt)} ${EventUtils.getFormattedTimeZone(endsAt)}"
-        } else {
-            rootView.eventDateDetailsFirst.text = EventUtils.getFormattedDateWithoutYear(startsAt)
-            rootView.eventDateDetailsSecond.text = "${EventUtils.getFormattedTime(startsAt)} - ${EventUtils.getFormattedTime(endsAt)} ${EventUtils.getFormattedTimeZone(endsAt)}"
-        }
+        rootView.eventDateDetailsFirst.text = EventUtils.getFormattedEventDateTimeRange(startsAt, endsAt)
+        rootView.eventDateDetailsSecond.text = EventUtils.getFormattedEventDateTimeRangeSecond(startsAt, endsAt)
 
         //Similar Events Section
         if (event.eventTopic != null) {

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -163,8 +163,7 @@ class EventDetailsFragment : Fragment() {
 
         //Date and Time section
         rootView.eventDateDetailsFirst.text = EventUtils.getFormattedEventDateTimeRange(startsAt, endsAt)
-        rootView.eventDateDetailsSecond.text = EventUtils.getFormattedEventDateTimeRangeSecond(startsAt, endsAt)
-
+        rootView.eventDateDetailsSecond.text = "${EventUtils.getFormattedEventDateTimeRangeSecond(startsAt, endsAt)}"
         //Similar Events Section
         if (event.eventTopic != null) {
             similarEventsContainer.visibility = View.VISIBLE

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -164,6 +164,7 @@ class EventDetailsFragment : Fragment() {
         //Date and Time section
         rootView.eventDateDetailsFirst.text = EventUtils.getFormattedEventDateTimeRange(startsAt, endsAt)
         rootView.eventDateDetailsSecond.text = "${EventUtils.getFormattedEventDateTimeRangeSecond(startsAt, endsAt)}"
+
         //Similar Events Section
         if (event.eventTopic != null) {
             similarEventsContainer.visibility = View.VISIBLE

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventUtils.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventUtils.kt
@@ -104,8 +104,10 @@ object EventUtils {
     }
 
     fun getFormattedEventDateTimeRange(startsAt: ZonedDateTime, endsAt: ZonedDateTime): String {
+        val startingDate = getFormattedDate(startsAt)
+        val endingDate = getFormattedDate(endsAt)
         try {
-            if (EventUtils.getFormattedDate(startsAt) != EventUtils.getFormattedDate(endsAt))
+            if (startingDate != endingDate)
                 return "${getFormattedDateShort(startsAt)}, ${getFormattedTime(startsAt)}"
             else
                 return "${getFormattedDateWithoutYear(startsAt)}"
@@ -116,8 +118,10 @@ object EventUtils {
     }
 
     fun getFormattedEventDateTimeRangeSecond(startsAt: ZonedDateTime, endsAt: ZonedDateTime): String {
+        val startingDate = getFormattedDate(startsAt)
+        val endingDate = getFormattedDate(endsAt)
         try {
-            if (EventUtils.getFormattedDate(startsAt) != EventUtils.getFormattedDate(endsAt))
+            if (startingDate != endingDate)
                 return "- ${getFormattedDateShort(endsAt)}, ${getFormattedTime(endsAt)} ${getFormattedTimeZone(endsAt)}"
             else
                 return "${getFormattedTime(startsAt)} - ${getFormattedTime(endsAt)} ${getFormattedTimeZone(endsAt)}"
@@ -128,11 +132,13 @@ object EventUtils {
     }
 
     fun getFormattedDateTimeRangeDetailed(startsAt: ZonedDateTime, endsAt: ZonedDateTime): String {
+        val startingDate = getFormattedDate(startsAt)
+        val endingDate = getFormattedDate(endsAt)
         try {
-            if (EventUtils.getFormattedDate(startsAt) != EventUtils.getFormattedDate(endsAt))
-                return "${getFormattedDate(startsAt)} at ${getFormattedTime(startsAt)} - ${getFormattedDate(endsAt)} at ${getFormattedTime(endsAt)} (${getFormattedTimeZone(endsAt)})"
+            if (startingDate != endingDate)
+                return "$startingDate at ${getFormattedTime(startsAt)} - $endingDate at ${getFormattedTime(endsAt)} (${getFormattedTimeZone(endsAt)})"
             else
-                return "${getFormattedDate(startsAt)} from ${getFormattedTime(startsAt)} to ${getFormattedTime(endsAt)} (${getFormattedTimeZone(endsAt)})"
+                return "$startingDate from ${getFormattedTime(startsAt)} to ${getFormattedTime(endsAt)} (${getFormattedTimeZone(endsAt)})"
         } catch (e: IllegalArgumentException) {
             Timber.e(e, "Error formatting time")
             return ""

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventUtils.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventUtils.kt
@@ -64,7 +64,7 @@ object EventUtils {
     }
 
     fun getFormattedDateShort(date: ZonedDateTime): String {
-        val dateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("EEE, MMM d,")
+        val dateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("EEE, MMM d")
         try {
             return dateFormat.format(date)
         } catch (e: IllegalArgumentException) {
@@ -106,7 +106,7 @@ object EventUtils {
     fun getFormattedEventDateTimeRange(startsAt: ZonedDateTime, endsAt: ZonedDateTime): String {
         try {
             if (EventUtils.getFormattedDate(startsAt) != EventUtils.getFormattedDate(endsAt))
-                return "${getFormattedDateShort(startsAt)} ${getFormattedTime(startsAt)}"
+                return "${getFormattedDateShort(startsAt)}, ${getFormattedTime(startsAt)}"
             else
                 return "${getFormattedDateWithoutYear(startsAt)}"
         } catch (e: IllegalArgumentException) {
@@ -118,7 +118,7 @@ object EventUtils {
     fun getFormattedEventDateTimeRangeSecond(startsAt: ZonedDateTime, endsAt: ZonedDateTime): String {
         try {
             if (EventUtils.getFormattedDate(startsAt) != EventUtils.getFormattedDate(endsAt))
-                return "- ${getFormattedDateShort(endsAt)} ${getFormattedTime(endsAt)} ${getFormattedTimeZone(endsAt)}"
+                return "- ${getFormattedDateShort(endsAt)}, ${getFormattedTime(endsAt)} ${getFormattedTimeZone(endsAt)}"
             else
                 return "${getFormattedTime(startsAt)} - ${getFormattedTime(endsAt)} ${getFormattedTimeZone(endsAt)}"
         } catch (e: IllegalArgumentException) {

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventUtils.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventUtils.kt
@@ -102,4 +102,15 @@ object EventUtils {
             return ""
         }
     }
+
+    fun getFormattedTimeZoneWithBrackets(date: ZonedDateTime): String {
+        val timeFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("(z)")
+        try {
+            return timeFormat.format(date)
+        } catch (e: IllegalArgumentException) {
+            Timber.e(e, "Error formatting time")
+            return ""
+        }
+    }
+
 }

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventUtils.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventUtils.kt
@@ -54,7 +54,27 @@ object EventUtils {
     }
 
     fun getFormattedDate(date: ZonedDateTime): String {
-        val dateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("EEE, MMM d")
+        val dateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("EEEE, MMM d, y")
+        try {
+            return dateFormat.format(date)
+        } catch (e: IllegalArgumentException) {
+            Timber.e(e, "Error formatting Date")
+            return ""
+        }
+    }
+
+    fun getFormattedDateShort(date: ZonedDateTime): String {
+        val dateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("EEE, MMM d,")
+        try {
+            return dateFormat.format(date)
+        } catch (e: IllegalArgumentException) {
+            Timber.e(e, "Error formatting Date")
+            return ""
+        }
+    }
+
+    fun getFormattedDateWithoutYear(date: ZonedDateTime): String {
+        val dateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("EEEE, MMM d")
         try {
             return dateFormat.format(date)
         } catch (e: IllegalArgumentException) {
@@ -64,7 +84,17 @@ object EventUtils {
     }
 
     fun getFormattedTime(date: ZonedDateTime): String {
-        val timeFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("hh:mm a Z")
+        val timeFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("hh:mm a")
+        try {
+            return timeFormat.format(date)
+        } catch (e: IllegalArgumentException) {
+            Timber.e(e, "Error formatting time")
+            return ""
+        }
+    }
+
+    fun getFormattedTimeZone(date: ZonedDateTime): String {
+        val timeFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("z")
         try {
             return timeFormat.format(date)
         } catch (e: IllegalArgumentException) {

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventUtils.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventUtils.kt
@@ -103,14 +103,39 @@ object EventUtils {
         }
     }
 
-    fun getFormattedTimeZoneWithBrackets(date: ZonedDateTime): String {
-        val timeFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("(z)")
+    fun getFormattedEventDateTimeRange(startsAt: ZonedDateTime, endsAt: ZonedDateTime): String {
         try {
-            return timeFormat.format(date)
+            if (EventUtils.getFormattedDate(startsAt) != EventUtils.getFormattedDate(endsAt))
+                return "${getFormattedDateShort(startsAt)} ${getFormattedTime(startsAt)}"
+            else
+                return "${getFormattedDateWithoutYear(startsAt)}"
         } catch (e: IllegalArgumentException) {
             Timber.e(e, "Error formatting time")
             return ""
         }
     }
 
+    fun getFormattedEventDateTimeRangeSecond(startsAt: ZonedDateTime, endsAt: ZonedDateTime): String {
+        try {
+            if (EventUtils.getFormattedDate(startsAt) != EventUtils.getFormattedDate(endsAt))
+                return "- ${getFormattedDateShort(endsAt)} ${getFormattedTime(endsAt)} ${getFormattedTimeZone(endsAt)}"
+            else
+                return "${getFormattedTime(startsAt)} - ${getFormattedTime(endsAt)} ${getFormattedTimeZone(endsAt)}"
+        } catch (e: IllegalArgumentException) {
+            Timber.e(e, "Error formatting time")
+            return ""
+        }
+    }
+
+    fun getFormattedDateTimeRangeDetailed(startsAt: ZonedDateTime, endsAt: ZonedDateTime): String {
+        try {
+            if (EventUtils.getFormattedDate(startsAt) != EventUtils.getFormattedDate(endsAt))
+                return "${getFormattedDate(startsAt)} at ${getFormattedTime(startsAt)} - ${getFormattedDate(endsAt)} at ${getFormattedTime(endsAt)} (${getFormattedTimeZone(endsAt)})"
+            else
+                return "${getFormattedDate(startsAt)} from ${getFormattedTime(startsAt)} to ${getFormattedTime(endsAt)} (${getFormattedTimeZone(endsAt)})"
+        } catch (e: IllegalArgumentException) {
+            Timber.e(e, "Error formatting time")
+            return ""
+        }
+    }
 }

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
@@ -119,11 +119,26 @@ class TicketsFragment : Fragment() {
         val dateString = StringBuilder()
         val startsAt = EventUtils.getLocalizedDateTime(event.startsAt)
         val endsAt = EventUtils.getLocalizedDateTime(event.endsAt)
-        rootView.time.text = dateString.append(EventUtils.getFormattedDate(startsAt))
-                .append(" - ")
-                .append(EventUtils.getFormattedDate(endsAt))
-                .append(" • ")
-                .append(EventUtils.getFormattedTime(startsAt))
+        if (EventUtils.getFormattedDate(startsAt) != EventUtils.getFormattedDate(endsAt)) {
+            rootView.time.text = dateString.append(EventUtils.getFormattedDate(startsAt))
+                    .append(" at ")
+                    .append(EventUtils.getFormattedTime(startsAt))
+                    .append(" - ")
+                    .append(EventUtils.getFormattedDate(endsAt))
+                    .append(" at ")
+                    .append(EventUtils.getFormattedTime(endsAt))
+                    .append(" ")
+                    .append(EventUtils.getFormattedTimeZone(endsAt))
+        } else {
+            rootView.time.text = dateString.append(EventUtils.getFormattedDate(startsAt))
+                    .append(" from ")
+                    .append(EventUtils.getFormattedTime(startsAt))
+                    .append(" to ")
+                    .append(EventUtils.getFormattedTime(endsAt))
+                    .append(" (")
+                    .append(EventUtils.getFormattedTimeZone(endsAt))
+                    .append(")")
+        }
     }
 
 }

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
@@ -116,28 +116,9 @@ class TicketsFragment : Fragment() {
     private fun loadEventDetails(event: Event) {
         rootView.eventName.text = event.name
         rootView.organizerName.text = "by ${event.organizerName.nullToEmpty()}"
-        val dateString = StringBuilder()
         val startsAt = EventUtils.getLocalizedDateTime(event.startsAt)
         val endsAt = EventUtils.getLocalizedDateTime(event.endsAt)
-        if (EventUtils.getFormattedDate(startsAt) != EventUtils.getFormattedDate(endsAt)) {
-            rootView.time.text = dateString.append(EventUtils.getFormattedDate(startsAt))
-                    .append(" at ")
-                    .append(EventUtils.getFormattedTime(startsAt))
-                    .append(" - ")
-                    .append(EventUtils.getFormattedDate(endsAt))
-                    .append(" at ")
-                    .append(EventUtils.getFormattedTime(endsAt))
-                    .append(" ")
-                    .append(EventUtils.getFormattedTimeZoneWithBrackets(endsAt))
-        } else {
-            rootView.time.text = dateString.append(EventUtils.getFormattedDate(startsAt))
-                    .append(" from ")
-                    .append(EventUtils.getFormattedTime(startsAt))
-                    .append(" to ")
-                    .append(EventUtils.getFormattedTime(endsAt))
-                    .append(" ")
-                    .append(EventUtils.getFormattedTimeZoneWithBrackets(endsAt))
-        }
+        rootView.time.text = EventUtils.getFormattedDateTimeRangeDetailed(startsAt,endsAt)
     }
 
 }

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
@@ -118,7 +118,7 @@ class TicketsFragment : Fragment() {
         rootView.organizerName.text = "by ${event.organizerName.nullToEmpty()}"
         val startsAt = EventUtils.getLocalizedDateTime(event.startsAt)
         val endsAt = EventUtils.getLocalizedDateTime(event.endsAt)
-        rootView.time.text = EventUtils.getFormattedDateTimeRangeDetailed(startsAt,endsAt)
+        rootView.time.text = EventUtils.getFormattedDateTimeRangeDetailed(startsAt, endsAt)
     }
 
 }

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
@@ -128,16 +128,15 @@ class TicketsFragment : Fragment() {
                     .append(" at ")
                     .append(EventUtils.getFormattedTime(endsAt))
                     .append(" ")
-                    .append(EventUtils.getFormattedTimeZone(endsAt))
+                    .append(EventUtils.getFormattedTimeZoneWithBrackets(endsAt))
         } else {
             rootView.time.text = dateString.append(EventUtils.getFormattedDate(startsAt))
                     .append(" from ")
                     .append(EventUtils.getFormattedTime(startsAt))
                     .append(" to ")
                     .append(EventUtils.getFormattedTime(endsAt))
-                    .append(" (")
-                    .append(EventUtils.getFormattedTimeZone(endsAt))
-                    .append(")")
+                    .append(" ")
+                    .append(EventUtils.getFormattedTimeZoneWithBrackets(endsAt))
         }
     }
 

--- a/app/src/main/res/layout/content_event.xml
+++ b/app/src/main/res/layout/content_event.xml
@@ -82,14 +82,14 @@
                             android:orientation="vertical">
 
                             <TextView
-                                android:id="@+id/startsOn"
+                                android:id="@+id/eventDateDetailsFirst"
                                 android:textColor="@color/dark_grey"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 tools:text="Tuesday June 5" />
 
                             <TextView
-                                android:id="@+id/endsOn"
+                                android:id="@+id/eventDateDetailsSecond"
                                 android:layout_width="wrap_content"
                                 android:textColor="@color/dark_grey"
                                 android:layout_height="wrap_content"

--- a/app/src/test/java/org/fossasia/openevent/general/event/EventUtilsTest.kt
+++ b/app/src/test/java/org/fossasia/openevent/general/event/EventUtilsTest.kt
@@ -157,4 +157,64 @@ class EventUtilsTest {
             """.trimIndent(), EventUtils.getFormattedDate(localizedDateTime))
     }
 
+    @Test
+    fun `should get formatted date range when start and end date are not same`() {
+        val event = getEvent()
+        val startsAt = getLocalizedDate(event.startsAt)
+        val endsAt = getLocalizedDate(event.endsAt)
+        assertEquals("""
+         Mon, Sep 15, 04:23 PM
+            """.trimIndent(), EventUtils.getFormattedEventDateTimeRange(startsAt, endsAt))
+    }
+
+    @Test
+    fun `should get formatted date range when start and end date are same`() {
+        val event = getEvent(endsAt = "2008-09-15T15:53:00+05:00")
+        val startsAt = getLocalizedDate(event.startsAt)
+        val endsAt = getLocalizedDate(event.endsAt)
+        assertEquals("""
+          Monday, Sep 15
+            """.trimIndent(), EventUtils.getFormattedEventDateTimeRange(startsAt, endsAt))
+    }
+
+    @Test
+    fun `should get formatted date range when start and end date are not same in event details`() {
+        val event = getEvent()
+        val startsAt = getLocalizedDate(event.startsAt)
+        val endsAt = getLocalizedDate(event.endsAt)
+        assertEquals("""
+          - Fri, Sep 19, 07:55 PM IST
+            """.trimIndent(), EventUtils.getFormattedEventDateTimeRangeSecond(startsAt, endsAt))
+    }
+
+    @Test
+    fun `should get formatted date range when start and end date are same in event details`() {
+        val event = getEvent(endsAt = "2008-09-15T15:53:00+05:00")
+        val startsAt = getLocalizedDate(event.startsAt)
+        val endsAt = getLocalizedDate(event.endsAt)
+        assertEquals("""
+          04:23 PM - 04:23 PM IST
+            """.trimIndent(), EventUtils.getFormattedEventDateTimeRangeSecond(startsAt, endsAt))
+    }
+
+    @Test
+    fun `should get formatted date range when start and end date are not same in details`() {
+        val event = getEvent()
+        val startsAt = getLocalizedDate(event.startsAt)
+        val endsAt = getLocalizedDate(event.endsAt)
+        assertEquals("""
+          - Fri, Sep 19, 07:55 PM IST
+            """.trimIndent(), EventUtils.getFormattedEventDateTimeRangeSecond(startsAt, endsAt))
+    }
+
+    @Test
+    fun `should get formatted date range when start and end date are same in details`() {
+        val event = getEvent(endsAt = "2008-09-15T15:53:00+05:00")
+        val startsAt = getLocalizedDate(event.startsAt)
+        val endsAt = getLocalizedDate(event.endsAt)
+        assertEquals("""
+          Monday, Sep 15, 2008 from 04:23 PM to 04:23 PM (IST)
+            """.trimIndent(), EventUtils.getFormattedDateTimeRangeDetailed(startsAt, endsAt))
+    }
+
 }

--- a/app/src/test/java/org/fossasia/openevent/general/event/EventUtilsTest.kt
+++ b/app/src/test/java/org/fossasia/openevent/general/event/EventUtilsTest.kt
@@ -122,15 +122,6 @@ class EventUtilsTest {
     }
 
     @Test
-    fun `should get timezone name with brackets`() {
-        val event = getEvent()
-        val localizedDateTime = getLocalizedDate(event.startsAt)
-        assertEquals("""
-           (IST)
-            """.trimIndent(), EventUtils.getFormattedTimeZoneWithBrackets(localizedDateTime))
-    }
-
-    @Test
     fun `should get formatted time`() {
         val event = getEvent()
         val localizedDateTime = getLocalizedDate(event.startsAt)

--- a/app/src/test/java/org/fossasia/openevent/general/event/EventUtilsTest.kt
+++ b/app/src/test/java/org/fossasia/openevent/general/event/EventUtilsTest.kt
@@ -144,7 +144,7 @@ class EventUtilsTest {
         val event = getEvent()
         val localizedDateTime = getLocalizedDate(event.startsAt)
         assertEquals("""
-          Mon, Sep 15,
+          Mon, Sep 15
             """.trimIndent(), EventUtils.getFormattedDateShort(localizedDateTime))
     }
 

--- a/app/src/test/java/org/fossasia/openevent/general/event/EventUtilsTest.kt
+++ b/app/src/test/java/org/fossasia/openevent/general/event/EventUtilsTest.kt
@@ -9,6 +9,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import org.threeten.bp.ZonedDateTime
 import java.time.ZoneId
 import java.util.*
 
@@ -42,6 +43,8 @@ class EventUtilsTest {
                          link: String? = null) =
             Event(id, name, identifier, startsAt, endsAt, timeZone,
                     description = description, externalEventUrl = link)
+
+    private fun getLocalizedDate(dateTime: String): ZonedDateTime = EventUtils.getLocalizedDateTime(dateTime)
 
     private fun setupStringMock() {
         every { resource.getString(R.string.event_name) }.returns("Event Name : ")
@@ -107,6 +110,60 @@ class EventUtilsTest {
             Ends On : 19 Sep 2008 07:55 PM
             Event Link : https://open-event-frontend-dev.herokuapp.com/e/abcdefgh
             """.trimIndent(), EventUtils.getSharableInfo(event, resource))
+    }
+
+    @Test
+    fun `should get timezone name`() {
+        val event = getEvent()
+        val localizedDateTime = getLocalizedDate(event.startsAt)
+        assertEquals("""
+           IST
+            """.trimIndent(), EventUtils.getFormattedTimeZone(localizedDateTime))
+    }
+
+    @Test
+    fun `should get timezone name with brackets`() {
+        val event = getEvent()
+        val localizedDateTime = getLocalizedDate(event.startsAt)
+        assertEquals("""
+           (IST)
+            """.trimIndent(), EventUtils.getFormattedTimeZoneWithBrackets(localizedDateTime))
+    }
+
+    @Test
+    fun `should get formatted time`() {
+        val event = getEvent()
+        val localizedDateTime = getLocalizedDate(event.startsAt)
+        assertEquals("""
+           04:23 PM
+            """.trimIndent(), EventUtils.getFormattedTime(localizedDateTime))
+    }
+
+    @Test
+    fun `should get formatted date and time without year`() {
+        val event = getEvent()
+        val localizedDateTime = getLocalizedDate(event.startsAt)
+        assertEquals("""
+          Monday, Sep 15
+            """.trimIndent(), EventUtils.getFormattedDateWithoutYear(localizedDateTime))
+    }
+
+    @Test
+    fun `should get formatted date short`() {
+        val event = getEvent()
+        val localizedDateTime = getLocalizedDate(event.startsAt)
+        assertEquals("""
+          Mon, Sep 15,
+            """.trimIndent(), EventUtils.getFormattedDateShort(localizedDateTime))
+    }
+
+    @Test
+    fun `should get formatted date`() {
+        val event = getEvent()
+        val localizedDateTime = getLocalizedDate(event.startsAt)
+        assertEquals("""
+          Monday, Sep 15, 2008
+            """.trimIndent(), EventUtils.getFormattedDate(localizedDateTime))
     }
 
 }

--- a/app/src/test/java/org/fossasia/openevent/general/event/EventUtilsTest.kt
+++ b/app/src/test/java/org/fossasia/openevent/general/event/EventUtilsTest.kt
@@ -203,8 +203,8 @@ class EventUtilsTest {
         val startsAt = getLocalizedDate(event.startsAt)
         val endsAt = getLocalizedDate(event.endsAt)
         assertEquals("""
-          - Fri, Sep 19, 07:55 PM IST
-            """.trimIndent(), EventUtils.getFormattedEventDateTimeRangeSecond(startsAt, endsAt))
+          Monday, Sep 15, 2008 at 04:23 PM - Friday, Sep 19, 2008 at 07:55 PM (IST)
+            """.trimIndent(), EventUtils.getFormattedDateTimeRangeDetailed(startsAt, endsAt))
     }
 
     @Test


### PR DESCRIPTION
fixes #240 #210 
changes: format date correctly and show the date and time in a different format if the start and end date are same
Screenshots:
![screenshot_20180702-225818](https://user-images.githubusercontent.com/20878145/42177800-b2792654-7e4b-11e8-8c36-6947fccc2d31.png)
![screenshot_20180702-225830](https://user-images.githubusercontent.com/20878145/42177797-b0fd6588-7e4b-11e8-8733-178371023ecf.png)

![screenshot_20180702-225841](https://user-images.githubusercontent.com/20878145/42177794-aeda700c-7e4b-11e8-922f-6d92d1a20b5c.png)
![screenshot_20180702-225847](https://user-images.githubusercontent.com/20878145/42177793-adb810c6-7e4b-11e8-8da3-0a3e3f6a2274.png)


