### PR TITLE
feat: store user profile on sign up or login

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/AuthService.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/AuthService.kt
@@ -2,6 +2,8 @@ package org.fossasia.openevent.general.auth
 
 import io.reactivex.Completable
 import io.reactivex.Single
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
 import timber.log.Timber
 
 
@@ -26,7 +28,10 @@ class AuthService(private val authApi: AuthApi,
         if (email.isNullOrEmpty() || password.isNullOrEmpty())
             throw IllegalArgumentException("Username or password cannot be empty")
 
-        return authApi.signUp(signUp)
+        return authApi.signUp(signUp).map {
+            userDao.insertUser(it)
+            it
+        }
     }
 
     fun isLoggedIn() = authHolder.isLoggedIn()

--- a/app/src/main/java/org/fossasia/openevent/general/auth/SignUpFragmentViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/SignUpFragmentViewModel.kt
@@ -54,10 +54,22 @@ class SignUpFragmentViewModel(private val authService: AuthService) : ViewModel(
                 }.subscribe({
                     loggedIn.value = true
                     Timber.d("Success!")
+                    fetchProfile()
                 }, {
                     error.value = "Unable to Login automatically"
                     Timber.d(it, "Failed")
                 }))
+    }
+
+    fun fetchProfile() {
+        compositeDisposable.add(authService.getProfile()
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({ user ->
+                    Timber.d("Fetched User Details")
+                }) {
+                    Timber.e(it, "Error loading user details")
+                })
     }
 
     override fun onCleared() {
@@ -65,7 +77,7 @@ class SignUpFragmentViewModel(private val authService: AuthService) : ViewModel(
         compositeDisposable.clear()
     }
 
-    private fun hasErrors(email: String?, password: String?, confirmPassword: String): Boolean{
+    private fun hasErrors(email: String?, password: String?, confirmPassword: String): Boolean {
         if (email.isNullOrEmpty() || password.isNullOrEmpty()) {
             error.value = "Email or Password cannot be empty!"
             return true


### PR DESCRIPTION
fixes #326 
After this : We dont need to open profile fragment to load user into database so that attendee details are automatically loaded on selecting tickets