### PR TITLE
feat: Add Smart Lock feature to login

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     kapt "android.arch.persistence.room:compiler:$roomVersion"
     implementation "android.arch.persistence.room:rxjava2:$roomVersion"
     testImplementation "android.arch.persistence.room:testing:$roomVersion"
+    implementation 'com.google.android.gms:play-services-auth:15.0.1'
 
     //Timber
     implementation 'com.jakewharton.timber:timber:4.7.0'

--- a/app/src/main/java/org/fossasia/openevent/general/auth/AuthHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/AuthHolder.kt
@@ -9,10 +9,7 @@ class AuthHolder(private val preference: Preference) {
 
     var token: String? = null
         get() {
-            if (field == null) {
-                field = preference.getString(TOKEN_KEY)
-            }
-
+            field = preference.getString(TOKEN_KEY)
             return field
         }
         set(value) {

--- a/app/src/main/java/org/fossasia/openevent/general/auth/AuthHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/AuthHolder.kt
@@ -9,7 +9,10 @@ class AuthHolder(private val preference: Preference) {
 
     var token: String? = null
         get() {
-            field = preference.getString(TOKEN_KEY)
+            if (field == null) {
+                field = preference.getString(TOKEN_KEY)
+            }
+
             return field
         }
         set(value) {

--- a/app/src/main/java/org/fossasia/openevent/general/auth/GoogleAuthBuilder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/GoogleAuthBuilder.kt
@@ -1,22 +1,37 @@
 package org.fossasia.openevent.general.auth
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
+import android.content.IntentSender
+import android.os.Build
 import android.os.Bundle
+import android.support.v4.app.ActivityCompat
+import android.support.v4.app.ActivityCompat.startActivityForResult
+import android.support.v4.app.ActivityCompat.startIntentSenderForResult
 import android.support.v4.app.FragmentActivity
 import android.support.v4.content.ContextCompat.startActivity
+import android.widget.EditText
 import com.google.android.gms.auth.api.Auth
+import com.google.android.gms.auth.api.credentials.Credential
 import com.google.android.gms.auth.api.credentials.CredentialRequest
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.common.api.GoogleApiClient
+import com.google.android.gms.common.api.Status
 import org.fossasia.openevent.general.MainActivity
 import org.fossasia.openevent.general.R
+import org.fossasia.openevent.general.utils.nullToEmpty
+import timber.log.Timber
 
 class GoogleAuthBuilder(private val context: Context, private val activity: FragmentActivity): GoogleApiClient.ConnectionCallbacks, GoogleApiClient.OnConnectionFailedListener {
 
     var googleApiClient: GoogleApiClient? = null
+    private var isResolving: Boolean = false
     var mode: Int = 0
+    var username: EditText? = null
+    var password: EditText? = null
+    var loginActivityViewModel: LoginFragmentViewModel? = null
 
     override fun onConnected(p0: Bundle?) {
         Auth.CredentialsApi.disableAutoSignIn(googleApiClient)
@@ -52,11 +67,44 @@ class GoogleAuthBuilder(private val context: Context, private val activity: Frag
         }
     }
 
+    @SuppressLint("RestrictedApi")
+    fun resolveResult(status: Status, requestCode: Int) {
+        if (isResolving) {
+            return
+        }
+
+        if (status.hasResolution()) {
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                    startIntentSenderForResult(activity, status.resolution.intentSender, requestCode, null, 0, 0, 0, null)
+                }
+                isResolving = true
+            } catch (e: IntentSender.SendIntentException) {
+                Timber.e(e)
+            }
+        } else {
+            Timber.e("Resolution Failed!")
+        }
+    }
+
+    fun saveCredential(credential: Credential) {
+        isResolving = false
+        Auth.CredentialsApi.save(googleApiClient, credential).setResultCallback { status ->
+
+            if (status.isSuccess) {
+                Timber.d("Credential saved")
+                redirectToMain()
+            } else {
+                Timber.d("Attempt to save credential failed ${status.statusMessage} ${status.statusCode}")
+                resolveResult(status, SAVE_DATA)
+            }
+        }
+    }
+
     fun redirectToMain() {
         val intent = Intent(activity, MainActivity::class.java)
         startActivity(context, intent, null)
         activity.overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_right)
         activity.finish()
     }
-
 }

--- a/app/src/main/java/org/fossasia/openevent/general/auth/GoogleAuthBuilder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/GoogleAuthBuilder.kt
@@ -1,0 +1,62 @@
+package org.fossasia.openevent.general.auth
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.support.v4.app.FragmentActivity
+import android.support.v4.content.ContextCompat.startActivity
+import com.google.android.gms.auth.api.Auth
+import com.google.android.gms.auth.api.credentials.CredentialRequest
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.api.CommonStatusCodes
+import com.google.android.gms.common.api.GoogleApiClient
+import org.fossasia.openevent.general.MainActivity
+import org.fossasia.openevent.general.R
+
+class GoogleAuthBuilder(private val context: Context, private val activity: FragmentActivity): GoogleApiClient.ConnectionCallbacks, GoogleApiClient.OnConnectionFailedListener {
+
+    var googleApiClient: GoogleApiClient? = null
+    var mode: Int = 0
+
+    override fun onConnected(p0: Bundle?) {
+        Auth.CredentialsApi.disableAutoSignIn(googleApiClient)
+        requestCredentials()
+    }
+
+    override fun onConnectionSuspended(p0: Int) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun onConnectionFailed(p0: ConnectionResult) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    init {
+        googleApiClient = GoogleApiClient.Builder(context)
+                .addConnectionCallbacks(this)
+                .enableAutoManage(activity, 0, this)
+                .addApi(Auth.CREDENTIALS_API)
+                .build()
+    }
+
+    fun requestCredentials() {
+        val request = CredentialRequest.Builder()
+                .setPasswordLoginSupported(true)
+                .build()
+
+        Auth.CredentialsApi.request(googleApiClient, request).setResultCallback { credentialRequestResult ->
+            val status = credentialRequestResult.status
+            if (status.statusCode == CommonStatusCodes.RESOLUTION_REQUIRED) {
+                resolveResult(status, FETCH_DATA)
+            }
+        }
+    }
+
+    fun redirectToMain() {
+        val intent = Intent(activity, MainActivity::class.java)
+        startActivity(context, intent, null)
+        activity.overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_right)
+        activity.finish()
+    }
+
+}

--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
@@ -10,25 +10,72 @@ import android.view.ViewGroup
 import android.widget.Toast
 import kotlinx.android.synthetic.main.fragment_login.*
 import kotlinx.android.synthetic.main.fragment_login.view.*
-import org.fossasia.openevent.general.MainActivity
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.utils.Utils
 import org.koin.android.architecture.ext.viewModel
+import com.google.android.gms.common.api.GoogleApiClient
+import com.google.android.gms.auth.api.Auth
+import com.google.android.gms.auth.api.credentials.Credential
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.api.Status
+import android.content.IntentSender
+import org.fossasia.openevent.general.MainActivity
+import com.google.android.gms.common.api.CommonStatusCodes
+import com.google.android.gms.auth.api.credentials.CredentialRequest
+import org.fossasia.openevent.general.utils.nullToEmpty
+import timber.log.Timber
 
-class LoginFragment : Fragment() {
+class LoginFragment : Fragment(), GoogleApiClient.ConnectionCallbacks, GoogleApiClient.OnConnectionFailedListener {
 
     private val loginActivityViewModel by viewModel<LoginFragmentViewModel>()
     private lateinit var rootView: View
+    private var googleApiClient: GoogleApiClient? = null
+    private var isResolving: Boolean = false
+    private var isRequesting: Boolean = false
+    private var SAVE_DATA: Int = 1
+    private var FETCH_DATA: Int = 3
+    private lateinit var credentialLogin: Credential
+    private var mode: Int = 0
+
+    override fun onConnected(p0: Bundle?) {
+        //Request credentials from a logged in account
+        Auth.CredentialsApi.disableAutoSignIn(googleApiClient)
+        requestCredentials()
+    }
+
+    override fun onConnectionSuspended(p0: Int) {}
+
+    override fun onConnectionFailed(p0: ConnectionResult) {}
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
         rootView = inflater.inflate(R.layout.fragment_login, container, false)
 
+        googleApiClient = context?.let {
+            activity?.let { it1 ->
+                GoogleApiClient.Builder(it)
+                        .addConnectionCallbacks(this)
+                        .enableAutoManage(it1, 0, this)
+                        .addApi(Auth.CREDENTIALS_API)
+                        .build()
+            }
+        }
 
         if (loginActivityViewModel.isLoggedIn())
             redirectToMain()
 
+        //Initialize credentialLogin
+        credentialLogin = Credential.Builder("id")
+                .setPassword("password")
+                .build()
+
         rootView.loginButton.setOnClickListener {
+            mode = SAVE_DATA
+            if (username.text.isNotEmpty() && password.text.isNotEmpty()) {
+                credentialLogin = Credential.Builder(username.text.toString())
+                        .setPassword(password.text.toString())
+                        .build()
+            }
             loginActivityViewModel.login(username.text.toString(), password.text.toString())
         }
 
@@ -45,7 +92,11 @@ class LoginFragment : Fragment() {
 
         loginActivityViewModel.loggedIn.observe(this, Observer {
             Toast.makeText(context, "Success!", Toast.LENGTH_LONG).show()
-            redirectToMain()
+            if (mode == FETCH_DATA) {
+                redirectToMain()
+            } else if (mode == SAVE_DATA) {
+                saveCredential(credentialLogin)
+            }
         })
 
         return rootView
@@ -56,6 +107,91 @@ class LoginFragment : Fragment() {
         startActivity(intent)
         activity?.overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_right)
         activity?.finish()
+    }
+
+    private fun saveCredential(credential: Credential) {
+        isResolving = false
+        Auth.CredentialsApi.save(googleApiClient, credential).setResultCallback { status ->
+
+            if (status.isSuccess) {
+                Timber.d("Credential saved")
+                redirectToMain()
+            } else {
+                Timber.d("Attempt to save credential failed " +
+                        status.statusMessage + " " +
+                        status.statusCode)
+                resolveResult(status, SAVE_DATA)
+            }
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        if (requestCode == FETCH_DATA) {
+            mode = FETCH_DATA
+            val credential = data?.getParcelableExtra<Credential>(Credential.EXTRA_KEY)
+            credential?.let { processRetrievedCredential(it) }
+        } else if (requestCode == SAVE_DATA) {
+            mode = SAVE_DATA
+            redirectToMain()
+        }
+    }
+
+    private fun resolveResult(status: Status, requestCode: Int) {
+        if (isResolving) {
+            return
+        }
+
+        if (status.hasResolution()) {
+            try {
+                startIntentSenderForResult(status.resolution.intentSender, requestCode,null, 0, 0, 0, null)
+                isResolving = true
+            } catch (e: IntentSender.SendIntentException) {
+                Timber.e(e)
+            }
+        } else {
+            Timber.e("Resolution Failed!")
+        }
+    }
+
+    private fun requestCredentials() {
+        isRequesting = true
+
+        val request = CredentialRequest.Builder()
+                .setPasswordLoginSupported(true)
+                .build()
+
+        Auth.CredentialsApi.request(googleApiClient, request).setResultCallback { credentialRequestResult ->
+            isRequesting = false
+            val status = credentialRequestResult.status
+            if (status.isSuccess) {
+                val credential = credentialRequestResult.credential
+                processRetrievedCredential(credential)
+            } else if (status.statusCode == CommonStatusCodes.RESOLUTION_REQUIRED) {
+                resolveResult(status, FETCH_DATA)
+            }
+
+        }
+    }
+
+    private fun processRetrievedCredential(credential: Credential) {
+        loginActivityViewModel.login(credential.id.nullToEmpty(), credential.password.nullToEmpty())
+        username.setText(credential.id)
+        password.setText(credential.password)
+    }
+
+    override fun onPause() {
+        activity?.let { googleApiClient?.stopAutoManage(it) }
+        googleApiClient?.disconnect()
+        super.onPause()
+    }
+
+    override fun onResume() {
+        if (googleApiClient?.isConnected == false) {
+            googleApiClient?.connect()
+        }
+        super.onResume()
     }
 
 }

--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
@@ -51,14 +51,14 @@ class LoginFragment : Fragment(), GoogleApiClient.ConnectionCallbacks, GoogleApi
                               savedInstanceState: Bundle?): View? {
         rootView = inflater.inflate(R.layout.fragment_login, container, false)
 
-        googleApiClient = context?.let {
-            activity?.let { it1 ->
-                GoogleApiClient.Builder(it)
-                        .addConnectionCallbacks(this)
-                        .enableAutoManage(it1, 0, this)
-                        .addApi(Auth.CREDENTIALS_API)
-                        .build()
-            }
+        val context = context
+        val activity = activity
+        if(context != null && activity!= null) {
+            googleApiClient =  GoogleApiClient.Builder(context)
+                    .addConnectionCallbacks(this)
+                    .enableAutoManage(activity, 0, this)
+                    .addApi(Auth.CREDENTIALS_API)
+                    .build()
         }
 
         if (loginActivityViewModel.isLoggedIn())

--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
@@ -117,9 +117,7 @@ class LoginFragment : Fragment(), GoogleApiClient.ConnectionCallbacks, GoogleApi
                 Timber.d("Credential saved")
                 redirectToMain()
             } else {
-                Timber.d("Attempt to save credential failed " +
-                        status.statusMessage + " " +
-                        status.statusCode)
+                Timber.d("Attempt to save credential failed ${status.statusMessage} ${status.statusCode}")
                 resolveResult(status, SAVE_DATA)
             }
         }
@@ -145,7 +143,7 @@ class LoginFragment : Fragment(), GoogleApiClient.ConnectionCallbacks, GoogleApi
 
         if (status.hasResolution()) {
             try {
-                startIntentSenderForResult(status.resolution.intentSender, requestCode,null, 0, 0, 0, null)
+                startIntentSenderForResult(status.resolution.intentSender, requestCode, null, 0, 0, 0, null)
                 isResolving = true
             } catch (e: IntentSender.SendIntentException) {
                 Timber.e(e)
@@ -171,7 +169,6 @@ class LoginFragment : Fragment(), GoogleApiClient.ConnectionCallbacks, GoogleApi
             } else if (status.statusCode == CommonStatusCodes.RESOLUTION_REQUIRED) {
                 resolveResult(status, FETCH_DATA)
             }
-
         }
     }
 


### PR DESCRIPTION
Fixes #330, #336 
Made it similar to EventBrite. Points->
*If it is a new credential, the app will ask whether to save it in our account.( The app asks only after there is login success, which means the account is present in server, (basically not an invalid account))
*A list of already saved credentials will be shown when we open login page. If the user selects one of those, the user will get logged in automatically
*If we manually enter an already saved account, the user won't be asked to save it again

![videotogif_2018 07 18_08 41 45](https://user-images.githubusercontent.com/28607714/42857355-28eaf43a-8a67-11e8-866c-8cab8e09bc56.gif)


