### PR TITLE
fix: events recycler visible in attendee fragment bug

### DIFF
--- a/app/src/main/res/layout/fragment_attendee.xml
+++ b/app/src/main/res/layout/fragment_attendee.xml
@@ -2,7 +2,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:background="@android:color/white"
+    android:layout_height="match_parent">
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
fixes #409 #376 
before fix : 
![videotogif_2018 07 31_01 40 07](https://user-images.githubusercontent.com/16715499/43421047-3aaa052a-9463-11e8-9f3c-6d7c81a69963.gif)
after fix : 
![screenshot_20180731-014230_open-event-android](https://user-images.githubusercontent.com/16715499/43421037-3422e7da-9463-11e8-9521-0021b5dcdbf6.jpg)
