### PR TITLE
fix: extend OpenEventGeneral from MultiDexApplication (#442)

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/OpenEventGeneral.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/OpenEventGeneral.kt
@@ -2,12 +2,13 @@ package org.fossasia.openevent.general
 
 import android.app.Application
 import android.content.Context
+import android.support.multidex.MultiDexApplication
 import com.jakewharton.threetenabp.AndroidThreeTen
 import org.fossasia.openevent.general.di.*
 import org.koin.android.ext.android.startKoin
 import timber.log.Timber
 
-class OpenEventGeneral : Application() {
+class OpenEventGeneral : MultiDexApplication() {
 
     companion object  {
         @JvmStatic


### PR DESCRIPTION
Sorry, if I did it not correctly; doing it first time; please, let me know what was wrong.

When extended from Application the app failed to open both on emulator with KitKat 4.4.2 (API 19) and on my physical device. As I replaced Application with MultiDexApplication it started opening OK. 