### PR TITLE
fix: Capitalize first letter of words in search

### DIFF
--- a/app/src/main/res/layout/activity_search_location.xml
+++ b/app/src/main/res/layout/activity_search_location.xml
@@ -8,6 +8,7 @@
         android:id="@+id/search"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:inputType="textCapWords"
         app:iconifiedByDefault="false"
         app:queryHint="@string/where"
         app:searchIcon="@null" />


### PR DESCRIPTION
Fixes #624 