### PR TITLE
feat: add how to use app in about section

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/settings/SettingsFragment.kt
@@ -22,6 +22,7 @@ class SettingsFragment : PreferenceFragmentCompat(), PreferenceChangeListener {
     private var email: String? = null
     val EMAIL: String = "EMAIL"
     val FORM_LINK: String = "https://docs.google.com/forms/d/e/1FAIpQLSd7Y1T1xoXeYaAG_b6Tu1YYK-jZssoC5ltmQbkUX0kmDZaKYw/viewform"
+    val SITE_LINK: String ="http://support.eventyay.com"
     private val settingsViewModel by viewModel<SettingsFragmentViewModel>()
 
     override fun preferenceChange(evt: PreferenceChangeEvent?) {
@@ -62,6 +63,13 @@ class SettingsFragment : PreferenceFragmentCompat(), PreferenceChangeListener {
         if (preference?.key == resources.getString(R.string.key_profile)) {
             //Logout Dialog shown
             showDialog()
+            return true
+        }
+        if (preference?.key == resources.getString(R.string.key_how_to_use)) {
+            //Links to support site
+            context?.let {
+                Utils.openUrl(it, SITE_LINK)
+            }
             return true
         }
         return false

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,6 +125,8 @@
     <string name="key_about">about</string>
     <string name="key_rating">rating</string>
     <string name="rating_settings">Rate Us</string>
+    <string name="key_how_to_use">How to use</string>
+    <string name="how_to_use">How to use the app</string>
     <string name="app_name_capital">Open Event Android</string>
     <string name="suggestion_settings">Suggest Improvement</string>
     <string name="key_acknowledgements">key_acknowledgements</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -12,6 +12,10 @@
             android:key="@string/key_suggestion"
             android:title="@string/suggestion_settings" />
 
+        <Preference
+            android:key="@string/key_how_to_use"
+            android:title="@string/how_to_use" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Fixes #632

Changes: how to use the app is added in about section of setting which will open the support site of the app.

