### PR TITLE
chore: Upgrade support library to recent 28

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'kotlin-android-extensions'
 def STRIPE_API_TOKEN = System.getenv('STRIPE_API_TOKEN') ?: "YOUR_API_KEY"
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         applicationId "com.eventyay.attendee"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 3
         versionName "0.0.3a"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -71,13 +71,16 @@ dependencies {
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:multidex:1.0.3'
-    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:preference-v14:28.0.0'
+    implementation 'com.android.support:support-media-compat:28.0.0'
+    implementation 'com.android.support:support-v4:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    implementation 'com.android.support:cardview-v7:27.1.1'
-    implementation 'com.android.support:recyclerview-v7:27.1.1'
-    implementation 'com.android.support:design:27.1.1'
-    implementation "com.android.support:customtabs:27.1.1"
-    implementation 'com.android.support:exifinterface:27.1.1'
+    implementation 'com.android.support:cardview-v7:28.0.0'
+    implementation 'com.android.support:recyclerview-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
+    implementation "com.android.support:customtabs:28.0.0"
+    implementation 'com.android.support:exifinterface:28.0.0'
     implementation "com.takisoft.fix:preference-v7:27.1.1.2"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.koin:koin-android:$koin_version"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-alpha16'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Fixes #648 

Changes: Upgrade support library, compileSdkVersion & targetSdkVersion to recent 28.
Add few android.support libraries because it must use same version specification. (Mixing versions can lead to runtime crashes).

Screenshots for the change:
![screenshot from 2018-10-16 23-14-48](https://user-images.githubusercontent.com/24621468/47036471-3c33da00-d19a-11e8-892c-47fb0ef6ed91.png)
