### PR TITLE
fix: User avatar not loading in EditProfileFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
@@ -52,8 +52,19 @@ class EditProfileFragment : Fragment() {
             it?.let {
                 val userFirstName = it.firstName.nullToEmpty()
                 val userLastName = it.lastName.nullToEmpty()
+                val imageUrl = it.avatarUrl.nullToEmpty()
                 rootView.firstName.setText(userFirstName)
                 rootView.lastName.setText(userLastName)
+                context?.let { ctx ->
+                    val drawable = AppCompatResources.getDrawable(ctx, R.drawable.ic_account_circle_grey_24dp)
+                    drawable?.let { icon ->
+                        Picasso.get()
+                            .load(imageUrl)
+                            .placeholder(icon)
+                            .transform(CircleTransform())
+                            .into(rootView.profilePhoto)
+                    }
+                }
             }
         })
         profileFragmentViewModel.fetchProfile()


### PR DESCRIPTION
Fixes #653 
Changes: Added logic to load the user's profile avatar in the EditProfileFragment.

Screenshots for the change:
![fixed-screenshot](https://user-images.githubusercontent.com/24315306/47363406-57e83480-d6f4-11e8-8684-19b064ecb9bb.jpg)
