### PR TITLE
chore: Switch to Gradle 3.2.1 and support for build tools v28 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,5 @@ script:
 after_success:
     - bash scripts/prep-key.sh
     - bash scripts/update-apk.sh
+before_install:
+- yes | sdkmanager "platforms;android-28"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-alpha16'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
This is a fix for unsupported gradle version error in Android Studio. Switching to Gradle v3.2.1 resolves this error, but causes the Travis CI builds to fail because the current travis.yml file does not allow support for build tools v28. Therefore, travis.yml file has also been modified to accept build tools v28.

Fixes #659 

Changes: 
1. Project level build.gradle file to use Gradle v3.2.1
2. .travis.yml file to allow build tools v28.