### PR TITLE
"Search text comes once in fragment"

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchFragment.kt
@@ -141,6 +141,7 @@ class SearchFragment : Fragment() {
             }
         }
         searchView.setOnQueryTextListener(queryListener)
+        searchView.maxWidth = Int.MAX_VALUE
         rootView.fabSearch.setOnClickListener {
             queryListener.onQueryTextSubmit(searchView.query.toString())
         }


### PR DESCRIPTION
Fixes #663

Changes: 
Made searchView occupy the whole ActionBar.

Screenshots for the change:
![search_issue](https://user-images.githubusercontent.com/34534870/47678141-102b4680-dbe7-11e8-8f22-4db08f7ead6b.gif)


