### PR TITLE
fixed issue of opening share window twice when share button is clicked twice in the events screen

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventViewHolder.kt
@@ -1,6 +1,7 @@
 package org.fossasia.openevent.general.event
 
 import android.content.Intent
+import android.os.Handler
 import android.support.v7.widget.RecyclerView
 import android.view.View
 import com.squareup.picasso.Picasso
@@ -21,7 +22,6 @@ class EventViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
 
         val startsAt = EventUtils.getLocalizedDateTime(event.startsAt)
         val endsAt = EventUtils.getLocalizedDateTime(event.endsAt)
-
         if (dateFormat == FAVORITE_EVENT_DATE_FORMAT) {
             itemView.date.text = EventUtils.getFormattedDateTimeRangeBulleted(startsAt, endsAt)
         } else {
@@ -44,10 +44,13 @@ class EventViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         itemView.shareFab.setOnClickListener {
             val sendIntent = Intent()
             sendIntent.action = Intent.ACTION_SEND
-
             sendIntent.putExtra(Intent.EXTRA_TEXT, EventUtils.getSharableInfo(event))
             sendIntent.type = "text/plain"
+            itemView.shareFab.isEnabled = false
             itemView.context.startActivity(Intent.createChooser(sendIntent, "Share Event Details"))
+            Handler().postDelayed({
+                itemView.shareFab.isEnabled = true
+            },100)
         }
 
         itemView.favoriteFab.setOnClickListener {

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsRecyclerAdapter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsRecyclerAdapter.kt
@@ -48,6 +48,7 @@ class EventsRecyclerAdapter : RecyclerView.Adapter<EventViewHolder>() {
     override fun onBindViewHolder(holder: EventViewHolder, position: Int) {
         val event = events[position]
         holder.bind(event, clickListener, favoriteFabListener, EVENT_DATE_FORMAT)
+
     }
 
     override fun getItemCount(): Int {

--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
@@ -49,6 +49,7 @@ class FavoriteFragment : Fragment() {
                 activity?.supportFragmentManager?.beginTransaction()?.add(R.id.rootLayout, fragment)?.addToBackStack(null)?.commit()
             }
         }
+
         val favouriteFabClickListener = object : FavoriteFabListener {
             override fun onClick(event: Event, isFavourite: Boolean) {
                 val id = favoriteEventsRecyclerAdapter.getPos(event.id)


### PR DESCRIPTION
Fixes #666 

Changes:
 on the onClickListener for shareFab the share fab button was disabled when the shareFab is clicked once and enabled after share window is closed.

Screenshots for the change:
![fixed](https://user-images.githubusercontent.com/41572056/47698557-cb7acc00-dc35-11e8-8a7f-089a40f7b752.gif)
