### PR TITLE
fix : App crash while trying to editing a profile with no profile picture

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
@@ -55,7 +55,7 @@ class EditProfileFragment : Fragment() {
                 val imageUrl = it.avatarUrl.nullToEmpty()
                 rootView.firstName.setText(userFirstName)
                 rootView.lastName.setText(userLastName)
-                if(!imageUrl.isEmpty()){ // picasso requires the imageUrl to be non empty
+                if (!imageUrl.isEmpty()) { // picasso requires the imageUrl to be non empty
                     context?.let { ctx ->
                         val drawable = AppCompatResources.getDrawable(ctx, R.drawable.ic_account_circle_grey_24dp)
                         drawable?.let{ icon ->

--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
@@ -58,11 +58,14 @@ class EditProfileFragment : Fragment() {
                 context?.let { ctx ->
                     val drawable = AppCompatResources.getDrawable(ctx, R.drawable.ic_account_circle_grey_24dp)
                     drawable?.let { icon ->
-                        Picasso.get()
-                            .load(imageUrl)
-                            .placeholder(icon)
-                            .transform(CircleTransform())
-                            .into(rootView.profilePhoto)
+                        if(!imageUrl.equals("")) { // picasso requires the imageUrl to be non empty
+                            Picasso.get()
+                                .load(imageUrl)
+                                .placeholder(icon)
+                                .transform(CircleTransform())
+                                .into(rootView.profilePhoto)
+
+                        }
                     }
                 }
             }

--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
@@ -55,10 +55,10 @@ class EditProfileFragment : Fragment() {
                 val imageUrl = it.avatarUrl.nullToEmpty()
                 rootView.firstName.setText(userFirstName)
                 rootView.lastName.setText(userLastName)
-                if(!imageUrl.isEmpty()) { // picasso requires the imageUrl to be non empty
+                if(!imageUrl.isEmpty()){ // picasso requires the imageUrl to be non empty
                     context?.let { ctx ->
                         val drawable = AppCompatResources.getDrawable(ctx, R.drawable.ic_account_circle_grey_24dp)
-                        drawable?.let { icon ->
+                        drawable?.let{ icon ->
                             Picasso.get()
                                     .load(imageUrl)
                                     .placeholder(icon)

--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
@@ -58,7 +58,7 @@ class EditProfileFragment : Fragment() {
                 if (!imageUrl.isEmpty()) { // picasso requires the imageUrl to be non empty
                     context?.let { ctx ->
                         val drawable = AppCompatResources.getDrawable(ctx, R.drawable.ic_account_circle_grey_24dp)
-                        drawable?.let{ icon ->
+                        drawable?.let { icon ->
                             Picasso.get()
                                     .load(imageUrl)
                                     .placeholder(icon)

--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
@@ -58,7 +58,7 @@ class EditProfileFragment : Fragment() {
                 context?.let { ctx ->
                     val drawable = AppCompatResources.getDrawable(ctx, R.drawable.ic_account_circle_grey_24dp)
                     drawable?.let { icon ->
-                        if(!imageUrl.equals("")) { // picasso requires the imageUrl to be non empty
+                        if(!imageUrl.isEmpty()) { // picasso requires the imageUrl to be non empty
                             Picasso.get()
                                 .load(imageUrl)
                                 .placeholder(icon)

--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
@@ -55,16 +55,15 @@ class EditProfileFragment : Fragment() {
                 val imageUrl = it.avatarUrl.nullToEmpty()
                 rootView.firstName.setText(userFirstName)
                 rootView.lastName.setText(userLastName)
-                context?.let { ctx ->
-                    val drawable = AppCompatResources.getDrawable(ctx, R.drawable.ic_account_circle_grey_24dp)
-                    drawable?.let { icon ->
-                        if(!imageUrl.isEmpty()) { // picasso requires the imageUrl to be non empty
+                if(!imageUrl.isEmpty()) { // picasso requires the imageUrl to be non empty
+                    context?.let { ctx ->
+                        val drawable = AppCompatResources.getDrawable(ctx, R.drawable.ic_account_circle_grey_24dp)
+                        drawable?.let { icon ->
                             Picasso.get()
-                                .load(imageUrl)
-                                .placeholder(icon)
-                                .transform(CircleTransform())
-                                .into(rootView.profilePhoto)
-
+                                    .load(imageUrl)
+                                    .placeholder(icon)
+                                    .transform(CircleTransform())
+                                    .into(rootView.profilePhoto)
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #683 

Changes: Added code to check if the profile picture URL is not empty, as Picasso requires a non-empty url. Thus if there is no profile picture initially, there should be no attempt to load such an image.  
