### PR TITLE
fix: improve logic of onBackPressed for Fragments

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
@@ -128,11 +128,18 @@ class MainActivity : AppCompatActivity() {
     override fun onBackPressed() {
         val currentFragment = this.supportFragmentManager.findFragmentById(R.id.frameContainer)
         val rootFragment = this.supportFragmentManager.findFragmentById(R.id.rootLayout)
-        if (currentFragment !is EventsFragment && rootFragment !is EventDetailsFragment) {
-            loadFragment(EventsFragment())
-            navigation.selectedItemId = navigation_events
-        } else {
+        if (rootFragment is EventDetailsFragment)
             super.onBackPressed()
-        }
+        else
+            when(currentFragment) {
+                is SearchFragment,
+                is FavoriteFragment,
+                is OrdersUnderUserFragment,
+                is ProfileFragment -> {
+                    loadFragment(EventsFragment())
+                    navigation.selectedItemId = navigation_events
+                }
+                else -> super.onBackPressed()
+            }
     }
 }


### PR DESCRIPTION
Fixes #686 

Changes: MainActivity.kt

![blank diagram 3](https://user-images.githubusercontent.com/27783786/48119245-d1eff000-e294-11e8-9851-0aa6cf1a79a1.jpeg)
