### PR TITLE
fix: Fix the no connectivity case bug on Main Activity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,5 @@ script:
 after_success:
     - bash scripts/prep-key.sh
     - bash scripts/update-apk.sh
+before_install:
+- yes | sdkmanager "platforms;android-28"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A native Android app using Kotlin for writing code.
 - InsertKoinIO [Docs](https://github.com/InsertKoinIO/koin)
 - JSON API Converter [Docs](https://github.com/jasminb/jsonapi-converter)
 - OkHttp [Docs](http://square.github.io/okhttp/)
-- Room Persistence Library [Docs] (https://developer.android.com/topic/libraries/architecture/room)
+- Room Persistence Library [Docs](https://developer.android.com/topic/libraries/architecture/room)
 
 ### Project Conventions
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,7 +107,7 @@ dependencies {
 
     // RxJava
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.0'
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.2'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.3'
     implementation 'com.squareup.retrofit2:adapter-rxjava2:2.4.0'
 
     //picasso
@@ -120,8 +120,8 @@ dependencies {
     implementation 'com.journeyapps:zxing-android-embedded:3.6.0'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation "io.mockk:mockk:1.8.9"
-    testImplementation 'org.threeten:threetenbp:1.3.7'
+    testImplementation "io.mockk:mockk:1.8.12"
+    testImplementation 'org.threeten:threetenbp:1.3.8'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }

--- a/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
@@ -6,11 +6,11 @@ import android.support.v4.app.Fragment
 import android.support.v7.app.AppCompatActivity
 import android.view.Menu
 import kotlinx.android.synthetic.main.activity_main.*
-import org.fossasia.openevent.general.R.id.navigation_events
-import org.fossasia.openevent.general.R.id.navigation_search
+import org.fossasia.openevent.general.R.id.*
 import org.fossasia.openevent.general.attendees.AttendeeFragment
 import org.fossasia.openevent.general.auth.LAUNCH_ATTENDEE
 import org.fossasia.openevent.general.auth.ProfileFragment
+import org.fossasia.openevent.general.event.EventDetailsFragment
 import org.fossasia.openevent.general.event.EventsFragment
 import org.fossasia.openevent.general.favorite.FavoriteFragment
 import org.fossasia.openevent.general.order.LAUNCH_TICKETS
@@ -127,7 +127,8 @@ class MainActivity : AppCompatActivity() {
 
     override fun onBackPressed() {
         val currentFragment = this.supportFragmentManager.findFragmentById(R.id.frameContainer)
-        if (currentFragment !is EventsFragment) {
+        val rootFragment = this.supportFragmentManager.findFragmentById(R.id.rootLayout)
+        if (currentFragment !is EventsFragment && rootFragment !is EventDetailsFragment) {
             loadFragment(EventsFragment())
             navigation.selectedItemId = navigation_events
         } else {

--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
@@ -52,8 +52,21 @@ class EditProfileFragment : Fragment() {
             it?.let {
                 val userFirstName = it.firstName.nullToEmpty()
                 val userLastName = it.lastName.nullToEmpty()
+                val imageUrl = it.avatarUrl.nullToEmpty()
                 rootView.firstName.setText(userFirstName)
                 rootView.lastName.setText(userLastName)
+                if (!imageUrl.isEmpty()) { // picasso requires the imageUrl to be non empty
+                    context?.let { ctx ->
+                        val drawable = AppCompatResources.getDrawable(ctx, R.drawable.ic_account_circle_grey_24dp)
+                        drawable?.let { icon ->
+                            Picasso.get()
+                                    .load(imageUrl)
+                                    .placeholder(icon)
+                                    .transform(CircleTransform())
+                                    .into(rootView.profilePhoto)
+                        }
+                    }
+                }
             }
         })
         profileFragmentViewModel.fetchProfile()

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -121,7 +121,12 @@ class EventsFragment : Fragment() {
 
         rootView.swiperefresh.setColorSchemeColors(Color.BLUE)
         rootView.swiperefresh.setOnRefreshListener {
-            eventsViewModel.retryLoadLocationEvents()
+            showNoInternetScreen(isNetworkConnected())
+            if (!isNetworkConnected()) {
+                rootView.swiperefresh.isRefreshing = false
+            } else {
+                eventsViewModel.retryLoadLocationEvents()
+            }
         }
 
         return rootView

--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
@@ -10,6 +10,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import kotlinx.android.synthetic.main.fragment_favorite.*
 import kotlinx.android.synthetic.main.fragment_favorite.view.*
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.event.*
@@ -55,6 +56,7 @@ class FavoriteFragment : Fragment() {
                 favoriteEventViewModel.setFavorite(event.id, !isFavourite)
                 event.favorite = !event.favorite
                 favoriteEventsRecyclerAdapter.notifyItemChanged(id)
+                showEmptyMessage(favoriteEventsRecyclerAdapter.itemCount)
             }
         }
 
@@ -64,6 +66,7 @@ class FavoriteFragment : Fragment() {
             it?.let {
                 favoriteEventsRecyclerAdapter.addAll(it)
                 favoriteEventsRecyclerAdapter.notifyDataSetChanged()
+                showEmptyMessage(favoriteEventsRecyclerAdapter.itemCount)
             }
             Timber.d("Fetched events of size %s", favoriteEventsRecyclerAdapter.itemCount)
         })
@@ -78,6 +81,10 @@ class FavoriteFragment : Fragment() {
 
         favoriteEventViewModel.loadFavoriteEvents()
         return rootView
+    }
+
+    private fun showEmptyMessage(itemCount: Int) {
+        noLikedText.visibility = if (itemCount == 0) View.VISIBLE else View.GONE
     }
 
     private fun showProgressBar(show: Boolean) {

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
@@ -10,6 +10,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import kotlinx.android.synthetic.main.content_no_tickets.*
+import kotlinx.android.synthetic.main.fragment_orders_under_user.*
 import kotlinx.android.synthetic.main.fragment_orders_under_user.view.*
 import org.fossasia.openevent.general.AuthActivity
 import org.fossasia.openevent.general.R
@@ -69,6 +71,10 @@ class OrdersUnderUserFragment : Fragment() {
                 Toast.makeText(context, it, Toast.LENGTH_LONG).show()
             })
 
+            ordersUnderUserVM.noTickets.observe(this, Observer {
+                it?.let { showNoTicketsScreen(it) }
+            })
+
             ordersUnderUserVM.attendeesNumber.observe(this, Observer {
                 it?.let {
                     ordersRecyclerAdapter.setAttendeeNumber(it)
@@ -88,6 +94,15 @@ class OrdersUnderUserFragment : Fragment() {
         }
 
         return rootView
+    }
+
+    private fun showNoTicketsScreen(show: Boolean) {
+        noTicketsScreen.visibility = if (show) View.VISIBLE else View.GONE
+        findMyTickets.setOnClickListener {
+            context?.let {
+                Utils.openUrl(it, resources.getString(R.string.ticket_issues_url))
+            }
+        }
     }
 
     private fun redirectToLogin() {

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserVM.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserVM.kt
@@ -27,6 +27,7 @@ class OrdersUnderUserVM(
     val message = SingleLiveEvent<String>()
     val eventAndOrderIdentifier = MutableLiveData<List<Pair<Event, String>>>()
     val progress = MutableLiveData<Boolean>()
+    val noTickets = MutableLiveData<Boolean>()
 
     fun getId() = authHolder.getId()
 
@@ -38,6 +39,7 @@ class OrdersUnderUserVM(
                 .observeOn(AndroidSchedulers.mainThread())
                 .doOnSubscribe {
                     progress.value = true
+                    noTickets.value = false
                 }.subscribe({
                     order = it
                     attendeesNumber.value = it.map { it.attendees?.size } as ArrayList<Int>
@@ -45,8 +47,10 @@ class OrdersUnderUserVM(
 
                     if (idList.size != 0)
                         eventsUnderUser(query)
-                    else
+                    else {
                         progress.value = false
+                        noTickets.value = true
+                    }
                 }, {
                     message.value = "Failed  to list Orders under a user"
                     Timber.d(it, "Failed  to list Orders under a user ")

--- a/app/src/main/res/drawable/round_shape.xml
+++ b/app/src/main/res/drawable/round_shape.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <stroke
+        android:width="@dimen/card_corner_radius"
+        android:color="@color/greyMore" />
+</shape>

--- a/app/src/main/res/layout/content_no_tickets.xml
+++ b/app/src/main/res/layout/content_no_tickets.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="@dimen/layout_margin_extra_large"
+    android:orientation="vertical">
+
+    <RelativeLayout
+        android:layout_width="@dimen/item_image_view_large"
+        android:layout_height="@dimen/item_image_view_large"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="@dimen/layout_margin_large">
+
+        <ImageView
+            android:layout_width="@dimen/item_image_view_large"
+            android:layout_height="@dimen/item_image_view_large"
+            android:layout_centerInParent="true"
+            android:scaleType="centerCrop"
+            app:srcCompat="@drawable/round_shape" />
+
+        <ImageView
+            android:id="@+id/ticketImageView"
+            android:layout_width="@dimen/item_image_view"
+            android:layout_height="@dimen/item_image_view"
+            android:layout_centerInParent="true"
+            android:scaleType="centerCrop"
+            app:srcCompat="@drawable/ic_baseline_ticket_24dp"
+            app:tint="@color/colorPrimary"/>
+
+    </RelativeLayout>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="@dimen/layout_margin_extra_large"
+        android:text="@string/no_ticket_message"
+        android:textSize="@dimen/text_size_medium" />
+
+    <TextView
+        android:id="@+id/findMyTickets"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="@dimen/layout_margin_large"
+        android:text="@string/find_my_tickets"
+        android:textColor="@color/colorPrimary"
+        android:textSize="@dimen/text_size_large" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_favorite.xml
+++ b/app/src/main/res/layout/fragment_favorite.xml
@@ -6,6 +6,34 @@
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
+       <LinearLayout
+           android:layout_width="match_parent"
+           android:layout_height="match_parent"
+           android:orientation="vertical">
+           <LinearLayout
+               android:layout_width="match_parent"
+               android:layout_height="match_parent"
+               android:orientation="vertical"
+               android:layout_gravity="center"
+               android:gravity="center_vertical"
+               android:textAlignment="center"
+               android:id="@+id/noLikedText"
+               android:layout_margin="5dp">
+               <TextView
+                   android:layout_width="match_parent"
+                   android:layout_height="wrap_content"
+                   android:text="@string/nothing_planned_yet"
+                   android:textSize="15sp"
+                   android:layout_gravity="center_horizontal"
+                   android:textAlignment="center"/>
+               <TextView
+                   android:layout_width="match_parent"
+                   android:layout_height="wrap_content"
+                   android:text="@string/find_something_to_do"
+                   android:textSize="25sp"
+                   android:textAlignment="center"/>
+
+           </LinearLayout>
 
         <ProgressBar
             android:layout_gravity="center"
@@ -18,8 +46,9 @@
         <android.support.v7.widget.RecyclerView
             android:id="@+id/favoriteEventsRecycler"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:scrollbars="vertical" />
+       </LinearLayout>
     </FrameLayout>
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_orders_under_user.xml
+++ b/app/src/main/res/layout/fragment_orders_under_user.xml
@@ -25,5 +25,9 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:visibility="gone" />
+
+        <include layout="@layout/content_no_tickets"
+            android:id="@+id/noTicketsScreen"
+            android:visibility="gone"/>
     </LinearLayout>
 </android.support.v4.widget.NestedScrollView>

--- a/app/src/main/res/menu/profile.xml
+++ b/app/src/main/res/menu/profile.xml
@@ -25,6 +25,6 @@
             android:icon="@drawable/ic_search_grey_24dp"
             android:title="@string/search"
             app:actionViewClass="android.support.v7.widget.SearchView"
-            app:showAsAction="always" />
+            app:showAsAction="ifRoom|collapseActionView" />
     </group>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,6 +92,8 @@
     <string name="whoops">Whoops!</string>
     <string name="ok">ok</string>
     <string name="view_ticket">View</string>
+    <string name="no_ticket_message">Not seeing your tickets? Learn more about how to find them.</string>
+    <string name="find_my_tickets">Find my tickets</string>
 
     <!--payment details-->
     <string name="card_number">Card Number</string>
@@ -136,5 +138,11 @@
     <!--settings profile dialog-->
     <string name="message">Are you sure you want to log out?</string>
     <string name="cancel">Cancel</string>
+    <string name="no_tickets">No Tickets</string>
+
+    <!--liked events tab -->
+    <string name="nothing_planned_yet">Nothing Planned ..yet?</string>
+    <string name="find_something_to_do">Find something to do!!</string>
+
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.71'
+    ext.kotlin_version = '1.3.0'
 
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-alpha16'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Improve logic of code to handle no connectivity better on refresh by showing the no internet card instantaneously, hide the refreshing layout, and not initiating non-required calls to network methods.

Fixes #691 
Changes: 

The code logic has been modified to handle the issue mentioned.

Screenshots for the change:
Before:
Refreshing the event list (one fully loaded) under no internet:
(This state remains for a long time as the connection methods are called, and finally terminates after 8-10 secs with a toast)

![screenshot_1542134680](https://user-images.githubusercontent.com/31897110/48436691-5f57a680-e7a5-11e8-9dff-f1c14010b63e.png)

After making the changes, and refreshing the events list (once fully loaded) under no internet:

![screenshot_1542135460](https://user-images.githubusercontent.com/31897110/48436650-3f27e780-e7a5-11e8-9bf3-6c21124520c4.png)
