### PR TITLE
fix: Display correct toolbar title on going back from Settings fragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/settings/SettingsFragment.kt
@@ -87,7 +87,6 @@ class SettingsFragment : PreferenceFragmentCompat(), PreferenceChangeListener {
     override fun onDestroyView() {
         val activity = activity as? AppCompatActivity
         activity?.supportActionBar?.setDisplayHomeAsUpEnabled(false)
-        activity?.supportActionBar?.title = "Profile"
         setHasOptionsMenu(false)
         super.onDestroyView()
     }


### PR DESCRIPTION
Fixes #714 

Changes: 
Now the toolbar title will be 'Events' instead of the wrongly displayed title 'Profile'.

GIF for the change:
![ezgif com-video-to-gif 9](https://user-images.githubusercontent.com/35566748/49684492-9dbd5880-fafa-11e8-9b3f-b4e064e78599.gif)
