### PR TITLE
fix: Remove continuous toggling between fragments

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
@@ -139,6 +139,10 @@ class MainActivity : AppCompatActivity() {
                     loadFragment(EventsFragment())
                     navigation.selectedItemId = navigation_events
                 }
+                is EventsFragment -> {
+                    android.os.Process.killProcess(android.os.Process.myPid());
+                    System.exit(1);
+                }
                 else -> super.onBackPressed()
             }
     }


### PR DESCRIPTION
Fixes #716 

Changes: 
Instead of toggling between fragments, the app will now close when back is pressed on the Events fragment.

GIF for the change:

![ezgif com-video-to-gif 12](https://user-images.githubusercontent.com/35566748/49685739-0282ae00-fb0f-11e8-9717-1d186214a0de.gif)


