### PR TITLE
docs: Add CONTRIBUTING.md file link it to README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+## How to Contribute
+
+### Raising an issue:
+ This is an Open Source project and we would be happy to see contributors who report bugs and file feature requests submitting pull requests as well.
+ This project adheres to the Contributor Covenant code of conduct.
+ By participating, you are expected to uphold this code style.
+ Please report issues here [Issues - fossasia/open-event-android](https://github.com/fossasia/open-event-android/issues)
+
+### Branch Policy
+
+#### Sending pull requests:
+
+Go to the repository on github at https://github.com/fossasia/open-event-android.
+
+Click the “Fork” button at the top right.
+
+You’ll now have your own copy of the original FOSSASIA repository in your github account.
+
+Open a terminal/shell.
+
+Type
+
+`$ git clone https://github.com/username/open-event-android`
+
+where 'username' is your username.
+
+You’ll now have a local copy of your version of the original FOSSASIA repository.
+
+#### Change into that project directory (open-event-android):
+
+`$ cd open-event-android`
+
+#### Add a connection to the original owner’s repository.
+
+`$ git remote add upstream https://github.com/fossasia/open-event-android`
+
+#### To check this remote add set up:
+
+`$ git remote -v`
+
+#### Make changes to files.
+
+`git add` and `git commit` those changes
+
+`git push` them back to github. These will go to your version of the repository.
+
+#### Now Create a PR (Pull Request)
+Go to your version of the repository on github.
+
+Click the “New pull request” button at the top.
+
+Note that FOSSASIA’s repository will be on the left and your repository will be on the right.
+
+Click the green button “Create pull request”. Give a succinct and informative title, in the comment field give a short explanation of the changes and click the green button “Create pull request” again.
+
+#### Pulling others’ changes
+Before you make further changes to the repository, you should check that your version is up to date relative to FOSSASIA’s version.
+
+Go into the directory for the project and type:
+
+`$ git checkout development`
+`$ git pull upstream development --rebase`
+
+This will pull down and merge all of the changes that have been made in the original FOSSASIA repository.
+
+Now push them back to your github repository.
+
+`$ git push origin development`

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Lastly, each class should only perform one task, do it well, and be unit tested 
 
 ### For first time Contributors
 
-First time contributors can read ContributionHelp.md file for help regarding creating issues and sending pull requests.
+First time contributors can read [CONTRIBUTING.md](/CONTRIBUTING.md) file for help regarding creating issues and sending pull requests.
 
 ### Branch Policy
 


### PR DESCRIPTION
Fixes #729 

Changes: There is a section for First Time Contributors to read the ContributionHelp.md but there is no such file. I have added the file and created the required link in README.md

Screenshots for the change:

README.md: Before, without link

![original contribution readme](https://user-images.githubusercontent.com/22665789/49785786-ab1b5280-fd47-11e8-93f5-3e308573dcce.png)

README.md: After, with link

![new readme](https://user-images.githubusercontent.com/22665789/49785815-bbcbc880-fd47-11e8-9e1d-671232679a57.png)


ContributionHelp.md: New file

![contributionhelp](https://user-images.githubusercontent.com/22665789/49785822-c38b6d00-fd47-11e8-9202-bfb84399d807.png)
