### PR TITLE
fix: the the back-button functionality in Ticket-Fragment.

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -204,7 +204,6 @@ class EventDetailsFragment : Fragment() {
         super.onDestroyView()
     }
 
-
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             android.R.id.home -> {

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -284,7 +284,6 @@ class EventDetailsFragment : Fragment() {
         menuActionBar = menu
     }
 
-
     private fun loadTicketFragment() {
         // Initialise Ticket Fragment
         val ticketFragment = TicketsFragment()

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -248,7 +248,7 @@ class EventDetailsFragment : Fragment() {
         }
     }
 
-    override fun onPrepareOptionsMenu(menu: Menu?) 
+    override fun onPrepareOptionsMenu(menu: Menu?) {
         menu?.setGroupVisible(R.id.search_menu, false)
         menu?.setGroupVisible(R.id.event_menu, true)
         super.onPrepareOptionsMenu(menu)

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -248,10 +248,7 @@ class EventDetailsFragment : Fragment() {
         }
     }
 
-    override fun onPrepareOptionsMenu(menu: Menu?) {
-        val activity = activity as? MainActivity
-        activity?.supportActionBar?.setDisplayHomeAsUpEnabled(true)
-        activity?.supportActionBar?.title = ""
+    override fun onPrepareOptionsMenu(menu: Menu?) 
         menu?.setGroupVisible(R.id.search_menu, false)
         menu?.setGroupVisible(R.id.event_menu, true)
         super.onPrepareOptionsMenu(menu)

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -20,6 +20,7 @@ import org.fossasia.openevent.general.utils.nullToEmpty
 import org.koin.android.architecture.ext.viewModel
 import timber.log.Timber
 import android.os.Build
+import android.support.v4.app.ActivityCompat
 import org.fossasia.openevent.general.event.topic.SimilarEventsFragment
 import kotlinx.android.synthetic.main.fragment_event.view.*
 import android.support.v4.content.ContextCompat
@@ -203,6 +204,7 @@ class EventDetailsFragment : Fragment() {
         super.onDestroyView()
     }
 
+
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             android.R.id.home -> {
@@ -248,6 +250,9 @@ class EventDetailsFragment : Fragment() {
     }
 
     override fun onPrepareOptionsMenu(menu: Menu?) {
+        val activity = activity as? MainActivity
+        activity?.supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        activity?.supportActionBar?.title = ""
         menu?.setGroupVisible(R.id.search_menu, false)
         menu?.setGroupVisible(R.id.event_menu, true)
         super.onPrepareOptionsMenu(menu)
@@ -280,6 +285,7 @@ class EventDetailsFragment : Fragment() {
         menuActionBar = menu
     }
 
+
     private fun loadTicketFragment() {
         // Initialise Ticket Fragment
         val ticketFragment = TicketsFragment()
@@ -287,7 +293,7 @@ class EventDetailsFragment : Fragment() {
         bundle.putLong("EVENT_ID", eventId)
         bundle.putString(CURRENCY, currency)
         ticketFragment.arguments = bundle
-        activity?.supportFragmentManager?.beginTransaction()?.replace(R.id.rootLayout, ticketFragment)?.addToBackStack(null)?.commit()
+        activity?.supportFragmentManager?.beginTransaction()?.replace(R.id.coordinatorLayout, ticketFragment)?.addToBackStack(null)?.commit()
     }
 
     private fun loadSocialLinksFragment() {

--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
@@ -7,6 +7,7 @@ import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.DividerItemDecoration
 import android.support.v7.widget.LinearLayoutManager
 import android.view.LayoutInflater
+import android.view.Menu
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
@@ -47,7 +48,7 @@ class FavoriteFragment : Fragment() {
                 val bundle = Bundle()
                 bundle.putLong(EVENT_ID, eventID)
                 fragment.arguments = bundle
-                activity?.supportFragmentManager?.beginTransaction()?.add(R.id.rootLayout, fragment)?.addToBackStack(null)?.commit()
+                activity?.supportFragmentManager?.beginTransaction()?.replace(R.id.rootLayout, fragment)?.addToBackStack(null)?.commit()
             }
         }
         val favouriteFabClickListener = object : FavoriteFabListener {
@@ -91,4 +92,8 @@ class FavoriteFragment : Fragment() {
         rootView.favoriteProgressBar.isIndeterminate = show
         rootView.favoriteProgressBar.visibility = if (show) View.VISIBLE else View.GONE
     }
+
+
+
+
 }

--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
@@ -92,8 +92,4 @@ class FavoriteFragment : Fragment() {
         rootView.favoriteProgressBar.isIndeterminate = show
         rootView.favoriteProgressBar.visibility = if (show) View.VISIBLE else View.GONE
     }
-
-
-
-
 }

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
@@ -3,7 +3,6 @@ package org.fossasia.openevent.general.ticket
 import android.app.AlertDialog
 import android.arch.lifecycle.Observer
 import android.os.Bundle
-import android.support.v4.app.ActivityCompat.invalidateOptionsMenu
 import android.support.v4.app.Fragment
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.LinearLayoutManager

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
@@ -3,6 +3,7 @@ package org.fossasia.openevent.general.ticket
 import android.app.AlertDialog
 import android.arch.lifecycle.Observer
 import android.os.Bundle
+import android.support.v4.app.ActivityCompat.invalidateOptionsMenu
 import android.support.v4.app.Fragment
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.LinearLayoutManager
@@ -144,7 +145,9 @@ class TicketsFragment : Fragment() {
     override fun onDestroyView() {
         val activity = activity as? MainActivity
         activity?.supportActionBar?.setDisplayHomeAsUpEnabled(false)
+        invalidateOptionsMenu(activity)
         super.onDestroyView()
+
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
@@ -145,9 +145,7 @@ class TicketsFragment : Fragment() {
     override fun onDestroyView() {
         val activity = activity as? MainActivity
         activity?.supportActionBar?.setDisplayHomeAsUpEnabled(false)
-        invalidateOptionsMenu(activity)
         super.onDestroyView()
-
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/res/layout/fragment_event.xml
+++ b/app/src/main/res/layout/fragment_event.xml
@@ -1,48 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinatorLayout"
     android:layout_width="match_parent"
-    android:background="@android:color/white"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@android:color/white">
 
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
         <android.support.v7.widget.CardView
+            android:id="@+id/buttonTickets"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:id="@+id/buttonTickets"
             android:layout_gravity="bottom"
-            app:cardElevation="@dimen/card_tickets_elevation"
+            android:layout_margin="@dimen/layout_margin_large"
             app:cardBackgroundColor="@color/colorAccent"
             app:cardCornerRadius="@dimen/card_tickets_radius"
-            android:layout_margin="@dimen/layout_margin_large">
+            app:cardElevation="@dimen/card_tickets_elevation">
 
             <TextView
-                android:layout_gravity="bottom"
-                android:textAlignment="center"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/card_tickets_text_height"
+                android:layout_gravity="bottom"
                 android:gravity="center"
-                android:textStyle="bold"
-                android:textSize="@dimen/text_size_large"
+                android:text="@string/tickets"
+                android:textAlignment="center"
                 android:textAllCaps="true"
                 android:textColor="@android:color/white"
-                android:text="@string/tickets"/>
+                android:textSize="@dimen/text_size_large"
+                android:textStyle="bold" />
         </android.support.v7.widget.CardView>
 
-        <include layout="@layout/content_event"
+        <include
+            layout="@layout/content_event"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginBottom="@dimen/event_details_divider_margin"/>
+            android:layout_marginBottom="@dimen/event_details_divider_margin" />
 
         <View
             android:layout_width="match_parent"
-            android:layout_marginBottom="@dimen/event_details_divider_margin"
+            android:layout_height="@dimen/event_details_divider"
             android:layout_gravity="bottom"
-            android:background="@color/grey"
-            android:layout_height="@dimen/event_details_divider"/>
+            android:layout_marginBottom="@dimen/event_details_divider_margin"
+            android:background="@color/grey" />
 
     </FrameLayout>
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
Fixes #726 

Changes: the issue arises because eventDetailFragment when the transition to TicketFragment replaces R.id.root fragment which is not present in the back stack(as was replaced previously when transitioning to eventDetailFragment), it has to replace the EventDetailFragment, so I give eventDetailFragment id= R.id.coordinatorLayout and replaces that in fragment transition from eventDetailFragment to TicketFragment
Also 'replace' method is used in place of 'add' in the transition from favoriteFragment to EventDetailFragment so onCreatview of favoriteFragment is called when coming back to favoriteFragment


Screenshots for the change: