### PR TITLE
fix: Handle fragment transaction correctly on rotation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
-            android:windowSoftInputMode="adjustPan">
+            android:windowSoftInputMode="adjustPan"
+            android:configChanges="orientation">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,9 +16,8 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
-            android:windowSoftInputMode="adjustPan"
-            android:configChanges="orientation">
-            <intent-filter>
+            android:windowSoftInputMode="adjustPan">
+        <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,8 +16,7 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
-            android:windowSoftInputMode="adjustPan"
-            android:configChanges="orientation">
+            android:windowSoftInputMode="adjustPan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         <activity
             android:name=".MainActivity"
             android:windowSoftInputMode="adjustPan">
-        <intent-filter>
+            <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
@@ -70,31 +70,30 @@ class MainActivity : AppCompatActivity() {
         supportActionBar?.title = "Events"
 
         val bundle = intent.extras
-        var openEventsFragment = true
 
-        if (bundle != null && bundle.getBoolean(TO_SEARCH)) {
-            loadFragment(supportFragmentManager, SearchFragment(), frameContainer.id)
-            supportActionBar?.title = "Search"
-            navigation.selectedItemId = navigation_search
-            openEventsFragment = false
-        }
-
-        if (bundle != null && bundle.getBoolean(LAUNCH_ATTENDEE)) {
-            val fragment = AttendeeFragment()
-            fragment.arguments = bundle
-            loadFragment(supportFragmentManager, fragment, frameContainer.id)
-            openEventsFragment = false
-        }
-
-        if (bundle != null && (bundle.getBoolean(TICKETS) || bundle.getBoolean(LAUNCH_TICKETS))) {
-            loadFragment(supportFragmentManager, OrdersUnderUserFragment(), frameContainer.id)
-            supportActionBar?.title = "Tickets"
-            navigation.selectedItemId = R.id.navigation_tickets
-            openEventsFragment = false
-        }
-
-        if (savedInstanceState == null && openEventsFragment)
+        if (savedInstanceState == null) {
             loadFragment(supportFragmentManager, EventsFragment(), frameContainer.id)
+        }
+
+        else {
+            if (bundle != null && bundle.getBoolean(TO_SEARCH)) {
+                loadFragment(supportFragmentManager, SearchFragment(), frameContainer.id)
+                supportActionBar?.title = "Search"
+                navigation.selectedItemId = navigation_search
+            }
+
+            if (bundle != null && bundle.getBoolean(LAUNCH_ATTENDEE)) {
+                val fragment = AttendeeFragment()
+                fragment.arguments = bundle
+                loadFragment(supportFragmentManager, fragment, frameContainer.id)
+            }
+
+            if (bundle != null && (bundle.getBoolean(TICKETS) || bundle.getBoolean(LAUNCH_TICKETS))) {
+                loadFragment(supportFragmentManager, OrdersUnderUserFragment(), frameContainer.id)
+                supportActionBar?.title = "Tickets"
+                navigation.selectedItemId = R.id.navigation_tickets
+            }
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {


### PR DESCRIPTION
Fixes #738 Rotating screen anywhere opens Tickets fragment 

**Changes:**
 
Now the fragment would not change to Tickets fragment when the screen is rotated.

**GIF for the change:**

![ezgif com-video-to-gif 5](https://user-images.githubusercontent.com/35566748/50051342-1b561980-0136-11e9-94ed-2daa5654a211.gif)
