### PR TITLE
fix: Display correct toolbar title on coming back to Likes fragment from EventDetailsFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -198,7 +198,13 @@ class EventDetailsFragment : Fragment() {
     override fun onDestroyView() {
         val activity = activity as? MainActivity
         activity?.supportActionBar?.setDisplayHomeAsUpEnabled(false)
-        activity?.supportActionBar?.title = resources.getString(R.string.events)
+
+        val currentFragment = fragmentManager?.findFragmentById(R.id.frameContainer)
+        if(currentFragment == EventsFragment())
+            activity?.supportActionBar?.title = resources.getString(R.string.events)
+        else
+            activity?.supportActionBar?.title = resources.getString(R.string.likes)
+
         setHasOptionsMenu(false)
         super.onDestroyView()
     }


### PR DESCRIPTION
Fixes #740 

**Changes:** 

Now, after coming back from EventDetailsFragment to Likes fragment, the toolbar title displayed is 'Likes'.

**GIF for the change:**

![ezgif com-video-to-gif 7](https://user-images.githubusercontent.com/35566748/50054971-8c192800-016e-11e9-8305-9c6ba3cccea8.gif)