### PR TITLE
fix: Change instance names of ViewModel for Signup & Login fragments

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
@@ -24,7 +24,7 @@ import org.koin.android.architecture.ext.viewModel
 const val LAUNCH_ATTENDEE: String = "LAUNCH_ATTENDEE"
 class LoginFragment : Fragment() {
 
-    private val loginActivityViewModel by viewModel<LoginFragmentViewModel>()
+    private val loginFragmentViewModel by viewModel<LoginFragmentViewModel>()
     private lateinit var rootView: View
     private var bundle: Bundle? = null
     private var ticketIdAndQty: List<Pair<Int, Int>>? = null
@@ -47,32 +47,32 @@ class LoginFragment : Fragment() {
     ): View? {
         rootView = inflater.inflate(R.layout.fragment_login, container, false)
 
-        if (loginActivityViewModel.isLoggedIn())
+        if (loginFragmentViewModel.isLoggedIn())
             redirectToMain(bundle)
 
         rootView.loginButton.setOnClickListener {
-            loginActivityViewModel.login(email.text.toString(), password.text.toString())
+            loginFragmentViewModel.login(email.text.toString(), password.text.toString())
             hideSoftKeyboard(context, rootView)
         }
 
-        loginActivityViewModel.progress.observe(this, Observer {
+        loginFragmentViewModel.progress.observe(this, Observer {
             it?.let {
                 Utils.showProgressBar(rootView.progressBar, it)
                 loginButton.isEnabled = !it
             }
         })
 
-        loginActivityViewModel.showNoInternetDialog.observe(this, Observer {
+        loginFragmentViewModel.showNoInternetDialog.observe(this, Observer {
             Utils.showNoInternetDialog(context)
         })
 
-        loginActivityViewModel.error.observe(this, Observer {
+        loginFragmentViewModel.error.observe(this, Observer {
             Toast.makeText(context, it, Toast.LENGTH_LONG).show()
         })
 
-        loginActivityViewModel.loggedIn.observe(this, Observer {
+        loginFragmentViewModel.loggedIn.observe(this, Observer {
             Toast.makeText(context, getString(R.string.welcome_back) , Toast.LENGTH_LONG).show()
-            loginActivityViewModel.fetchProfile()
+            loginFragmentViewModel.fetchProfile()
         })
 
         rootView.email.addTextChangedListener(object : TextWatcher {
@@ -81,16 +81,16 @@ class LoginFragment : Fragment() {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
 
             override fun onTextChanged(email: CharSequence, start: Int, before: Int, count: Int) {
-                loginActivityViewModel.checkEmail(email.toString())
+                loginFragmentViewModel.checkEmail(email.toString())
             }
         })
 
-        loginActivityViewModel.requestTokenSuccess.observe(this, Observer {
+        loginFragmentViewModel.requestTokenSuccess.observe(this, Observer {
             rootView.sentEmailLayout.visibility = View.VISIBLE
             rootView.loginLayout.visibility = View.GONE
         })
 
-        loginActivityViewModel.isCorrectEmail.observe(this, Observer {
+        loginFragmentViewModel.isCorrectEmail.observe(this, Observer {
             it?.let {
                 onEmailEntered(it)
             }
@@ -103,10 +103,10 @@ class LoginFragment : Fragment() {
 
         rootView.forgotPassword.setOnClickListener {
             hideSoftKeyboard(context, rootView)
-            loginActivityViewModel.sendResetPasswordEmail(email.text.toString())
+            loginFragmentViewModel.sendResetPasswordEmail(email.text.toString())
         }
 
-        loginActivityViewModel.user.observe(this, Observer {
+        loginFragmentViewModel.user.observe(this, Observer {
             redirectToMain(bundle)
         })
 

--- a/app/src/main/java/org/fossasia/openevent/general/auth/SignUpFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/SignUpFragment.kt
@@ -1,9 +1,9 @@
 package org.fossasia.openevent.general.auth
 
-import android.support.v4.app.Fragment
 import android.arch.lifecycle.Observer
 import android.content.Intent
 import android.os.Bundle
+import android.support.v4.app.Fragment
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.LayoutInflater
@@ -19,7 +19,7 @@ import org.koin.android.architecture.ext.viewModel
 
 class SignUpFragment : Fragment() {
 
-    private val signUpActivityViewModel by viewModel<SignUpFragmentViewModel>()
+    private val signUpFragmentViewModel by viewModel<SignUpFragmentViewModel>()
     private lateinit var rootView: View
 
     override fun onCreateView(
@@ -39,30 +39,30 @@ class SignUpFragment : Fragment() {
             signUp.firstName = firstNameText.text.toString()
             signUp.lastName = lastNameText.text.toString()
             confirmPassword = confirmPasswords.text.toString()
-            signUpActivityViewModel.signUp(signUp, confirmPassword)
+            signUpFragmentViewModel.signUp(signUp, confirmPassword)
         }
 
-        signUpActivityViewModel.progress.observe(this, Observer {
+        signUpFragmentViewModel.progress.observe(this, Observer {
             it?.let {
                 Utils.showProgressBar(rootView.progressBarSignUp, it)
                 signUpButton.isEnabled = !it
             }
         })
 
-        signUpActivityViewModel.showNoInternetDialog.observe(this, Observer {
+        signUpFragmentViewModel.showNoInternetDialog.observe(this, Observer {
             Utils.showNoInternetDialog(context)
         })
 
-        signUpActivityViewModel.error.observe(this, Observer {
+        signUpFragmentViewModel.error.observe(this, Observer {
             Toast.makeText(context, it, Toast.LENGTH_LONG).show()
         })
 
-        signUpActivityViewModel.signedUp.observe(this, Observer {
+        signUpFragmentViewModel.signedUp.observe(this, Observer {
             Toast.makeText(context, "Sign Up Success!", Toast.LENGTH_LONG).show()
-            signUpActivityViewModel.login(signUp)
+            signUpFragmentViewModel.login(signUp)
         })
 
-        signUpActivityViewModel.loggedIn.observe(this, Observer {
+        signUpFragmentViewModel.loggedIn.observe(this, Observer {
             Toast.makeText(context, "Logged in Automatically!", Toast.LENGTH_LONG).show()
             redirectToMain()
         })


### PR DESCRIPTION

Fixes #752 
Changes: 
Changed names of the instances of the ViewModel classes in SignupFragment and LoginFragment in the auth package along with all the usages of the variable i.e. refactored the name of the variables.

Screenshots for the change:
![annotation 2018-12-21 231030](https://user-images.githubusercontent.com/22665789/50355757-bb1c0900-0575-11e9-9645-1d9c39f4c38c.jpg)
![annotation 2018-12-21 231111](https://user-images.githubusercontent.com/22665789/50355760-c0795380-0575-11e9-8497-475baf870b7e.jpg)
