### PR TITLE
fix: Refactor ViewModels and their instances across the project

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
@@ -55,7 +55,7 @@ private const val TERMS_OF_SERVICE = "https://eventyay.com/terms/"
 class AttendeeFragment : Fragment() {
 
     private lateinit var rootView: View
-    private val attendeeFragmentViewModel by viewModel<AttendeeViewModel>()
+    private val attendeeViewModel by viewModel<AttendeeViewModel>()
     private val ticketsRecyclerAdapter: TicketDetailsRecyclerAdapter = TicketDetailsRecyclerAdapter()
     private val attendeeRecyclerAdapter: AttendeeRecyclerAdapter = AttendeeRecyclerAdapter()
     private lateinit var linearLayoutManager: LinearLayoutManager
@@ -152,13 +152,13 @@ class AttendeeFragment : Fragment() {
         linearLayoutManager.orientation = LinearLayoutManager.VERTICAL
         rootView.ticketsRecycler.layoutManager = linearLayoutManager
 
-        attendeeFragmentViewModel.ticketDetails(ticketIdAndQty)
+        attendeeViewModel.ticketDetails(ticketIdAndQty)
 
-        attendeeFragmentViewModel.updatePaymentSelectorVisibility(ticketIdAndQty)
+        attendeeViewModel.updatePaymentSelectorVisibility(ticketIdAndQty)
         val paymentOptions = ArrayList<String>()
         paymentOptions.add("PayPal")
         paymentOptions.add("Stripe")
-        attendeeFragmentViewModel.paymentSelectorVisibility.observe(this, Observer {
+        attendeeViewModel.paymentSelectorVisibility.observe(this, Observer {
             if (it != null && it) {
                 rootView.paymentSelector.visibility = View.VISIBLE
             } else {
@@ -179,43 +179,43 @@ class AttendeeFragment : Fragment() {
             }
         }
 
-        attendeeFragmentViewModel.initializeSpinner()
+        attendeeViewModel.initializeSpinner()
 
-        rootView.month.adapter = ArrayAdapter(context, android.R.layout.simple_spinner_dropdown_item, attendeeFragmentViewModel.month)
+        rootView.month.adapter = ArrayAdapter(context, android.R.layout.simple_spinner_dropdown_item, attendeeViewModel.month)
         rootView.month.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onNothingSelected(p0: AdapterView<*>?) {
             }
 
             override fun onItemSelected(p0: AdapterView<*>?, p1: View?, p2: Int, p3: Long) {
                 expiryMonth = p2
-                rootView.monthText.text = attendeeFragmentViewModel.month[p2]
+                rootView.monthText.text = attendeeViewModel.month[p2]
             }
         }
 
-        rootView.year.adapter = ArrayAdapter(context, android.R.layout.simple_spinner_dropdown_item, attendeeFragmentViewModel.year)
+        rootView.year.adapter = ArrayAdapter(context, android.R.layout.simple_spinner_dropdown_item, attendeeViewModel.year)
         rootView.year.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onNothingSelected(p0: AdapterView<*>?) {
             }
 
             override fun onItemSelected(p0: AdapterView<*>?, p1: View?, p2: Int, p3: Long) {
-                expiryYear = attendeeFragmentViewModel.year[p2]
+                expiryYear = attendeeViewModel.year[p2]
                 if (expiryYear == "Year")
                     expiryYear = "2017" // invalid year, if the user hasn't selected the year
-                rootView.yearText.text = attendeeFragmentViewModel.year[p2]
+                rootView.yearText.text = attendeeViewModel.year[p2]
             }
         }
 
-        rootView.cardSelector.adapter = ArrayAdapter(context, android.R.layout.simple_spinner_dropdown_item, attendeeFragmentViewModel.cardType)
+        rootView.cardSelector.adapter = ArrayAdapter(context, android.R.layout.simple_spinner_dropdown_item, attendeeViewModel.cardType)
         rootView.cardSelector.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onNothingSelected(p0: AdapterView<*>?) {
             }
 
             override fun onItemSelected(p0: AdapterView<*>?, p1: View?, p2: Int, p3: Long) {
-                cardBrand = attendeeFragmentViewModel.cardType[p2]
+                cardBrand = attendeeViewModel.cardType[p2]
                 rootView.selectCard.text = cardBrand
             }
         }
-        attendeeFragmentViewModel.qtyList.observe(this, Observer {
+        attendeeViewModel.qtyList.observe(this, Observer {
             it?.let { it1 -> ticketsRecyclerAdapter.setQty(it1) }
         })
 
@@ -229,30 +229,30 @@ class AttendeeFragment : Fragment() {
             }
         }
 
-        attendeeFragmentViewModel.loadEvent(id)
+        attendeeViewModel.loadEvent(id)
 
-        if (attendeeFragmentViewModel.isLoggedIn()) {
+        if (attendeeViewModel.isLoggedIn()) {
 
-            attendeeFragmentViewModel.loadUser(attendeeFragmentViewModel.getId())
-            attendeeFragmentViewModel.loadEvent(id)
+            attendeeViewModel.loadUser(attendeeViewModel.getId())
+            attendeeViewModel.loadEvent(id)
 
-            attendeeFragmentViewModel.message.observe(this, Observer {
+            attendeeViewModel.message.observe(this, Observer {
                 Toast.makeText(context, it, Toast.LENGTH_LONG).show()
             })
 
-            attendeeFragmentViewModel.progress.observe(this, Observer {
+            attendeeViewModel.progress.observe(this, Observer {
                 it?.let { Utils.showProgressBar(rootView.progressBarAttendee, it) }
             })
 
-            attendeeFragmentViewModel.event.observe(this, Observer {
+            attendeeViewModel.event.observe(this, Observer {
                 it?.let { loadEventDetails(it) }
-                attendeeFragmentViewModel.totalAmount.observe(this, Observer {
+                attendeeViewModel.totalAmount.observe(this, Observer {
                     rootView.amount.text = "Total: $paymentCurrency$it"
                 })
             })
 
             attendeeRecyclerAdapter.eventId = eventId
-            attendeeFragmentViewModel.tickets.observe(this, Observer {
+            attendeeViewModel.tickets.observe(this, Observer {
                 it?.let {
                     ticketsRecyclerAdapter.addAll(it)
                     ticketsRecyclerAdapter.notifyDataSetChanged()
@@ -261,28 +261,28 @@ class AttendeeFragment : Fragment() {
                             val pos = ticketIdAndQty?.map { it.first }?.indexOf(it.id)
                             val iterations = pos?.let { it1 -> ticketIdAndQty?.get(it1)?.second } ?: 0
                             for (i in 0 until iterations)
-                                attendeeRecyclerAdapter.add(Attendee(attendeeFragmentViewModel.getId()), it)
+                                attendeeRecyclerAdapter.add(Attendee(attendeeViewModel.getId()), it)
                             attendeeRecyclerAdapter.notifyDataSetChanged()
                         }
                 }
             })
 
-            attendeeFragmentViewModel.totalQty.observe(this, Observer {
+            attendeeViewModel.totalQty.observe(this, Observer {
                 rootView.qty.text = " — $it items"
             })
 
-            attendeeFragmentViewModel.countryVisibility.observe(this, Observer {
+            attendeeViewModel.countryVisibility.observe(this, Observer {
                 if (it != null && singleTicket) {
                     rootView.countryArea.visibility = if (it) View.VISIBLE else View.GONE
                 }
             })
 
-            attendeeFragmentViewModel.paymentCompleted.observe(this, Observer {
+            attendeeViewModel.paymentCompleted.observe(this, Observer {
                 if (it != null && it)
                     openOrderCompletedFragment()
             })
 
-            attendeeFragmentViewModel.attendee.observe(this, Observer {
+            attendeeViewModel.attendee.observe(this, Observer {
                 it?.let {
                     helloUser.text = "Hello ${it.firstName.nullToEmpty()}"
                     firstName.text = Editable.Factory.getInstance().newEditable(it.firstName.nullToEmpty())
@@ -292,13 +292,13 @@ class AttendeeFragment : Fragment() {
             })
 
             rootView.signOut.setOnClickListener {
-                attendeeFragmentViewModel.logout()
+                attendeeViewModel.logout()
                 redirectToLogin()
             }
 
-            attendeeFragmentViewModel.getCustomFormsForAttendees(eventId.id)
+            attendeeViewModel.getCustomFormsForAttendees(eventId.id)
 
-            attendeeFragmentViewModel.forms.observe(this, Observer {
+            attendeeViewModel.forms.observe(this, Observer {
                 it?.let {
                     if (singleTicket)
                         fillInformationSection(it)
@@ -320,7 +320,7 @@ class AttendeeFragment : Fragment() {
                 if (singleTicket) {
                     val pos = ticketIdAndQty?.map { it.second }?.indexOf(1)
                     val ticket = pos?.let { it1 -> ticketIdAndQty?.get(it1)?.first?.toLong() } ?: -1
-                    val attendee = Attendee(id = attendeeFragmentViewModel.getId(),
+                    val attendee = Attendee(id = attendeeViewModel.getId(),
                             firstname = firstName.text.toString(),
                             lastname = lastName.text.toString(),
                             city = getAttendeeField("city"),
@@ -334,14 +334,14 @@ class AttendeeFragment : Fragment() {
                     attendees.addAll(attendeeRecyclerAdapter.attendeeList)
                 }
                 val country = if (country.text.isEmpty()) country.text.toString() else null
-                attendeeFragmentViewModel.createAttendees(attendees, country, selectedPaymentOption)
+                attendeeViewModel.createAttendees(attendees, country, selectedPaymentOption)
             }
         } else {
             redirectToLogin()
             Toast.makeText(context, "You need to log in first!", Toast.LENGTH_LONG).show()
         }
 
-        attendeeFragmentViewModel.ticketSoldOut.observe(this, Observer
+        attendeeViewModel.ticketSoldOut.observe(this, Observer
         {
             it?.let {
                 showTicketSoldOutDialog(it)
@@ -391,8 +391,8 @@ class AttendeeFragment : Fragment() {
                         object : TokenCallback {
                             override fun onSuccess(token: Token) {
                                 // Send this token to server
-                                val charge = Charge(attendeeFragmentViewModel.getId().toInt(), token.id, null)
-                                attendeeFragmentViewModel.completeOrder(charge)
+                                val charge = Charge(attendeeViewModel.getId().toInt(), token.id, null)
+                                attendeeViewModel.completeOrder(charge)
                             }
 
                             override fun onError(error: Exception) {
@@ -420,7 +420,7 @@ class AttendeeFragment : Fragment() {
     }
 
     private fun openOrderCompletedFragment() {
-        attendeeFragmentViewModel.paymentCompleted.value = false
+        attendeeViewModel.paymentCompleted.value = false
         // Initialise Order Completed Fragment
         val orderCompletedFragment = OrderCompletedFragment()
         val bundle = Bundle()

--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
@@ -32,7 +32,7 @@ import java.io.InputStream
 
 class EditProfileFragment : Fragment() {
 
-    private val profileFragmentViewModel by viewModel<ProfileFragmentViewModel>()
+    private val profileViewModel by viewModel<ProfileViewModel>()
     private val editProfileViewModel by viewModel<EditProfileViewModel>()
     private lateinit var rootView: View
     private var permissionGranted = false
@@ -48,7 +48,7 @@ class EditProfileFragment : Fragment() {
     ): View? {
         rootView = inflater.inflate(R.layout.fragment_edit_profile, container, false)
 
-        profileFragmentViewModel.user.observe(this, Observer {
+        profileViewModel.user.observe(this, Observer {
             it?.let {
                 val userFirstName = it.firstName.nullToEmpty()
                 val userLastName = it.lastName.nullToEmpty()
@@ -69,7 +69,7 @@ class EditProfileFragment : Fragment() {
                 }
             }
         })
-        profileFragmentViewModel.fetchProfile()
+        profileViewModel.fetchProfile()
 
         editProfileViewModel.progress.observe(this, Observer {
             it?.let {

--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
@@ -24,7 +24,7 @@ import org.koin.android.architecture.ext.viewModel
 const val LAUNCH_ATTENDEE: String = "LAUNCH_ATTENDEE"
 class LoginFragment : Fragment() {
 
-    private val loginFragmentViewModel by viewModel<LoginFragmentViewModel>()
+    private val loginViewModel by viewModel<LoginViewModel>()
     private lateinit var rootView: View
     private var bundle: Bundle? = null
     private var ticketIdAndQty: List<Pair<Int, Int>>? = null
@@ -47,32 +47,32 @@ class LoginFragment : Fragment() {
     ): View? {
         rootView = inflater.inflate(R.layout.fragment_login, container, false)
 
-        if (loginFragmentViewModel.isLoggedIn())
+        if (loginViewModel.isLoggedIn())
             redirectToMain(bundle)
 
         rootView.loginButton.setOnClickListener {
-            loginFragmentViewModel.login(email.text.toString(), password.text.toString())
+            loginViewModel.login(email.text.toString(), password.text.toString())
             hideSoftKeyboard(context, rootView)
         }
 
-        loginFragmentViewModel.progress.observe(this, Observer {
+        loginViewModel.progress.observe(this, Observer {
             it?.let {
                 Utils.showProgressBar(rootView.progressBar, it)
                 loginButton.isEnabled = !it
             }
         })
 
-        loginFragmentViewModel.showNoInternetDialog.observe(this, Observer {
+        loginViewModel.showNoInternetDialog.observe(this, Observer {
             Utils.showNoInternetDialog(context)
         })
 
-        loginFragmentViewModel.error.observe(this, Observer {
+        loginViewModel.error.observe(this, Observer {
             Toast.makeText(context, it, Toast.LENGTH_LONG).show()
         })
 
-        loginFragmentViewModel.loggedIn.observe(this, Observer {
+        loginViewModel.loggedIn.observe(this, Observer {
             Toast.makeText(context, getString(R.string.welcome_back) , Toast.LENGTH_LONG).show()
-            loginFragmentViewModel.fetchProfile()
+            loginViewModel.fetchProfile()
         })
 
         rootView.email.addTextChangedListener(object : TextWatcher {
@@ -81,16 +81,16 @@ class LoginFragment : Fragment() {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
 
             override fun onTextChanged(email: CharSequence, start: Int, before: Int, count: Int) {
-                loginFragmentViewModel.checkEmail(email.toString())
+                loginViewModel.checkEmail(email.toString())
             }
         })
 
-        loginFragmentViewModel.requestTokenSuccess.observe(this, Observer {
+        loginViewModel.requestTokenSuccess.observe(this, Observer {
             rootView.sentEmailLayout.visibility = View.VISIBLE
             rootView.loginLayout.visibility = View.GONE
         })
 
-        loginFragmentViewModel.isCorrectEmail.observe(this, Observer {
+        loginViewModel.isCorrectEmail.observe(this, Observer {
             it?.let {
                 onEmailEntered(it)
             }
@@ -103,10 +103,10 @@ class LoginFragment : Fragment() {
 
         rootView.forgotPassword.setOnClickListener {
             hideSoftKeyboard(context, rootView)
-            loginFragmentViewModel.sendResetPasswordEmail(email.text.toString())
+            loginViewModel.sendResetPasswordEmail(email.text.toString())
         }
 
-        loginFragmentViewModel.user.observe(this, Observer {
+        loginViewModel.user.observe(this, Observer {
             redirectToMain(bundle)
         })
 

--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginViewModel.kt
@@ -10,7 +10,7 @@ import org.fossasia.openevent.general.common.SingleLiveEvent
 import org.fossasia.openevent.general.data.Network
 import timber.log.Timber
 
-class LoginFragmentViewModel(
+class LoginViewModel(
     private val authService: AuthService,
     private val network: Network
 ) : ViewModel() {

--- a/app/src/main/java/org/fossasia/openevent/general/auth/ProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/ProfileFragment.kt
@@ -23,7 +23,7 @@ import org.fossasia.openevent.general.utils.nullToEmpty
 import org.koin.android.architecture.ext.viewModel
 
 class ProfileFragment : Fragment() {
-    private val profileFragmentViewModel by viewModel<ProfileFragmentViewModel>()
+    private val profileViewModel by viewModel<ProfileViewModel>()
 
     private lateinit var rootView: View
     private var emailSettings: String? = null
@@ -40,7 +40,7 @@ class ProfileFragment : Fragment() {
 
     override fun onAttach(context: Context?) {
         super.onAttach(context)
-        if (!profileFragmentViewModel.isLoggedIn()) {
+        if (!profileViewModel.isLoggedIn()) {
             Toast.makeText(context, "You need to Login!", Toast.LENGTH_LONG).show()
             redirectToLogin()
         }
@@ -55,15 +55,15 @@ class ProfileFragment : Fragment() {
 
         setHasOptionsMenu(true)
 
-        profileFragmentViewModel.progress.observe(this, Observer {
+        profileViewModel.progress.observe(this, Observer {
             it?.let { Utils.showProgressBar(rootView.progressBar, it) }
         })
 
-        profileFragmentViewModel.error.observe(this, Observer {
+        profileViewModel.error.observe(this, Observer {
             Toast.makeText(context, it, Toast.LENGTH_LONG).show()
         })
 
-        profileFragmentViewModel.user.observe(this, Observer {
+        profileViewModel.user.observe(this, Observer {
             it?.let {
                 rootView.name.text = "${it.firstName.nullToEmpty()} ${it.lastName.nullToEmpty()}"
                 rootView.email.text = it.email
@@ -100,7 +100,7 @@ class ProfileFragment : Fragment() {
                 return true
             }
             R.id.logout -> {
-                profileFragmentViewModel.logout()
+                profileViewModel.logout()
                 activity?.supportFragmentManager?.beginTransaction()?.remove(this)?.commit()
                 redirectToMain()
                 return true
@@ -141,11 +141,11 @@ class ProfileFragment : Fragment() {
     }
 
     private fun fetchProfile() {
-        if (!profileFragmentViewModel.isLoggedIn())
+        if (!profileViewModel.isLoggedIn())
             return
 
         rootView.progressBar.isIndeterminate = true
-        profileFragmentViewModel.fetchProfile()
+        profileViewModel.fetchProfile()
     }
 
     override fun onResume() {

--- a/app/src/main/java/org/fossasia/openevent/general/auth/ProfileViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/ProfileViewModel.kt
@@ -7,7 +7,7 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import timber.log.Timber
 
-class ProfileFragmentViewModel(private val authService: AuthService) : ViewModel() {
+class ProfileViewModel(private val authService: AuthService) : ViewModel() {
 
     private val compositeDisposable = CompositeDisposable()
 

--- a/app/src/main/java/org/fossasia/openevent/general/auth/SignUpFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/SignUpFragment.kt
@@ -19,7 +19,7 @@ import org.koin.android.architecture.ext.viewModel
 
 class SignUpFragment : Fragment() {
 
-    private val signUpFragmentViewModel by viewModel<SignUpFragmentViewModel>()
+    private val signUpViewModel by viewModel<SignUpViewModel>()
     private lateinit var rootView: View
 
     override fun onCreateView(
@@ -39,30 +39,30 @@ class SignUpFragment : Fragment() {
             signUp.firstName = firstNameText.text.toString()
             signUp.lastName = lastNameText.text.toString()
             confirmPassword = confirmPasswords.text.toString()
-            signUpFragmentViewModel.signUp(signUp, confirmPassword)
+            signUpViewModel.signUp(signUp, confirmPassword)
         }
 
-        signUpFragmentViewModel.progress.observe(this, Observer {
+        signUpViewModel.progress.observe(this, Observer {
             it?.let {
                 Utils.showProgressBar(rootView.progressBarSignUp, it)
                 signUpButton.isEnabled = !it
             }
         })
 
-        signUpFragmentViewModel.showNoInternetDialog.observe(this, Observer {
+        signUpViewModel.showNoInternetDialog.observe(this, Observer {
             Utils.showNoInternetDialog(context)
         })
 
-        signUpFragmentViewModel.error.observe(this, Observer {
+        signUpViewModel.error.observe(this, Observer {
             Toast.makeText(context, it, Toast.LENGTH_LONG).show()
         })
 
-        signUpFragmentViewModel.signedUp.observe(this, Observer {
+        signUpViewModel.signedUp.observe(this, Observer {
             Toast.makeText(context, "Sign Up Success!", Toast.LENGTH_LONG).show()
-            signUpFragmentViewModel.login(signUp)
+            signUpViewModel.login(signUp)
         })
 
-        signUpFragmentViewModel.loggedIn.observe(this, Observer {
+        signUpViewModel.loggedIn.observe(this, Observer {
             Toast.makeText(context, "Logged in Automatically!", Toast.LENGTH_LONG).show()
             redirectToMain()
         })

--- a/app/src/main/java/org/fossasia/openevent/general/auth/SignUpViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/SignUpViewModel.kt
@@ -10,7 +10,7 @@ import org.fossasia.openevent.general.data.Network
 import org.fossasia.openevent.general.utils.nullToEmpty
 import timber.log.Timber
 
-class SignUpFragmentViewModel(
+class SignUpViewModel(
     private val authService: AuthService,
     private val network: Network
 ) : ViewModel() {

--- a/app/src/main/java/org/fossasia/openevent/general/di/Modules.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/di/Modules.kt
@@ -27,7 +27,7 @@ import org.fossasia.openevent.general.paypal.PaypalApi
 import org.fossasia.openevent.general.search.SearchLocationViewModel
 import org.fossasia.openevent.general.search.SearchTimeViewModel
 import org.fossasia.openevent.general.search.SearchViewModel
-import org.fossasia.openevent.general.settings.SettingsFragmentViewModel
+import org.fossasia.openevent.general.settings.SettingsViewModel
 import org.fossasia.openevent.general.social.SocialLink
 import org.fossasia.openevent.general.social.SocialLinkApi
 import org.fossasia.openevent.general.social.SocialLinksService
@@ -91,10 +91,10 @@ val apiModule = applicationContext {
 }
 
 val viewModelModule = applicationContext {
-    viewModel { LoginFragmentViewModel(get(), get()) }
+    viewModel { LoginViewModel(get(), get()) }
     viewModel { EventsViewModel(get(), get()) }
-    viewModel { ProfileFragmentViewModel(get()) }
-    viewModel { SignUpFragmentViewModel(get(), get()) }
+    viewModel { ProfileViewModel(get()) }
+    viewModel { SignUpViewModel(get(), get()) }
     viewModel { EventDetailsViewModel(get()) }
     viewModel { SearchViewModel(get(), get(), get()) }
     viewModel { AttendeeViewModel(get(), get(), get(), get(), get(), get()) }
@@ -104,7 +104,7 @@ val viewModelModule = applicationContext {
     viewModel { AboutEventViewModel(get()) }
     viewModel { SocialLinksViewModel(get()) }
     viewModel { FavouriteEventsViewModel(get()) }
-    viewModel { SettingsFragmentViewModel(get()) }
+    viewModel { SettingsViewModel(get()) }
     viewModel { SimilarEventsViewModel(get()) }
     viewModel { OrderCompletedViewModel(get()) }
     viewModel { OrdersUnderUserVM(get(), get(), get()) }

--- a/app/src/main/java/org/fossasia/openevent/general/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/settings/SettingsFragment.kt
@@ -6,23 +6,23 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
-import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat
 import android.support.v7.preference.Preference
-import android.view.*
-import java.util.prefs.PreferenceChangeEvent
-import java.util.prefs.PreferenceChangeListener
-import org.fossasia.openevent.general.R
+import android.view.MenuItem
+import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat
 import org.fossasia.openevent.general.BuildConfig
 import org.fossasia.openevent.general.MainActivity
+import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.utils.Utils
 import org.fossasia.openevent.general.utils.nullToEmpty
 import org.koin.android.architecture.ext.viewModel
+import java.util.prefs.PreferenceChangeEvent
+import java.util.prefs.PreferenceChangeListener
 
 class SettingsFragment : PreferenceFragmentCompat(), PreferenceChangeListener {
     private var email: String? = null
     val EMAIL: String = "EMAIL"
     val FORM_LINK: String = "https://docs.google.com/forms/d/e/1FAIpQLSd7Y1T1xoXeYaAG_b6Tu1YYK-jZssoC5ltmQbkUX0kmDZaKYw/viewform"
-    private val settingsViewModel by viewModel<SettingsFragmentViewModel>()
+    private val settingsViewModel by viewModel<SettingsViewModel>()
 
     override fun preferenceChange(evt: PreferenceChangeEvent?) {
         preferenceChange(evt)

--- a/app/src/main/java/org/fossasia/openevent/general/settings/SettingsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/settings/SettingsViewModel.kt
@@ -7,7 +7,7 @@ import io.reactivex.schedulers.Schedulers
 import org.fossasia.openevent.general.auth.AuthService
 import timber.log.Timber
 
-class SettingsFragmentViewModel(private val authService: AuthService) : ViewModel() {
+class SettingsViewModel(private val authService: AuthService) : ViewModel() {
 
     private val compositeDisposable = CompositeDisposable()
 


### PR DESCRIPTION
Fixes #754 

Changes: The ViewModel classes,their created instances and all their usages have been refactored according to convention by removing the term "Fragment" from them. The ViewModels changed:

attendeeFragmentViewModel -> attendeeViewModel (instances only)
ProfileFragmentViewModel -> ProfileViewModel (class and instances)
LoginFragmentViewModel -> LoginViewModel (class and instances)
ProfileFragmentViewModel -> ProfileViewModel (class and instances)
SignUpFragmentViewModel -> SignUpViewModel (class and instances)
SettingsFragmentViewModel -> SettingsViewModel (class only)
