### PR TITLE
fix: Variable ticketIdAndQty initialized twice

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
@@ -108,7 +108,7 @@ class AttendeeFragment : Fragment() {
         if (bundle != null) {
             id = bundle.getLong(EVENT_ID, -1)
             eventId = EventId(id)
-            val ticketIdAndQty = bundle.getSerializable(TICKET_ID_AND_QTY) as List<Pair<Int, Int>>
+            ticketIdAndQty = bundle.getSerializable(TICKET_ID_AND_QTY) as List<Pair<Int, Int>>
         }
         singleTicket = ticketIdAndQty?.map { it.second }?.sum() == 1
         API_KEY = activity?.packageManager?.getApplicationInfo(activity?.packageName, PackageManager.GET_META_DATA)


### PR DESCRIPTION
Fixes #744

Earlier it is tanking value from 2nd initialization but after chore updates, it acts as variable form first initialization which is always null due to 2nd value is not effective. 