### PR TITLE
fix: Authenticate user by start activity for results in attendee section

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
@@ -6,11 +6,8 @@ import androidx.fragment.app.Fragment
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import kotlinx.android.synthetic.main.activity_main.frameContainer
 import kotlinx.android.synthetic.main.activity_main.navigation
-import kotlinx.android.synthetic.main.activity_main.rootLayout
 import org.fossasia.openevent.general.R.id.navigation_events
 import org.fossasia.openevent.general.R.id.navigation_search
-import org.fossasia.openevent.general.attendees.AttendeeFragment
-import org.fossasia.openevent.general.auth.LAUNCH_ATTENDEE
 import org.fossasia.openevent.general.auth.ProfileFragment
 import org.fossasia.openevent.general.event.EventDetailsFragment
 import org.fossasia.openevent.general.event.EventsFragment
@@ -75,12 +72,6 @@ class MainActivity : AppCompatActivity() {
                 loadFragment(supportFragmentManager, SearchFragment(), frameContainer.id)
                 supportActionBar?.title = "Search"
                 navigation.selectedItemId = navigation_search
-            }
-
-            if (bundle.getBoolean(LAUNCH_ATTENDEE)) {
-                val fragment = AttendeeFragment()
-                fragment.arguments = bundle
-                loadFragment(supportFragmentManager, fragment, rootLayout.id)
             }
 
             if (bundle.getBoolean(TICKETS) || bundle.getBoolean(LAUNCH_TICKETS)) {

--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
@@ -1,5 +1,6 @@
 package org.fossasia.openevent.general.auth
 
+import android.app.Activity.RESULT_OK
 import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
@@ -31,7 +32,6 @@ import org.fossasia.openevent.general.utils.Utils.hideSoftKeyboard
 import org.fossasia.openevent.general.utils.extensions.nonNull
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
-const val LAUNCH_ATTENDEE: String = "LAUNCH_ATTENDEE"
 class LoginFragment : Fragment() {
 
     private val loginViewModel by viewModel<LoginViewModel>()
@@ -137,11 +137,12 @@ class LoginFragment : Fragment() {
         val intent = Intent(activity, MainActivity::class.java)
         if (bundle != null) {
             if (id != -1L && ticketIdAndQty != null) {
-                intent.putExtra(LAUNCH_ATTENDEE, true)
+                activity?.setResult(RESULT_OK, intent)
+            } else {
+                intent.putExtras(bundle)
+                startActivity(intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP))
             }
-            intent.putExtras(bundle)
         }
-        startActivity(intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP))
         activity?.overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_right)
         activity?.finish()
     }


### PR DESCRIPTION
Fixes #770 
Fixes #791 

Authenticate user by startActivityForResult and handle result in the attendee fragment. No need to start new main activity, set the fragment and get bundles.