### PR TITLE
Attendee Details UI Correction in Terms of Services

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
@@ -131,9 +131,9 @@ class AttendeeFragment : Fragment() {
         val privacyText = getString(R.string.privacy_text)
 
         paragraph.append(startText)
-        paragraph.append(termsText)
-        paragraph.append(middleText)
-        paragraph.append(privacyText)
+        paragraph.append(" "+ termsText)
+        paragraph.append(" "+ middleText)
+        paragraph.append(" "+ privacyText)
 
         val termsSpan = object : ClickableSpan() {
             override fun updateDrawState(ds: TextPaint?) {
@@ -161,9 +161,9 @@ class AttendeeFragment : Fragment() {
             }
         }
 
-        paragraph.setSpan(termsSpan, startText.length, startText.length + termsText.length,
+        paragraph.setSpan(termsSpan, startText.length, startText.length + termsText.length + 2,
             Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
-        paragraph.setSpan(privacyPolicySpan, paragraph.length - privacyText.length, paragraph.length - 1,
+        paragraph.setSpan(privacyPolicySpan, paragraph.length - privacyText.length, paragraph.length ,
             Spannable.SPAN_EXCLUSIVE_EXCLUSIVE) // -1 so that we don't include "." in the link
 
         rootView.accept.text = paragraph

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,9 +155,9 @@
     <!--attendee fragment-->
     <string name="attendee_details">Attendee Details</string>
     <string name="start_text">I accept the</string>
-    <string name="terms_text">terms of service</string>
+    <string name="terms_text">Terms of Service</string>
     <string name="middle_text">and have read the</string>
-    <string name="privacy_text">privacy policy</string>
+    <string name="privacy_text">Privacy Policy</string>
     <string name="privacy_policy" translatable="false">https://eventyay.com/privacy-policy/</string>
     <string name="terms_of_service" translatable="false">https://eventyay.com/terms/</string>
     <string name="stripe">Stripe</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,9 +155,9 @@
     <!--attendee fragment-->
     <string name="attendee_details">Attendee Details</string>
     <string name="start_text">I accept the</string>
-    <string name="terms_text">Terms of Service</string>
+    <string name="terms_text">terms of service</string>
     <string name="middle_text">and have read the</string>
-    <string name="privacy_text">Privacy Policy</string>
+    <string name="privacy_text">privacy policy</string>
     <string name="privacy_policy" translatable="false">https://eventyay.com/privacy-policy/</string>
     <string name="terms_of_service" translatable="false">https://eventyay.com/terms/</string>
     <string name="stripe">Stripe</string>


### PR DESCRIPTION
Fixes #808 

Changes: Corrections in the Terms of Service sentence (add space between words, color correction in privacy policy).

Screenshots for the change:

![screenshot_1546432876](https://user-images.githubusercontent.com/16197563/50595872-e1617300-0eaa-11e9-9593-e84c350f66d8.png)
![screenshot_1546440370](https://user-images.githubusercontent.com/16197563/50596761-f390e080-0ead-11e9-9c41-19a838a05ed1.png)
