### PR TITLE
fix: Correction in Attendee Details (Terms of Service)

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
@@ -131,9 +131,9 @@ class AttendeeFragment : Fragment() {
         val privacyText = getString(R.string.privacy_text)
 
         paragraph.append(startText)
-        paragraph.append(termsText)
-        paragraph.append(middleText)
-        paragraph.append(privacyText)
+        paragraph.append(" $termsText")
+        paragraph.append(" $middleText")
+        paragraph.append(" $privacyText")
 
         val termsSpan = object : ClickableSpan() {
             override fun updateDrawState(ds: TextPaint?) {
@@ -161,9 +161,9 @@ class AttendeeFragment : Fragment() {
             }
         }
 
-        paragraph.setSpan(termsSpan, startText.length, startText.length + termsText.length,
+        paragraph.setSpan(termsSpan, startText.length, startText.length + termsText.length + 2,
             Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
-        paragraph.setSpan(privacyPolicySpan, paragraph.length - privacyText.length, paragraph.length - 1,
+        paragraph.setSpan(privacyPolicySpan, paragraph.length - privacyText.length, paragraph.length,
             Spannable.SPAN_EXCLUSIVE_EXCLUSIVE) // -1 so that we don't include "." in the link
 
         rootView.accept.text = paragraph


### PR DESCRIPTION
Fixes #808

Changes: Corrections in the Terms of Service sentence (add space between words, color correction in privacy policy).

Screenshots for the change:
![50602548-47a4c080-0ec0-11e9-8550-678a680443ad](https://user-images.githubusercontent.com/16197563/50664590-42c23880-0fb6-11e9-98b0-a317e39eb514.png)
![50602591-5ab79080-0ec0-11e9-9069-ac805caac6f8](https://user-images.githubusercontent.com/16197563/50664618-5ec5da00-0fb6-11e9-8658-addb8cf4e5da.png)
