### PR TITLE
fix: Reposition sign in canceled Snackbar

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.navigation.ui.NavigationUI.setupWithNavController
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.activity_main.navigation
 import kotlinx.android.synthetic.main.activity_main.navigationAuth
+import kotlinx.android.synthetic.main.activity_main.mainFragmentCoordinatorLayout
 import org.fossasia.openevent.general.order.LAUNCH_TICKETS
 import org.fossasia.openevent.general.order.TICKETS
 import org.fossasia.openevent.general.search.TO_SEARCH
@@ -70,7 +71,7 @@ class MainActivity : AppCompatActivity() {
             R.id.loginFragment,
             R.id.signUpFragment -> {
                 navController.popBackStack(R.id.eventsFragment, false)
-                Snackbar.make(window.decorView, "Sign in canceled!", Snackbar.LENGTH_SHORT).show()
+                Snackbar.make(mainFragmentCoordinatorLayout, "Sign in canceled!", Snackbar.LENGTH_SHORT).show()
             }
             else -> super.onBackPressed()
         }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,16 +9,23 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-        <fragment
-            android:id="@+id/frameContainer"
-            android:name="androidx.navigation.fragment.NavHostFragment"
+        <androidx.coordinatorlayout.widget.CoordinatorLayout
+            android:id="@+id/mainFragmentCoordinatorLayout"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:background="@android:color/white"
-            android:layout_weight="1"
-            app:defaultNavHost="true"
-            app:navGraph="@navigation/navigation_graph"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+            android:layout_weight="1">
+
+            <fragment
+                android:id="@+id/frameContainer"
+                android:name="androidx.navigation.fragment.NavHostFragment"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@android:color/white"
+                app:defaultNavHost="true"
+                app:navGraph="@navigation/navigation_graph"
+                app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+        </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
         <com.google.android.material.bottomnavigation.BottomNavigationView
             android:id="@+id/navigation"


### PR DESCRIPTION
Fixes #869 
Changes: 
The snackbar is now visible above the bottom navigation view

Screenshots for the change:

![pr 870](https://user-images.githubusercontent.com/22665789/50947406-33fee880-14c4-11e9-9717-ed693494f29d.gif)
