### PR TITLE
fix: Removes extra space in Settings screen

### DIFF
--- a/app/src/main/res/layout/preference_category_about.xml
+++ b/app/src/main/res/layout/preference_category_about.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/preferenceCategory"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/layout_margin_large"
+        android:text="@string/about"
+        android:textColor="@color/colorAccent"
+        android:textSize="@dimen/text_size_medium"
+        android:textStyle="bold"
+        tools:ignore="RtlSymmetry" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/preference_category_profile.xml
+++ b/app/src/main/res/layout/preference_category_profile.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/preferenceCategory"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/layout_margin_large"
+        android:text="@string/profile"
+        android:textColor="@color/colorAccent"
+        android:textSize="@dimen/text_size_medium"
+        android:textStyle="bold"
+        tools:ignore="RtlSymmetry" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/preference_category_version.xml
+++ b/app/src/main/res/layout/preference_category_version.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/preferenceCategory"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/layout_margin_large"
+        android:text="@string/app_name_capital"
+        android:textColor="@color/colorAccent"
+        android:textSize="@dimen/text_size_medium"
+        android:textStyle="bold"
+        tools:ignore="RtlSymmetry" />
+
+</LinearLayout>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -1,32 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
     <PreferenceCategory
         android:key="@string/key_about"
-        android:title="@string/about" >
+        android:title="@string/about"
+        android:layout="@layout/preference_category_about">
 
         <Preference
             android:key="@string/key_rating"
-            android:title="@string/rating_settings" />
+            android:title="@string/rating_settings"
+            app:iconSpaceReserved="false" />
 
         <Preference
             android:key="@string/key_suggestion"
-            android:title="@string/suggestion_settings" />
+            android:title="@string/suggestion_settings"
+            app:iconSpaceReserved="false" />
 
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:title="@string/profile" >
+        android:title="@string/profile"
+        android:layout="@layout/preference_category_profile">
 
         <Preference
             android:key="@string/key_profile"
-            android:title="@string/logged_in_account" />
+            android:title="@string/logged_in_account"
+            app:iconSpaceReserved="false"/>
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:title="@string/app_name_capital" >
+        android:title="@string/app_name_capital"
+        android:layout="@layout/preference_category_version">
 
         <Preference
             android:key="@string/key_version"
-            android:title="@string/version_settings" />
+            android:title="@string/version_settings"
+            app:iconSpaceReserved="false"/>
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Fixes #873 

Changes: 
Included ``` app:iconSpaceReserved="false" ```  for Preference Elements and added three seperate content files for Preference Category since removing space is not directly possible in the preference dependency we are using.

Screenshots for the change:
![settings](https://user-images.githubusercontent.com/34534870/51070806-4f592780-166d-11e9-987a-038ffa3d9098.jpg)
@iamareebjamal @nikit19 Do review.