### PR TITLE
feat:Added Support Library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -147,7 +147,9 @@ dependencies {
     //Navigation
     implementation 'android.arch.navigation:navigation-fragment:1.0.0-alpha09'
     implementation 'android.arch.navigation:navigation-ui:1.0.0-alpha09'
-
+    //Support Library
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    
     testImplementation 'junit:junit:4.12'
     testImplementation "io.mockk:mockk:1.9"
     testImplementation 'org.threeten:threetenbp:1.3.8'


### PR DESCRIPTION
The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.

Fixes #[Add issue number here. If you do not solve the issue entirely, please change the message e.g. "First steps for issues #IssueNumber]

Changes: [Add here what changes were made in this issue and if possible provide links.]

Screenshots for the change: