### PR TITLE
fix: Keyboard shows up automatically when search location fragment opens.

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchLocationFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchLocationFragment.kt
@@ -34,6 +34,8 @@ class SearchLocationFragment : Fragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         rootView = inflater.inflate(R.layout.fragment_search_location, container, false)
 
+        Utils.showSoftKeyboard(context, view)
+
         val thisActivity = activity
         if (thisActivity is AppCompatActivity) {
             thisActivity.supportActionBar?.show()

--- a/app/src/main/java/org/fossasia/openevent/general/utils/Utils.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/utils/Utils.kt
@@ -44,9 +44,9 @@ object Utils {
             .show()
     }
 
-    fun showSoftKeyboard(context: Context?, view: View) {
+    fun showSoftKeyboard(context: Context?, view: View?) {
         val manager = context?.getSystemService(Context.INPUT_METHOD_SERVICE)
-        if (manager is InputMethodManager) manager.showSoftInput(view, InputMethodManager.SHOW_FORCED)
+        if (manager is InputMethodManager) manager.showSoftInput(view, InputMethodManager.RESULT_UNCHANGED_SHOWN)
     }
 
     fun hideSoftKeyboard(context: Context?, view: View) {


### PR DESCRIPTION
Fixes #928, #922 

Changes: Keyboard pops up automatically when the search location fragment is opened. Hence the user can start typing straight away instead of first tapping "where". Now if the back press is tapped once, the keyboard goes down and when the back press is tapped again, the user is sent back to the main activity.

GIF for the change:

![ezgif com-video-to-gif 5](https://user-images.githubusercontent.com/41234408/51430473-e3188e00-1c41-11e9-879b-7781f80d0948.gif)
