### PR TITLE
fix: two different anims for switching between login/signup

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/ProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/ProfileFragment.kt
@@ -29,7 +29,6 @@ import org.fossasia.openevent.general.MainActivity
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.utils.Utils
 import org.fossasia.openevent.general.utils.Utils.getAnimFade
-import org.fossasia.openevent.general.utils.Utils.getAnimSlide
 import org.fossasia.openevent.general.utils.Utils.requireDrawable
 import org.fossasia.openevent.general.utils.extensions.nonNull
 import org.fossasia.openevent.general.utils.nullToEmpty
@@ -45,7 +44,7 @@ class ProfileFragment : Fragment() {
     private fun redirectToLogin() {
         val args = getString(R.string.log_in_first)
         val bundle = bundleOf(SNACKBAR_MESSAGE to args)
-        findNavController(rootView).navigate(R.id.loginFragment, bundle, getAnimSlide())
+        findNavController(rootView).navigate(R.id.loginFragment, bundle, getAnimFade())
     }
 
     private fun redirectToMain() {

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
@@ -23,7 +23,6 @@ import org.fossasia.openevent.general.auth.SNACKBAR_MESSAGE
 import org.fossasia.openevent.general.event.EVENT_ID
 import org.fossasia.openevent.general.utils.Utils
 import org.fossasia.openevent.general.utils.Utils.getAnimFade
-import org.fossasia.openevent.general.utils.Utils.getAnimSlide
 import org.fossasia.openevent.general.utils.extensions.nonNull
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import timber.log.Timber
@@ -130,6 +129,6 @@ class OrdersUnderUserFragment : Fragment() {
     private fun redirectToLogin() {
         val args = getString(R.string.log_in_first)
         val bundle = bundleOf(SNACKBAR_MESSAGE to args)
-        findNavController(rootView).navigate(R.id.loginFragment, bundle, getAnimSlide())
+        findNavController(rootView).navigate(R.id.loginFragment, bundle, getAnimFade())
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
@@ -29,6 +29,7 @@ import kotlinx.android.synthetic.main.fragment_tickets.view.time
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.event.Event
 import org.fossasia.openevent.general.event.EventUtils
+import org.fossasia.openevent.general.utils.Utils.getAnimFade
 import org.fossasia.openevent.general.utils.Utils.getAnimSlide
 import org.fossasia.openevent.general.utils.extensions.nonNull
 import org.fossasia.openevent.general.utils.nullToEmpty
@@ -137,7 +138,7 @@ class TicketsFragment : Fragment() {
         if (ticketsViewModel.isLoggedIn())
             redirectToAttendee()
         else {
-            Snackbar.make(ticketsCoordinatorLayout, "You need to log in first!", Snackbar.LENGTH_LONG).show()
+            Snackbar.make(ticketsCoordinatorLayout, getString(R.string.log_in_first), Snackbar.LENGTH_LONG).show()
             redirectToLogin()
         }
     }
@@ -152,7 +153,7 @@ class TicketsFragment : Fragment() {
     private fun redirectToLogin() {
         val args = getString(R.string.log_in_first)
         val bundle = bundleOf(SNACKBAR_MESSAGE to args)
-        findNavController(rootView).navigate(R.id.loginFragment, bundle, getAnimSlide())
+        findNavController(rootView).navigate(R.id.loginFragment, bundle, getAnimFade())
     }
 
     private fun handleTicketSelect(id: Int, quantity: Int) {

--- a/app/src/main/java/org/fossasia/openevent/general/utils/Utils.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/utils/Utils.kt
@@ -89,8 +89,8 @@ object Utils {
         val builder = NavOptions.Builder()
         builder.setEnterAnim(R.anim.fade_in)
         builder.setExitAnim(R.anim.fade_out)
-        builder.setPopEnterAnim(R.anim.slide_in_left)
-        builder.setPopExitAnim(R.anim.slide_out_right)
+        builder.setPopEnterAnim(R.anim.fade_in)
+        builder.setPopExitAnim(R.anim.fade_out)
         return builder.build()
     }
 


### PR DESCRIPTION
Fixes #924 
Changes: 
Replaces slide animations with fade animations for login and signup fragments.

Screenshots for the change:
![pr 932](https://user-images.githubusercontent.com/22665789/51438632-aba6f180-1cd4-11e9-8a4a-c67c6703e65c.gif)
