### PR TITLE
feat: change edit profile button to FAB

### DIFF
--- a/app/src/main/res/drawable/ic_create_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_create_white_24dp.xml
@@ -4,6 +4,6 @@
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="#FFFFFF"
         android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z"/>
 </vector>

--- a/app/src/main/res/layout/fragment_edit_profile.xml
+++ b/app/src/main/res/layout/fragment_edit_profile.xml
@@ -14,11 +14,11 @@
 
         <ImageView
             android:id="@+id/profilePhoto"
-            android:layout_width="@dimen/item_image_view_large"
-            android:layout_height="@dimen/item_image_view_large"
+            android:layout_width="@dimen/avatar_medium"
+            android:layout_height="@dimen/avatar_medium"
             android:layout_gravity="center_horizontal"
+            android:layout_marginTop="@dimen/layout_margin_large"
             android:contentDescription="Profile Photo"
-            android:padding="@dimen/padding_large"
             app:srcCompat="@drawable/ic_account_circle_grey_24dp" />
 
         <LinearLayout

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -42,13 +43,6 @@
                 android:textColor="@color/black"
                 android:textSize="@dimen/text_size_expanded_title" />
 
-            <ImageButton
-                android:id="@+id/editProfileButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="@dimen/layout_margin_medium"
-                android:background="@null"
-                app:srcCompat="@drawable/ic_create_black_24dp" />
         </LinearLayout>
 
         <TextView
@@ -63,4 +57,16 @@
             android:textSize="@dimen/text_size_medium" />
 
     </LinearLayout>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/editProfileButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end|bottom"
+        android:layout_margin="@dimen/layout_margin_large"
+        android:clickable="true"
+        android:focusable="true"
+        app:backgroundTint="@color/colorAccent"
+        app:layout_anchorGravity="bottom|right|end"
+        app:srcCompat="@drawable/ic_create_white_24dp" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Fixes #934 

Changes: 
- Image button to Floating Action Button for launching EditProfileFragment
- Dimensions of the avatar icon in EditProfileFragment to match the dimensions of the same in ProfileFragment
- Color of pencil icon to be more consistent with FloatingActionButton ( from black to white)
Screenshots for the change:
![pr](https://user-images.githubusercontent.com/22665789/51442081-eb82ce80-1cfe-11e9-89da-4f2fb39cb270.gif)
