### PR TITLE
chore: replace fill_parent with match_parent in fragment_profile

### DIFF
--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -30,7 +30,7 @@
             app:srcCompat="@drawable/ic_account_circle_grey_24dp" />
 
         <LinearLayout
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center"
             android:orientation="horizontal">


### PR DESCRIPTION
Fixes #936 

Changes:
Replace deprecated constant "fill_parent" with "match_parent" in fragment_profile.xml
