### PR TITLE
fix: Show error in edittext when email is invalid

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
@@ -13,9 +13,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.Navigation.findNavController
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.fragment_login.email
-import kotlinx.android.synthetic.main.fragment_login.loginButton
-import kotlinx.android.synthetic.main.fragment_login.password
+import kotlinx.android.synthetic.main.fragment_login.*
 import kotlinx.android.synthetic.main.fragment_login.view.email
 import kotlinx.android.synthetic.main.fragment_login.view.loginCoordinatorLayout
 import kotlinx.android.synthetic.main.fragment_login.view.forgotPassword
@@ -133,6 +131,7 @@ class LoginFragment : Fragment() {
     }
 
     private fun onEmailEntered(enable: Boolean) {
+        if (!enable) textInputLayoutEmail.error = getString(R.string.email_error) else textInputLayoutEmail.error = null
         rootView.loginButton.isEnabled = enable
         rootView.forgotPassword.isVisible = enable
     }

--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
@@ -14,7 +14,10 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.Navigation.findNavController
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.fragment_login.*
+import kotlinx.android.synthetic.main.fragment_login.email
+import kotlinx.android.synthetic.main.fragment_login.loginButton
+import kotlinx.android.synthetic.main.fragment_login.password
+import kotlinx.android.synthetic.main.fragment_login.textInputLayoutEmail
 import kotlinx.android.synthetic.main.fragment_login.view.email
 import kotlinx.android.synthetic.main.fragment_login.view.loginCoordinatorLayout
 import kotlinx.android.synthetic.main.fragment_login.view.forgotPassword

--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
@@ -1,6 +1,7 @@
 package org.fossasia.openevent.general.auth
 
 import android.os.Bundle
+import android.os.CountDownTimer
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.LayoutInflater
@@ -84,12 +85,19 @@ class LoginFragment : Fragment() {
             })
 
         rootView.email.addTextChangedListener(object : TextWatcher {
+            var timer: CountDownTimer? = null
             override fun afterTextChanged(s: Editable) {}
 
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
 
             override fun onTextChanged(email: CharSequence, start: Int, before: Int, count: Int) {
-                loginViewModel.checkEmail(email.toString())
+                timer?.cancel()
+                timer = object : CountDownTimer(1000, 1000) {
+                    override fun onTick(millisUntilFinished: Long) {}
+                    override fun onFinish() {
+                        loginViewModel.checkEmail(email.toString())
+                    }
+                }.start()
             }
         })
 

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -36,6 +36,7 @@
                     android:text="@string/eventyay_logo"/>
                 <!-- Email Label -->
                 <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/textInputLayoutEmail"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/padding_medium"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,7 @@
     <string name="last_name_optional">Last Name (Optional)</string>
     <string name="welcome_back">Welcome back!</string>
     <string name="update">Update</string>
+    <string name="email_error">Valid Email Required</string>
 
     <!--eventyay-->
     <string name="eventyay_logo">eventyay</string>


### PR DESCRIPTION
Fixes #927 

Changes: added TextInputlayout error with message when entered email is wrong

Screenshots for the change:

![valid](https://user-images.githubusercontent.com/25877454/51782220-c650ee80-214a-11e9-88f5-e427c73c394a.gif)

