### PR TITLE
fix: Search view elements getting overflowed out of screen

### DIFF
--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -4,18 +4,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
-
         <LinearLayout
             android:id="@+id/searchLinearLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/layout_margin_medium"
             android:layout_marginRight="@dimen/layout_margin_medium"
-            android:layout_marginTop="@dimen/layout_margin_search_view"
+            android:layout_gravity="center"
             android:gravity="center"
             android:orientation="vertical">
 
@@ -89,7 +84,6 @@
             </RelativeLayout>
 
         </LinearLayout>
-    </LinearLayout>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fabSearch"


### PR DESCRIPTION
fixed :#960 Search view getting overflowed out of the screen 

removed the extra parent linear-layout, removed the top margin give the parent linear-layout gravity centre and also layout_gravity centre

fix: #960 