### PR TITLE
fix: Snackbar is appearing in the middle of the screen in eventDetailFragment

### DIFF
--- a/app/src/main/res/layout/fragment_event.xml
+++ b/app/src/main/res/layout/fragment_event.xml
@@ -8,7 +8,8 @@
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        app:layout_dodgeInsetEdges="bottom">
 
         <androidx.cardview.widget.CardView
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_social_links.xml
+++ b/app/src/main/res/layout/fragment_social_links.xml
@@ -2,12 +2,8 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true">
-
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:id="@+id/socialLinksCoordinatorLayout">
+    android:fitsSystemWindows="true"
+    android:id="@+id/socialLinksCoordinatorLayout">
 
         <TextView
             android:id="@+id/eventHostDetails"
@@ -35,5 +31,5 @@
             android:layout_marginBottom="@dimen/details_header_margin_top"
             android:layout_height="wrap_content"
             android:scrollbars="vertical" />
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_social_links.xml
+++ b/app/src/main/res/layout/fragment_social_links.xml
@@ -31,5 +31,4 @@
             android:layout_marginBottom="@dimen/details_header_margin_top"
             android:layout_height="wrap_content"
             android:scrollbars="vertical" />
-
 </FrameLayout>


### PR DESCRIPTION
fix #962   Snackbar is appearing in the middle of the screen in eventDetailFragment 

removed the coordinate layout from fragment_social_links
added app:layout_dodgeInsetEdges="bottom" top frameLayout of fragment_event so whole thing shifts up when snackbar is shown
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/44601530/51816195-73fb0380-22eb-11e9-8238-07b64d886afa.gif)

fix #962 