### PR TITLE
fix: Snackbar issue fixed in tickets fragment

### DIFF
--- a/app/src/main/res/layout/fragment_tickets.xml
+++ b/app/src/main/res/layout/fragment_tickets.xml
@@ -6,6 +6,7 @@
     android:layout_height="match_parent"
     android:background="@android:color/white"
     android:orientation="vertical"
+    android:fillViewport="true"        
     app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout


### PR DESCRIPTION
Fixes #957

Changes: 
Added `android:fillViewport="true"` in scrollview in tickets fragment which pushes the snackbar to the bottom of the screen.

Screenshots for the change:
![](https://media.giphy.com/media/SJ5vVk1ebw7pdCp1GD/giphy.gif)