### PR TITLE
fix: wrong placement of snackbar in edit profile segment

### DIFF
--- a/app/src/main/res/layout/fragment_edit_profile.xml
+++ b/app/src/main/res/layout/fragment_edit_profile.xml
@@ -4,13 +4,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/editProfileCoordinatorLayout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:padding="@dimen/padding_large">
+    android:layout_height="match_parent">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:padding="@dimen/padding_large">
 
         <ImageView
             android:id="@+id/profilePhoto"


### PR DESCRIPTION
fixed :#986 wrong placement of snackbar in edit profile segment

removed padding from parent coordinateLayout and added to child linearLayout

fix : #986 
![whatsapp image 2019-01-31 at 1 32 23 pm](https://user-images.githubusercontent.com/44601530/52040228-c1ca7280-255c-11e9-98ce-f120067c6e35.jpeg)
