### PR TITLE
fix: all tickets are not showing in ticket-fragment in landscape mode

### DIFF
--- a/app/src/main/res/layout/fragment_tickets.xml
+++ b/app/src/main/res/layout/fragment_tickets.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -12,7 +12,8 @@
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:id="@+id/ticketsCoordinatorLayout">
+        android:id="@+id/ticketsCoordinatorLayout"
+        android:descendantFocusability="blocksDescendants">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -130,4 +131,4 @@
                 android:textColor="@android:color/white" />
         </LinearLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
-</ScrollView>
+</androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
changed the parent element from ScrollView to NestedScrollView in ticket_fragment
added android:descendantFocusability="blocksDescendants" property to get the scroll position to top every time orientation changed

![whatsapp image 2019-01-31 at 2 09 36 pm](https://user-images.githubusercontent.com/44601530/52041994-ff7dca00-2561-11e9-9a8c-bb6e0629b7a3.jpeg)
![whatsapp image 2019-01-31 at 2 09 36 pm 1](https://user-images.githubusercontent.com/44601530/52041995-00166080-2562-11e9-8f17-c7279e7c2fa7.jpeg)
![whatsapp image 2019-01-31 at 2 09 36 pm 2](https://user-images.githubusercontent.com/44601530/52042000-01478d80-2562-11e9-8780-dcd40363148a.jpeg)

fixed: #988 