### PR TITLE
fix: Splash screen shown once from Welcome Fragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/WelcomeFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/WelcomeFragment.kt
@@ -20,6 +20,7 @@ import org.fossasia.openevent.general.search.SearchLocationViewModel
 import org.fossasia.openevent.general.utils.Utils
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
+const val FROM_WELCOME: String = "FromWelcomeFragment"
 const val LOCATION_SAVED = "LOCATION_SAVED"
 const val LOCATION_PERMISSION_REQUEST = 1000
 
@@ -34,7 +35,9 @@ class WelcomeFragment : Fragment() {
         if (thisActivity is AppCompatActivity)
             thisActivity.supportActionBar?.hide()
         rootView.pickCityButton.setOnClickListener {
-            Navigation.findNavController(rootView).navigate(R.id.searchLocationFragment, null, Utils.getAnimSlide())
+            val bundle = Bundle()
+            bundle.putBoolean(FROM_WELCOME, true)
+            Navigation.findNavController(rootView).navigate(R.id.searchLocationFragment, bundle, Utils.getAnimSlide())
         }
 
         geoLocationViewModel.currentLocationVisibility.observe(this, Observer {

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchLocationFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchLocationFragment.kt
@@ -99,10 +99,9 @@ class SearchLocationFragment : Fragment() {
 
     private fun redirectToMain() {
         val startMainActivity = Intent(activity, MainActivity::class.java).setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-        if(fromWelcomeFragment){
+        if (fromWelcomeFragment) {
             Navigation.findNavController(rootView).navigate(R.id.eventsFragment, null, Utils.getAnimSlide())
-        }
-        else if (fromSearchFragment) {
+        } else if (fromSearchFragment) {
             val searchBundle = Bundle()
             searchBundle.putBoolean(TO_SEARCH, true)
             startMainActivity.putExtras(searchBundle)

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchLocationFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchLocationFragment.kt
@@ -13,11 +13,13 @@ import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
+import androidx.navigation.Navigation
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.fragment_search_location.search
 import kotlinx.android.synthetic.main.fragment_search_location.view.locationProgressBar
 import kotlinx.android.synthetic.main.fragment_search_location.view.search
 import kotlinx.android.synthetic.main.fragment_search_location.view.currentLocation
+import org.fossasia.openevent.general.FROM_WELCOME
 import org.fossasia.openevent.general.MainActivity
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.utils.Utils
@@ -30,6 +32,7 @@ class SearchLocationFragment : Fragment() {
     private val searchLocationViewModel by viewModel<SearchLocationViewModel>()
     private val geoLocationViewModel by viewModel<GeoLocationViewModel>()
     private var fromSearchFragment: Boolean = false
+    private var fromWelcomeFragment: Boolean = false
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         rootView = inflater.inflate(R.layout.fragment_search_location, container, false)
@@ -45,6 +48,7 @@ class SearchLocationFragment : Fragment() {
         setHasOptionsMenu(true)
 
         fromSearchFragment = arguments?.getBoolean(FROM_SEARCH) ?: false
+        fromWelcomeFragment = arguments?.getBoolean(FROM_WELCOME) ?: false
 
         geoLocationViewModel.currentLocationVisibility.observe(this, Observer {
             rootView.currentLocation.visibility = View.GONE
@@ -95,14 +99,18 @@ class SearchLocationFragment : Fragment() {
 
     private fun redirectToMain() {
         val startMainActivity = Intent(activity, MainActivity::class.java).setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-        if (fromSearchFragment) {
+        if(fromWelcomeFragment){
+            Navigation.findNavController(rootView).navigate(R.id.eventsFragment, null, Utils.getAnimSlide())
+        }
+        else if (fromSearchFragment) {
             val searchBundle = Bundle()
             searchBundle.putBoolean(TO_SEARCH, true)
             startMainActivity.putExtras(searchBundle)
+        } else {
+            activity?.startActivity(startMainActivity)
+            activity?.overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_right)
+            activity?.finish()
         }
-        activity?.startActivity(startMainActivity)
-        activity?.overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_right)
-        activity?.finish()
     }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {


### PR DESCRIPTION
Fixes #993 

Changes: 
Used Navigation Controller along with passing a value to prevent restarting activity.

Screenshots for the change:
![splash_sol](https://user-images.githubusercontent.com/34534870/52085664-0e4c9700-25cb-11e9-800e-5df0b94ac213.gif)

@liveHarshit @nikit19 Your review.