### PR TITLE
fix: stretched out event placeholder image

### DIFF
--- a/app/src/main/res/layout/content_event.xml
+++ b/app/src/main/res/layout/content_event.xml
@@ -21,7 +21,7 @@
                 android:id="@+id/logo"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/event_details_image"
-                android:background="@drawable/placeholder"
+                android:src="@drawable/placeholder"
                 android:scaleType="centerCrop" />
 
             <LinearLayout


### PR DESCRIPTION
Fixes #1000

Changes: 
Change placeholder image from "background" to "src" so that scaleType is applicable for the image

Screenshots for the change:

![pr new](https://user-images.githubusercontent.com/22665789/52163699-ec0e6280-270b-11e9-8501-9a5750c72091.gif)
