### PR TITLE
fix: consistent spelling of 'favorite'

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/di/Modules.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/di/Modules.kt
@@ -38,7 +38,7 @@ import org.fossasia.openevent.general.event.EventsViewModel
 import org.fossasia.openevent.general.event.topic.EventTopic
 import org.fossasia.openevent.general.event.topic.EventTopicApi
 import org.fossasia.openevent.general.event.topic.SimilarEventsViewModel
-import org.fossasia.openevent.general.favorite.FavouriteEventsViewModel
+import org.fossasia.openevent.general.favorite.FavoriteEventsViewModel
 import org.fossasia.openevent.general.order.Charge
 import org.fossasia.openevent.general.order.ConfirmOrder
 import org.fossasia.openevent.general.order.Order
@@ -134,7 +134,7 @@ val viewModelModule = module {
     viewModel { TicketsViewModel(get(), get(), get()) }
     viewModel { AboutEventViewModel(get()) }
     viewModel { SocialLinksViewModel(get()) }
-    viewModel { FavouriteEventsViewModel(get()) }
+    viewModel { FavoriteEventsViewModel(get()) }
     viewModel { SettingsViewModel(get()) }
     viewModel { SimilarEventsViewModel(get()) }
     viewModel { OrderCompletedViewModel(get()) }

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsViewModel.kt
@@ -55,8 +55,8 @@ class EventDetailsViewModel(private val eventService: EventService) : ViewModel(
         return mapUrlInitial + latLong + mapUrlProperties + latLong + mapUrlMapType
     }
 
-    fun setFavorite(eventId: Long, favourite: Boolean) {
-        compositeDisposable.add(eventService.setFavorite(eventId, favourite)
+    fun setFavorite(eventId: Long, favorite: Boolean) {
+        compositeDisposable.add(eventService.setFavorite(eventId, favorite)
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe({

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventService.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventService.kt
@@ -86,9 +86,9 @@ class EventService(
         return eventApi.eventsUnderUser(eventId)
     }
 
-    fun setFavorite(eventId: Long, favourite: Boolean): Completable {
+    fun setFavorite(eventId: Long, favorite: Boolean): Completable {
         return Completable.fromAction {
-            eventDao.setFavorite(eventId, favourite)
+            eventDao.setFavorite(eventId, favorite)
         }
     }
 

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventViewHolder.kt
@@ -55,8 +55,8 @@ class EventViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         }
     }
 
-    fun setFabBackground(isFavourite: Boolean) {
-        if (isFavourite) {
+    fun setFabBackground(isFavorite: Boolean) {
+        if (isFavorite) {
             itemView.favoriteFab.setImageResource(R.drawable.ic_baseline_favorite_24px)
         } else {
             itemView.favoriteFab.setImageResource(R.drawable.ic_baseline_favorite_border_24px)

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -74,16 +74,16 @@ class EventsFragment : Fragment() {
             }
         }
 
-        val favouriteFabClickListener = object : FavoriteFabListener {
-            override fun onClick(event: Event, isFavourite: Boolean) {
+        val favoriteFabClickListener = object : FavoriteFabListener {
+            override fun onClick(event: Event, isFavorite: Boolean) {
                 val id = eventsRecyclerAdapter.getPos(event.id)
-                eventsViewModel.setFavorite(event.id, !isFavourite)
+                eventsViewModel.setFavorite(event.id, !isFavorite)
                 event.favorite = !event.favorite
                 eventsRecyclerAdapter.notifyItemChanged(id)
             }
         }
         eventsRecyclerAdapter.setListener(recyclerViewClickListener)
-        eventsRecyclerAdapter.setFavorite(favouriteFabClickListener)
+        eventsRecyclerAdapter.setFavorite(favoriteFabClickListener)
         eventsViewModel.events
             .nonNull()
             .observe(this, Observer {

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsRecyclerAdapter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsRecyclerAdapter.kt
@@ -66,5 +66,5 @@ interface RecyclerViewClickListener {
 }
 
 interface FavoriteFabListener {
-    fun onClick(event: Event, isFavourite: Boolean)
+    fun onClick(event: Event, isFavorite: Boolean)
 }

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
@@ -67,8 +67,8 @@ class EventsViewModel(private val eventService: EventService, private val prefer
         )
     }
 
-    fun setFavorite(eventId: Long, favourite: Boolean) {
-        compositeDisposable.add(eventService.setFavorite(eventId, favourite)
+    fun setFavorite(eventId: Long, favorite: Boolean) {
+        compositeDisposable.add(eventService.setFavorite(eventId, favorite)
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe({

--- a/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsFragment.kt
@@ -71,10 +71,10 @@ class SimilarEventsFragment : Fragment() {
             }
         }
 
-        val favouriteFabClickListener = object : FavoriteFabListener {
-            override fun onClick(event: Event, isFavourite: Boolean) {
+        val favoriteFabClickListener = object : FavoriteFabListener {
+            override fun onClick(event: Event, isFavorite: Boolean) {
                 val id = similarEventsRecyclerAdapter.getPos(event.id)
-                similarEventsViewModel.setFavorite(event.id, !isFavourite)
+                similarEventsViewModel.setFavorite(event.id, !isFavorite)
                 event.favorite = !event.favorite
                 similarEventsRecyclerAdapter.notifyItemChanged(id)
             }
@@ -102,7 +102,7 @@ class SimilarEventsFragment : Fragment() {
                 progressBar.isVisible = it
             })
 
-        similarEventsRecyclerAdapter.setFavorite(favouriteFabClickListener)
+        similarEventsRecyclerAdapter.setFavorite(favoriteFabClickListener)
         similarEventsViewModel.loadSimilarEvents(eventTopicId)
 
         return rootView

--- a/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsViewModel.kt
@@ -42,8 +42,8 @@ class SimilarEventsViewModel(private val eventService: EventService) : ViewModel
         )
     }
 
-    fun setFavorite(eventId: Long, favourite: Boolean) {
-        compositeDisposable.add(eventService.setFavorite(eventId, favourite)
+    fun setFavorite(eventId: Long, favorite: Boolean) {
+        compositeDisposable.add(eventService.setFavorite(eventId, favorite)
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe({

--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteEventsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteEventsViewModel.kt
@@ -10,7 +10,7 @@ import org.fossasia.openevent.general.event.Event
 import org.fossasia.openevent.general.event.EventService
 import timber.log.Timber
 
-class FavouriteEventsViewModel(private val eventService: EventService) : ViewModel() {
+class FavoriteEventsViewModel(private val eventService: EventService) : ViewModel() {
 
     private val compositeDisposable = CompositeDisposable()
 
@@ -36,9 +36,9 @@ class FavouriteEventsViewModel(private val eventService: EventService) : ViewMod
         )
     }
 
-    fun setFavorite(eventId: Long, favourite: Boolean) {
+    fun setFavorite(eventId: Long, favorite: Boolean) {
         compositeDisposable.add(
-            eventService.setFavorite(eventId, favourite)
+            eventService.setFavorite(eventId, favorite)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({

--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
@@ -13,7 +13,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.navigation.Navigation.findNavController
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.fragment_favorite.noLikedText
-import kotlinx.android.synthetic.main.fragment_favorite.favouriteCoordinatorLayout
+import kotlinx.android.synthetic.main.fragment_favorite.favoriteCoordinatorLayout
 import kotlinx.android.synthetic.main.fragment_favorite.view.favoriteEventsRecycler
 import kotlinx.android.synthetic.main.fragment_favorite.view.favoriteProgressBar
 import org.fossasia.openevent.general.R
@@ -30,7 +30,7 @@ const val FAVORITE_EVENT_DATE_FORMAT: String = "favoriteEventDateFormat"
 
 class FavoriteFragment : Fragment() {
     private val favoriteEventsRecyclerAdapter: FavoriteEventsRecyclerAdapter = FavoriteEventsRecyclerAdapter()
-    private val favoriteEventViewModel by viewModel<FavouriteEventsViewModel>()
+    private val favoriteEventViewModel by viewModel<FavoriteEventsViewModel>()
     private lateinit var rootView: View
 
     override fun onCreateView(
@@ -60,10 +60,10 @@ class FavoriteFragment : Fragment() {
                 findNavController(rootView).navigate(R.id.eventDetailsFragment, bundle, getAnimFade())
             }
         }
-        val favouriteFabClickListener = object : FavoriteFabListener {
-            override fun onClick(event: Event, isFavourite: Boolean) {
+        val favoriteFabClickListener = object : FavoriteFabListener {
+            override fun onClick(event: Event, isFavorite: Boolean) {
                 val id = favoriteEventsRecyclerAdapter.getPos(event.id)
-                favoriteEventViewModel.setFavorite(event.id, !isFavourite)
+                favoriteEventViewModel.setFavorite(event.id, !isFavorite)
                 event.favorite = !event.favorite
                 favoriteEventsRecyclerAdapter.notifyItemChanged(id)
                 showEmptyMessage(favoriteEventsRecyclerAdapter.itemCount)
@@ -71,7 +71,7 @@ class FavoriteFragment : Fragment() {
         }
 
         favoriteEventsRecyclerAdapter.setListener(recyclerViewClickListener)
-        favoriteEventsRecyclerAdapter.setFavorite(favouriteFabClickListener)
+        favoriteEventsRecyclerAdapter.setFavorite(favoriteFabClickListener)
         favoriteEventViewModel.events
             .nonNull()
             .observe(this, Observer {
@@ -85,7 +85,7 @@ class FavoriteFragment : Fragment() {
         favoriteEventViewModel.error
             .nonNull()
             .observe(this, Observer {
-                Snackbar.make(favouriteCoordinatorLayout, it, Snackbar.LENGTH_LONG).show()
+                Snackbar.make(favoriteCoordinatorLayout, it, Snackbar.LENGTH_LONG).show()
             })
 
         favoriteEventViewModel.progress

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
@@ -63,15 +63,15 @@ class SearchResultsFragment : Fragment() {
             }
         }
 
-        val favouriteFabClickListener = object : FavoriteFabListener {
-            override fun onClick(event: Event, isFavourite: Boolean) {
+        val favoriteFabClickListener = object : FavoriteFabListener {
+            override fun onClick(event: Event, isFavorite: Boolean) {
                 val id = eventsRecyclerAdapter.getPos(event.id)
-                searchViewModel.setFavorite(event.id, !isFavourite)
+                searchViewModel.setFavorite(event.id, !isFavorite)
                 event.favorite = !event.favorite
                 eventsRecyclerAdapter.notifyItemChanged(id)
             }
         }
-        eventsRecyclerAdapter.setFavorite(favouriteFabClickListener)
+        eventsRecyclerAdapter.setFavorite(favoriteFabClickListener)
         eventsRecyclerAdapter.setListener(recyclerViewClickListener)
         searchViewModel.events
             .nonNull()

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchViewModel.kt
@@ -176,8 +176,8 @@ class SearchViewModel(
         preference.remove(SearchTimeViewModel.tokenKeyNextDate)
     }
 
-    fun setFavorite(eventId: Long, favourite: Boolean) {
-        compositeDisposable.add(eventService.setFavorite(eventId, favourite)
+    fun setFavorite(eventId: Long, favorite: Boolean) {
+        compositeDisposable.add(eventService.setFavorite(eventId, favorite)
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe({

--- a/app/src/main/res/layout/fragment_favorite.xml
+++ b/app/src/main/res/layout/fragment_favorite.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:id="@+id/favouriteCoordinatorLayout">
+    android:id="@+id/favoriteCoordinatorLayout">
 
     <FrameLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #1007

Changes: 
Changed the spelling of "favourite" to "favorite" in 38 occurences over 14 files. This includes refactoring variables & classes and their instances.
