### PR TITLE
hide actionbar in forgot password section

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
@@ -137,6 +137,7 @@ class LoginFragment : Fragment() {
 
         rootView.forgotPassword.setOnClickListener {
             hideSoftKeyboard(context, rootView)
+            (activity as AppCompatActivity).supportActionBar?.hide()
             loginViewModel.sendResetPasswordEmail(email.text.toString())
         }
 


### PR DESCRIPTION
Fixes #606 
Changes:
Hide the toolbar when user clicks on forgot password.

Screenshots for the change:
![screenshot_2019-02-02-21-12-47-365_com eventyay attendee](https://user-images.githubusercontent.com/38163725/52166145-66041300-272f-11e9-8007-01bc7e941197.png)
