### PR TITLE
fix: Search view getting overflowed out of the screen

### DIFF
--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -4,18 +4,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
-
         <LinearLayout
             android:id="@+id/searchLinearLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/layout_margin_medium"
             android:layout_marginRight="@dimen/layout_margin_medium"
-            android:layout_marginTop="@dimen/layout_margin_search_view"
+            android:layout_gravity="center"
             android:gravity="center"
             android:orientation="vertical">
 
@@ -89,7 +84,6 @@
             </RelativeLayout>
 
         </LinearLayout>
-    </LinearLayout>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fabSearch"


### PR DESCRIPTION
removed the extra parent linear-layout, removed the top margin give the parent linear-layout gravity centre and also layout_gravity centre

fix: #960 #931

![image](https://user-images.githubusercontent.com/44601530/52174115-3dbef780-27b5-11e9-84f6-38269a5a7ca4.png)
![image](https://user-images.githubusercontent.com/44601530/52174117-47485f80-27b5-11e9-9316-4c3e295376b3.png)

