### PR TITLE
fix: back button disappear after orientation change in about fragment 

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/about/AboutEventFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/about/AboutEventFragment.kt
@@ -44,8 +44,10 @@ class AboutEventFragment : Fragment(), AppBarLayout.OnOffsetChangedListener {
         rootView = layoutInflater.inflate(R.layout.fragment_about_event, container, false)
 
         val thisActivity = activity
-        if (thisActivity is AppCompatActivity)
+        if (thisActivity is AppCompatActivity) {
             thisActivity.supportActionBar?.title = ""
+            thisActivity.supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        }
         setHasOptionsMenu(true)
 
         rootView.appBar.addOnOffsetChangedListener(this)


### PR DESCRIPTION
fixed: #1018 back button disappear after orientation change in about fragment #

set the setDisplayHomeAsUpEnable property to true of supportActionBar

fix: #1018 