### PR TITLE
fix: make register buttons corners rounded

### DIFF
--- a/app/src/main/res/layout/fragment_attendee.xml
+++ b/app/src/main/res/layout/fragment_attendee.xml
@@ -457,17 +457,18 @@
                         android:layout_height="wrap_content" />
                 </LinearLayout>
 
-                <Button
-                    style="@style/Widget.AppCompat.Button.Colored"
+                <com.google.android.material.button.MaterialButton
                     android:id="@+id/register"
+                    style="@style/AppTheme.MaterialButton.RoundedCorners"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:layout_margin="@dimen/layout_margin_large"
-                    android:backgroundTint="@color/colorAccent"
-                    android:padding="@dimen/padding_medium"
-                    android:text="@string/register"
-                    android:textColor="@android:color/white" />
+                    android:layout_marginStart="@dimen/details_margin_small"
+                    android:layout_marginEnd="@dimen/details_margin_small"
+                    android:layout_marginTop="@dimen/layout_margin_large"
+                    android:layout_marginBottom="@dimen/layout_margin_large"
+                    android:enabled="false"
+                    android:text="@string/register"/>
             </LinearLayout>
 
             <ProgressBar

--- a/app/src/main/res/layout/fragment_event.xml
+++ b/app/src/main/res/layout/fragment_event.xml
@@ -15,28 +15,14 @@
         android:layout_height="match_parent"
         app:layout_dodgeInsetEdges="bottom">
 
-        <androidx.cardview.widget.CardView
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonTickets"
+            style="@style/AppTheme.MaterialButton.RoundedCorners"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:id="@+id/buttonTickets"
             android:layout_gravity="bottom"
-            app:cardElevation="@dimen/card_tickets_elevation"
-            app:cardBackgroundColor="@color/colorAccent"
-            app:cardCornerRadius="@dimen/card_tickets_radius"
-            android:layout_margin="@dimen/layout_margin_large">
-
-            <TextView
-                android:layout_gravity="bottom"
-                android:textAlignment="center"
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/card_tickets_text_height"
-                android:gravity="center"
-                android:textStyle="bold"
-                android:textSize="@dimen/text_size_large"
-                android:textAllCaps="true"
-                android:textColor="@android:color/white"
-                android:text="@string/tickets"/>
-        </androidx.cardview.widget.CardView>
+            android:layout_margin="@dimen/layout_margin_large"
+            android:text="@string/tickets"/>
 
         <include layout="@layout/content_event"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_tickets.xml
+++ b/app/src/main/res/layout/fragment_tickets.xml
@@ -65,7 +65,7 @@
                 android:id="@+id/ticketInfoTextView"
                 android:textAlignment="center"
                 android:visibility="gone"
-                android:text="No tickets available!"
+                android:text="@string/no_tickets_available"
                 android:padding="@dimen/padding_medium"
                 android:layout_marginTop="@dimen/layout_margin_medium"
                 android:layout_marginLeft="@dimen/layout_margin_medium"
@@ -121,16 +121,17 @@
                 tools:itemCount="6"
                 tools:listitem="@layout/item_ticket" />
 
-            <androidx.appcompat.widget.AppCompatButton
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/register"
+                style="@style/AppTheme.MaterialButton.RoundedCorners"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:layout_margin="@dimen/layout_margin_large"
-                android:padding="@dimen/padding_medium"
-                android:backgroundTint="@color/colorAccent"
-                android:text="@string/register"
-                android:textColor="@android:color/white" />
+                android:layout_marginStart="@dimen/layout_margin_medium"
+                android:layout_marginEnd="@dimen/layout_margin_medium"
+                android:layout_marginTop="@dimen/layout_margin_large"
+                android:layout_marginBottom="@dimen/layout_margin_large"
+                android:text="@string/register" />
         </LinearLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -56,6 +56,7 @@
     <dimen name="text_margin">16dp</dimen>
     <dimen name="view_height_25dp">25dp</dimen>
     <dimen name="placeholder_tickets_view_height">30dp</dimen>
+    <dimen name="round_corners_button_radius">20dp</dimen>
 
     <!--image view specifics -->
     <dimen name="item_image_view_small">24dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,7 @@
     <string name="view_ticket">View</string>
     <string name="no_ticket_message">Not seeing your tickets? Learn more about how to find them.</string>
     <string name="find_my_tickets">Find my tickets</string>
+    <string name="no_tickets_available">No tickets available!</string>
 
     <!--payment details-->
     <string name="card_number">Card Number</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -10,6 +10,7 @@
         <item name="colorPrimaryVariant">@color/colorPrimaryVariant</item>
         <item name="colorSecondary">@color/colorSecondary</item>
         <item name="colorSecondaryVariant">@color/colorSecondaryVariant</item>
+        <item name="materialButtonStyle">@style/AppTheme.MaterialButton</item>
     </style>
 
     <style name="AppTheme.NoActionBar">
@@ -31,5 +32,15 @@
         <item name="android:textColor">@android:color/white</item>
         <item name="android:padding">@dimen/padding_medium</item>
         <item name="android:enabled">false</item>
+    </style>
+
+    <style name="AppTheme.MaterialButton" parent="Widget.MaterialComponents.Button">
+        <item name="backgroundTint">@color/colorSecondary</item>
+    </style>
+    <style name="AppTheme.MaterialButton.RoundedCorners" parent="AppTheme.MaterialButton">
+        <item name="cornerRadius">@dimen/round_corners_button_radius</item>
+        <item name="android:textColor">@android:color/white</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:textSize">@dimen/text_size_large</item>
     </style>
 </resources>


### PR DESCRIPTION
Fixes #1020 

Changes: 
- Modified "register" buttons in fragment_attendee and fragment_tickets to Material Buttons 
and then applying rounded corners.
- Changed CardView of Tickets button in fragment_event to MaterialButton

Screenshots for the change:


![ezgif com-video-to-gif](https://user-images.githubusercontent.com/22665789/55098842-a6a35b80-50e4-11e9-87ff-ef6cfd719935.gif)
