### PR TITLE
feat: tweak the search location screen's layout

### DIFF
--- a/app/src/main/res/layout/fragment_search_location.xml
+++ b/app/src/main/res/layout/fragment_search_location.xml
@@ -11,24 +11,27 @@
         android:layout_height="wrap_content"
         android:inputType="textCapWords"
         app:iconifiedByDefault="false"
-        app:queryHint="@string/where"
+        app:queryHint="@string/location_hint"
         app:searchIcon="@null" />
 
     <LinearLayout
         android:id="@+id/currentLocation"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:gravity="center_vertical"
         android:orientation="horizontal">
 
         <ImageView
+            android:id="@+id/locationButtonIcon"
             android:layout_width="@dimen/item_image_view_medium"
             android:layout_height="@dimen/item_image_view_medium"
             android:layout_margin="@dimen/layout_margin_medium"
             app:srcCompat="@drawable/ic_location_pin" />
 
         <TextView
+            android:id="@+id/locationButtonText"
             android:layout_width="wrap_content"
-            android:layout_height="@dimen/item_image_view_medium"
+            android:layout_height="wrap_content"
             android:layout_margin="@dimen/layout_margin_medium"
             android:text="@string/current_location"
             android:textColor="@color/colorPrimary"
@@ -41,6 +44,6 @@
             android:layout_gravity="center"
             android:layout_marginStart="@dimen/layout_margin_large"
             android:layout_marginLeft="@dimen/layout_margin_large"
-            android:visibility="gone"/>
+            android:visibility="gone" />
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="profile">Profile</string>
     <string name="likes">Likes</string>
     <string name="saved_date">savedDate</string>
+    <string name="location_hint">Enter a location</string>
 
     <!--event details-->
     <string name="event_card_date">Event Date :</string>


### PR DESCRIPTION
Make the hint which appears in the location text field more
polite/professional. Vertically centre the "Use my current location"
button text with respect to the button icon.
Fixes #1056 

Changes: Make the hint which appears in the location text field more polite/professional and vertically centre the "Use my current location" button text with respect to the button icon.

I've made a separate string resource for the hint instead of modifying the old resource because it was being used in search screen and the new resource was not suitable for use there.

Screenshots for the change:
Before
![search_location_current](https://user-images.githubusercontent.com/37890870/52490990-0f458000-2bec-11e9-8928-7fe31b10fe23.png)
After
![search_location_new](https://user-images.githubusercontent.com/37890870/52490996-17052480-2bec-11e9-85d6-229740ee4a7f.png)
