### PR TITLE
fix: Progress bar hidden on incomplete information submission

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeViewModel.kt
@@ -164,6 +164,7 @@ class AttendeeViewModel(
         if (attendee.email.isNullOrEmpty() || attendee.firstname.isNullOrEmpty() || attendee.lastname.isNullOrEmpty()) {
             mutableMessage.value = "Please fill in all the fields"
             mutableIsAttendeeCreated.value = false
+            mutableProgress.value = false
             return
         }
 


### PR DESCRIPTION
Fixes #1059 

Changes: 
Now the progress bar is not shown when incomplete information is submitted in attendees fragment.

GIF for the change:
![](https://media.giphy.com/media/t6lrXO1fnoWGlqjtYv/giphy.gif)