### PR TITLE
fix: progress bar in event details not in center.

### DIFF
--- a/app/src/main/res/layout/content_event.xml
+++ b/app/src/main/res/layout/content_event.xml
@@ -325,13 +325,15 @@
                                 android:ellipsize="end"
                                 android:textColor="@color/light_grey"
                                 tools:text="Description" />
-
-                            <FrameLayout
-                                android:id="@+id/frameContainerSocial"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content" />
                         </LinearLayout>
                     </LinearLayout>
+
+                    <FrameLayout
+                        android:id="@+id/frameContainerSocial"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:paddingTop="@dimen/padding_small"
+                        android:paddingBottom="@dimen/padding_small" />
                 </LinearLayout>
 
                 <LinearLayout


### PR DESCRIPTION
Fixes #494 

Changes: Made the progress bar in event details centered.

Screenshots for the change:
![whatsapp image 2019-02-09 at 00 54 41](https://user-images.githubusercontent.com/37517284/52501036-5b50ee80-2c05-11e9-9393-85e3d2c866a2.jpeg)
