### PR TITLE
fix: multiple popups in login screen on device rotation

### DIFF
--- a/app/src/playStore/java/org/fossasia/openevent/general/search/SmartAuthViewModel.kt
+++ b/app/src/playStore/java/org/fossasia/openevent/general/search/SmartAuthViewModel.kt
@@ -22,6 +22,7 @@ const val RC_CREDENTIALS_READ = 2
 const val RC_CREDENTIALS_SAVE = 3
 
 class SmartAuthViewModel : ViewModel() {
+    private var requestedCredentialsEarlier = false
     private lateinit var credentialsClient: CredentialsClient
     private lateinit var signInClient: GoogleSignInClient
     private lateinit var thisActivity: Activity
@@ -45,13 +46,15 @@ class SmartAuthViewModel : ViewModel() {
     }
 
     fun requestCredentials(activity: Activity?) {
-        if (activity == null) return
+        if (activity == null || requestedCredentialsEarlier) return
         val crBuilder = CredentialRequest.Builder()
             .setPasswordLoginSupported(true)
         crBuilder.setAccountTypes(IdentityProviders.GOOGLE)
         mutableProgress.value = true
         credentialsClient.request(crBuilder.build()).addOnCompleteListener(
             OnCompleteListener<CredentialRequestResponse> { task ->
+                requestedCredentialsEarlier = true
+
                 mutableProgress.value = false
                 if (task.isSuccessful) {
                     mutableId.value = task.result?.credential?.id


### PR DESCRIPTION
Fixes #1066 

Changes: Earlier, rotating the device would cause multiple popups to be shown if the user didn't dismiss the earlier ones. This was because the popup was shown whenever onStart() of the LoginFragment was called. But onStart() is called everytime on device rotation, leading to this bug.

Now, a boolean tracks whether the popup has been shown before.

Screenshots for the change:
There is no visual difference. The popups used to overlap each other completely, making it impossible to distinguish between them via screenshots.