### PR TITLE
chore: remove direct uses of Android classes from GeoLocationViewModel

### DIFF
--- a/app/src/fdroid/java/org/fossasia/openevent/general/search/GeoLocationViewModel.kt
+++ b/app/src/fdroid/java/org/fossasia/openevent/general/search/GeoLocationViewModel.kt
@@ -1,17 +1,25 @@
 package org.fossasia.openevent.general.search
 
-import android.app.Activity
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import org.fossasia.openevent.general.common.SingleLiveEvent
 
-class GeoLocationViewModel : ViewModel() {
+class GeoLocationViewModel(locationService: LocationService) : ViewModel() {
     private val mutableLocation = MutableLiveData<String>()
     val location: LiveData<String> = mutableLocation
     private val mutableVisibility = MutableLiveData<Boolean>()
     val currentLocationVisibility: LiveData<Boolean> = mutableVisibility
+    private val mutableOpenLocationSettings = MutableLiveData<Boolean>()
+    val openLocationSettings: LiveData<Boolean> = mutableOpenLocationSettings
+    private val mutableErrorMessage = SingleLiveEvent<String>()
+    val errorMessage: LiveData<String> = mutableErrorMessage
 
-    fun configure(activity: Activity?) {
+    init {
+        mutableVisibility.value = false
+    }
+
+    fun configure() {
         mutableVisibility.value = false
         return
     }

--- a/app/src/fdroid/java/org/fossasia/openevent/general/search/LocationServiceImpl.kt
+++ b/app/src/fdroid/java/org/fossasia/openevent/general/search/LocationServiceImpl.kt
@@ -1,0 +1,11 @@
+package org.fossasia.openevent.general.search
+
+import android.content.Context
+import io.reactivex.Single
+
+class LocationServiceImpl(context: Context) : LocationService {
+
+    override fun getAdministrativeArea(): Single<String> {
+        throw IllegalStateException("Attempt to use location functionality in F-Droid flavor")
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/general/WelcomeFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/WelcomeFragment.kt
@@ -1,8 +1,10 @@
 package org.fossasia.openevent.general
 
 import android.Manifest
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
+import android.provider.Settings
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -40,16 +42,27 @@ class WelcomeFragment : Fragment() {
         geoLocationViewModel.currentLocationVisibility.observe(this, Observer {
             rootView.currentLocation.visibility = View.GONE
         })
-        geoLocationViewModel.configure(null)
 
         rootView.currentLocation.setOnClickListener {
             checkLocationPermission()
-            geoLocationViewModel.configure(activity)
+            geoLocationViewModel.configure()
             rootView.locationProgressBar.visibility = View.VISIBLE
         }
         geoLocationViewModel.location.observe(this, Observer { location ->
             searchLocationViewModel.saveSearch(location)
             redirectToMain()
+        })
+
+        geoLocationViewModel.openLocationSettings.observe(this, Observer { open ->
+            if (open) {
+                val intent = Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
+                startActivity(intent)
+            }
+        })
+
+        geoLocationViewModel.errorMessage.observe(this, Observer { message ->
+            rootView.locationProgressBar.visibility = View.VISIBLE
+            Snackbar.make(rootView, message, Snackbar.LENGTH_SHORT).show()
         })
 
         return rootView
@@ -59,7 +72,7 @@ class WelcomeFragment : Fragment() {
         when (requestCode) {
             LOCATION_PERMISSION_REQUEST -> {
                 if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    geoLocationViewModel.configure(activity)
+                    geoLocationViewModel.configure()
                 } else {
                     Snackbar.make(rootView, "Cannot fetch location!", Snackbar.LENGTH_SHORT).show()
                     rootView.locationProgressBar.visibility = View.GONE

--- a/app/src/main/java/org/fossasia/openevent/general/di/Modules.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/di/Modules.kt
@@ -54,6 +54,8 @@ import org.fossasia.openevent.general.search.SearchLocationViewModel
 import org.fossasia.openevent.general.search.SearchTimeViewModel
 import org.fossasia.openevent.general.search.SearchViewModel
 import org.fossasia.openevent.general.search.SmartAuthViewModel
+import org.fossasia.openevent.general.search.LocationService
+import org.fossasia.openevent.general.search.LocationServiceImpl
 import org.fossasia.openevent.general.settings.SettingsViewModel
 import org.fossasia.openevent.general.social.SocialLink
 import org.fossasia.openevent.general.social.SocialLinkApi
@@ -65,6 +67,7 @@ import org.fossasia.openevent.general.ticket.TicketId
 import org.fossasia.openevent.general.ticket.TicketService
 import org.fossasia.openevent.general.ticket.TicketsViewModel
 import org.koin.android.ext.koin.androidApplication
+import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.viewmodel.ext.koin.viewModel
 import org.koin.dsl.module.module
 import retrofit2.Retrofit
@@ -75,6 +78,7 @@ import java.util.concurrent.TimeUnit
 val commonModule = module {
     single { Preference() }
     single { Network() }
+    factory<LocationService> { LocationServiceImpl(androidContext()) }
 }
 
 val apiModule = module {
@@ -141,7 +145,7 @@ val viewModelModule = module {
     viewModel { OrdersUnderUserVM(get(), get(), get()) }
     viewModel { OrderDetailsViewModel(get(), get()) }
     viewModel { EditProfileViewModel(get(), get()) }
-    viewModel { GeoLocationViewModel() }
+    viewModel { GeoLocationViewModel(get()) }
     viewModel { SmartAuthViewModel() }
 }
 

--- a/app/src/main/java/org/fossasia/openevent/general/location/LocationExceptions.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/location/LocationExceptions.kt
@@ -1,0 +1,11 @@
+package org.fossasia.openevent.general.location
+
+/**
+ * Thrown when there isn't a location source available.
+ * */
+class NoLocationSourceException : Exception()
+
+/**
+ * Thrown when the user hasn't granted permission necessary to complete an action.
+ * */
+class LocationPermissionException : Exception()

--- a/app/src/main/java/org/fossasia/openevent/general/search/LocationService.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/LocationService.kt
@@ -1,0 +1,14 @@
+package org.fossasia.openevent.general.search
+
+import io.reactivex.Single
+
+/**
+ * Implementations of this interface provide functionality related to the user location.
+ * */
+interface LocationService {
+
+    /**
+     * Gives the administrative area of the current location the user is in.
+     * */
+    fun getAdministrativeArea(): Single<String>
+}

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchLocationFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchLocationFragment.kt
@@ -49,11 +49,9 @@ class SearchLocationFragment : Fragment() {
             rootView.currentLocation.visibility = View.GONE
         })
 
-        geoLocationViewModel.configure(null)
-
         rootView.currentLocation.setOnClickListener {
             checkLocationPermission()
-            geoLocationViewModel.configure(activity)
+            geoLocationViewModel.configure()
             rootView.locationProgressBar.visibility = View.VISIBLE
         }
 
@@ -101,7 +99,7 @@ class SearchLocationFragment : Fragment() {
         when (requestCode) {
             LOCATION_PERMISSION_REQUEST -> {
                 if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    geoLocationViewModel.configure(activity)
+                    geoLocationViewModel.configure()
                 } else {
                     Snackbar.make(rootView, R.string.cannot_fetch_location, Snackbar.LENGTH_SHORT).show()
                     rootView.locationProgressBar.visibility = View.GONE

--- a/app/src/playStore/java/org/fossasia/openevent/general/search/LocationServiceImpl.kt
+++ b/app/src/playStore/java/org/fossasia/openevent/general/search/LocationServiceImpl.kt
@@ -1,0 +1,74 @@
+package org.fossasia.openevent.general.search
+
+import android.content.Context
+import android.location.Geocoder
+import android.location.LocationManager
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
+import com.google.android.gms.location.LocationServices
+import io.reactivex.Single
+import org.fossasia.openevent.general.location.LocationPermissionException
+import org.fossasia.openevent.general.location.NoLocationSourceException
+import timber.log.Timber
+import java.io.IOException
+import java.util.Locale
+
+class LocationServiceImpl(private val context: Context) : LocationService {
+
+    override fun getAdministrativeArea(): Single<String> {
+        val locationManager = context.getSystemService(Context.LOCATION_SERVICE)
+
+        if (locationManager !is LocationManager) {
+            return Single.error(IllegalStateException())
+        }
+
+        if (!locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)) {
+            return Single.error(NoLocationSourceException())
+        }
+
+        val locationRequest = LocationRequest.create().apply {
+            priority = LocationRequest.PRIORITY_LOW_POWER
+        }
+        return Single.create { emitter ->
+            try {
+                LocationServices
+                    .getFusedLocationProviderClient(context)
+                    .requestLocationUpdates(locationRequest, object : LocationCallback() {
+
+                        override fun onLocationResult(locationResult: LocationResult?) {
+                            if (locationResult == null) {
+                                emitter.onError(IllegalStateException())
+                                return
+                            }
+                            try {
+                                val adminArea = locationResult.getAdminArea()
+                                emitter.onSuccess(adminArea)
+                            } catch (e: IllegalArgumentException) {
+                                emitter.onError(e)
+                            }
+                        }
+                    }, null)
+            } catch (e: SecurityException) {
+                emitter.onError(LocationPermissionException())
+            }
+        }
+    }
+
+    private fun LocationResult.getAdminArea(): String {
+        locations.filterNotNull().forEach { location ->
+            val latitude = location.latitude
+            val longitude = location.longitude
+            try {
+                val geocoder = Geocoder(context, Locale.getDefault())
+                val addresses = geocoder.getFromLocation(latitude, longitude, 2)
+                val address = addresses.first { address -> address.adminArea != null }
+                return address.adminArea
+            } catch (exception: IOException) {
+                Timber.e(exception, "Error Fetching Location")
+                throw IllegalArgumentException()
+            }
+        }
+        throw IllegalArgumentException()
+    }
+}


### PR DESCRIPTION
Fixes #1072 

Changes: Earlier, `GeoLocationViewModel` contained code that directly used Android classes. This made it difficult to test.

I made `LocationService` interface to provide access to the administrative area and made two implementations of it: one for playstore and one for f-droid. The f-droid flavored implementation simply throws an exception on trying to get the administrative area.

The F-droid flavored `GeoLocationViewModel` simply hides the location option from the
user on initialization. The Playstore flavored `GeoLocationViewModel` works fully.

Made suitable changes to the Koin code.

Since `GeoLocationViewModel`'s new code doesn't require `Activity?`, it is no longer passed in
as a parameter in the `configure` method.