### PR TITLE
feat: change bottom bar's inactive title color to grey

### DIFF
--- a/app/src/main/res/color/navigation_item.xml
+++ b/app/src/main/res/color/navigation_item.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/colorPrimary" android:state_selected="true" />
+    <item android:color="@color/lighter_grey" android:state_selected="false" />
+</selector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -34,9 +34,10 @@
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
             android:background="?android:attr/windowBackground"
-            app:itemBackground="@android:color/white"
             android:foreground="?attr/selectableItemBackground"
-            app:itemTextColor="@color/colorPrimaryDark"
+            app:itemBackground="@android:color/white"
+            app:itemIconTint="@color/navigation_item"
+            app:itemTextColor="@color/navigation_item"
             app:labelVisibilityMode="labeled"
             app:menu="@menu/navigation" />
 
@@ -46,9 +47,10 @@
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
             android:background="@android:color/white"
-            app:itemBackground="@android:color/white"
             android:foreground="?attr/selectableItemBackground"
-            app:itemTextColor="@color/colorPrimaryDark"
+            app:itemBackground="@android:color/white"
+            app:itemIconTint="@color/navigation_item"
+            app:itemTextColor="@color/navigation_item"
             app:menu="@menu/navigation_auth" />
 
     </LinearLayout>


### PR DESCRIPTION
Fixes #1079

Changes: Earlier, all the tab titles were purple in color irrespective of whether
the tabs were active or not.

So, a color-list resource was made to rectify this.

Now, only the active tab's title is purple. Other's are grey(the same
color as the tab icons).

Screenshots for the change:
Current look:
![main_nav_current](https://user-images.githubusercontent.com/37890870/52586116-b3cdf900-2e5c-11e9-880a-ef1471100162.png)
![auth_nav_current](https://user-images.githubusercontent.com/37890870/52586119-b4ff2600-2e5c-11e9-998f-f05616d35ea0.png)
Updated look:
![main_nav_updated](https://user-images.githubusercontent.com/37890870/52586139-bf212480-2e5c-11e9-9c05-1aab0f8f244c.png)
![auth_nav_updated](https://user-images.githubusercontent.com/37890870/52586144-c1837e80-2e5c-11e9-8303-1596c1bdfa43.png)

