### PR TITLE
refactor: two ViewModels in the welcome screen into one ViewModel

### DIFF
--- a/app/src/fdroid/java/org/fossasia/openevent/general/welcome/WelcomeViewModel.kt
+++ b/app/src/fdroid/java/org/fossasia/openevent/general/welcome/WelcomeViewModel.kt
@@ -1,0 +1,28 @@
+package org.fossasia.openevent.general.welcome
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import org.fossasia.openevent.general.common.SingleLiveEvent
+import org.fossasia.openevent.general.data.Preference
+import org.fossasia.openevent.general.search.LocationService
+
+class WelcomeViewModel(locationService: LocationService, preference: Preference) : ViewModel() {
+
+    private val mutableRedirectToMain = MutableLiveData<Boolean>()
+    val redirectToMain: LiveData<Boolean> = mutableRedirectToMain
+    private val mutableVisibility = MutableLiveData<Boolean>()
+    val currentLocationVisibility: LiveData<Boolean> = mutableVisibility
+    private val mutableOpenLocationSettings = MutableLiveData<Boolean>()
+    val openLocationSettings: LiveData<Boolean> = mutableOpenLocationSettings
+    private val mutableErrorMessage = SingleLiveEvent<String>()
+    val errorMessage: LiveData<String> = mutableErrorMessage
+
+    init {
+        mutableVisibility.value = false
+    }
+
+    fun configure() {
+        // Since there are no location services for f-droid, this doesn't do anything.
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/general/di/Modules.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/di/Modules.kt
@@ -66,6 +66,7 @@ import org.fossasia.openevent.general.ticket.TicketApi
 import org.fossasia.openevent.general.ticket.TicketId
 import org.fossasia.openevent.general.ticket.TicketService
 import org.fossasia.openevent.general.ticket.TicketsViewModel
+import org.fossasia.openevent.general.welcome.WelcomeViewModel
 import org.koin.android.ext.koin.androidApplication
 import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.viewmodel.ext.koin.viewModel
@@ -147,6 +148,7 @@ val viewModelModule = module {
     viewModel { EditProfileViewModel(get(), get()) }
     viewModel { GeoLocationViewModel(get()) }
     viewModel { SmartAuthViewModel() }
+    viewModel { WelcomeViewModel(get(), get()) }
 }
 
 val networkModule = module {

--- a/app/src/main/java/org/fossasia/openevent/general/welcome/WelcomeFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/welcome/WelcomeFragment.kt
@@ -1,4 +1,4 @@
-package org.fossasia.openevent.general
+package org.fossasia.openevent.general.welcome
 
 import android.Manifest
 import android.content.Intent
@@ -17,6 +17,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.fragment_welcome.view.pickCityButton
 import kotlinx.android.synthetic.main.fragment_welcome.view.currentLocation
 import kotlinx.android.synthetic.main.fragment_welcome.view.locationProgressBar
+import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.search.GeoLocationViewModel
 import org.fossasia.openevent.general.search.SearchLocationViewModel
 import org.fossasia.openevent.general.utils.Utils

--- a/app/src/main/java/org/fossasia/openevent/general/welcome/WelcomeFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/welcome/WelcomeFragment.kt
@@ -18,8 +18,6 @@ import kotlinx.android.synthetic.main.fragment_welcome.view.pickCityButton
 import kotlinx.android.synthetic.main.fragment_welcome.view.currentLocation
 import kotlinx.android.synthetic.main.fragment_welcome.view.locationProgressBar
 import org.fossasia.openevent.general.R
-import org.fossasia.openevent.general.search.GeoLocationViewModel
-import org.fossasia.openevent.general.search.SearchLocationViewModel
 import org.fossasia.openevent.general.utils.Utils
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
@@ -28,8 +26,7 @@ const val LOCATION_PERMISSION_REQUEST = 1000
 
 class WelcomeFragment : Fragment() {
     private lateinit var rootView: View
-    private val geoLocationViewModel by viewModel<GeoLocationViewModel>()
-    private val searchLocationViewModel by viewModel<SearchLocationViewModel>()
+    private val welcomeViewModel by viewModel<WelcomeViewModel>()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         rootView = inflater.inflate(R.layout.fragment_welcome, container, false)
@@ -40,28 +37,30 @@ class WelcomeFragment : Fragment() {
             Navigation.findNavController(rootView).navigate(R.id.searchLocationFragment, null, Utils.getAnimSlide())
         }
 
-        geoLocationViewModel.currentLocationVisibility.observe(this, Observer {
+        welcomeViewModel.currentLocationVisibility.observe(this, Observer {
             rootView.currentLocation.visibility = View.GONE
         })
 
         rootView.currentLocation.setOnClickListener {
             checkLocationPermission()
-            geoLocationViewModel.configure()
+            welcomeViewModel.configure()
             rootView.locationProgressBar.visibility = View.VISIBLE
         }
-        geoLocationViewModel.location.observe(this, Observer { location ->
-            searchLocationViewModel.saveSearch(location)
-            redirectToMain()
+
+        welcomeViewModel.redirectToMain.observe(this, Observer { redirect ->
+            if (redirect) {
+                redirectToMain()
+            }
         })
 
-        geoLocationViewModel.openLocationSettings.observe(this, Observer { open ->
+        welcomeViewModel.openLocationSettings.observe(this, Observer { open ->
             if (open) {
                 val intent = Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
                 startActivity(intent)
             }
         })
 
-        geoLocationViewModel.errorMessage.observe(this, Observer { message ->
+        welcomeViewModel.errorMessage.observe(this, Observer { message ->
             rootView.locationProgressBar.visibility = View.VISIBLE
             Snackbar.make(rootView, message, Snackbar.LENGTH_SHORT).show()
         })
@@ -73,7 +72,7 @@ class WelcomeFragment : Fragment() {
         when (requestCode) {
             LOCATION_PERMISSION_REQUEST -> {
                 if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    geoLocationViewModel.configure()
+                    welcomeViewModel.configure()
                 } else {
                     Snackbar.make(rootView, "Cannot fetch location!", Snackbar.LENGTH_SHORT).show()
                     rootView.locationProgressBar.visibility = View.GONE

--- a/app/src/main/res/layout-land/fragment_welcome.xml
+++ b/app/src/main/res/layout-land/fragment_welcome.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="org.fossasia.openevent.general.WelcomeFragment">
+    tools:context="org.fossasia.openevent.general.welcome.WelcomeFragment">
 
     <TextView
         android:id="@+id/heading"

--- a/app/src/main/res/layout/fragment_welcome.xml
+++ b/app/src/main/res/layout/fragment_welcome.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="org.fossasia.openevent.general.WelcomeFragment">
+    tools:context="org.fossasia.openevent.general.welcome.WelcomeFragment">
 
     <RelativeLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -7,7 +7,7 @@
 
     <fragment
         android:id="@+id/welcomeFragment"
-        android:name="org.fossasia.openevent.general.WelcomeFragment"
+        android:name="org.fossasia.openevent.general.welcome.WelcomeFragment"
         android:label="WelcomeFragment"
         tools:layout="@layout/fragment_welcome" />
     <fragment

--- a/app/src/playStore/java/org/fossasia/openevent/general/welcome/WelcomeViewModel.kt
+++ b/app/src/playStore/java/org/fossasia/openevent/general/welcome/WelcomeViewModel.kt
@@ -1,0 +1,57 @@
+package org.fossasia.openevent.general.welcome
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import io.reactivex.disposables.CompositeDisposable
+import org.fossasia.openevent.general.common.SingleLiveEvent
+import org.fossasia.openevent.general.data.Preference
+import org.fossasia.openevent.general.location.LocationPermissionException
+import org.fossasia.openevent.general.location.NoLocationSourceException
+import org.fossasia.openevent.general.search.LocationService
+
+const val SAVED_LOCATION = "LOCATION"
+
+class WelcomeViewModel(private val locationService: LocationService, private val preference: Preference) : ViewModel() {
+
+    private val mutableRedirectToMain = MutableLiveData<Boolean>()
+    val redirectToMain: LiveData<Boolean> = mutableRedirectToMain
+    private val mutableVisibility = MutableLiveData<Boolean>()
+    val currentLocationVisibility: LiveData<Boolean> = mutableVisibility
+    private val mutableOpenLocationSettings = MutableLiveData<Boolean>()
+    val openLocationSettings: LiveData<Boolean> = mutableOpenLocationSettings
+    private val mutableErrorMessage = SingleLiveEvent<String>()
+    val errorMessage: LiveData<String> = mutableErrorMessage
+
+    private val compositeDisposable = CompositeDisposable()
+
+    fun configure() {
+        compositeDisposable.add(locationService.getAdministrativeArea()
+            .subscribe(
+                { adminArea ->
+                    preference.putString(SAVED_LOCATION, adminArea)
+                    mutableRedirectToMain.value = true
+                },
+                { error ->
+                    when (error) {
+                        is NoLocationSourceException -> {
+                            mutableErrorMessage.value = "No location sources are enabled"
+                            mutableOpenLocationSettings.value = true
+                        }
+                        is LocationPermissionException -> {
+                            mutableErrorMessage.value = "Please give the location permission"
+                        }
+                        else -> {
+                            mutableErrorMessage.value = "Something went wrong"
+                            mutableVisibility.value = false
+                        }
+                    }
+                }
+            ))
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        compositeDisposable.clear()
+    }
+}


### PR DESCRIPTION
Fixes #1073 

Changes: Earlier, there were two `ViewModel`s being used in `WelcomeFragment`.

In MVVM, a `View` is associated with only one `ViewModel`. To avoid duplication of logic, all distinct logic is split into smaller classes which can then be reused in different `ViewModel`s.

So now, `WelcomeFragment` has only one `ViewModel`(with two flavors: fdroid and playstore). Also, made a separate package for the welcome screen since its also a screen like others.

Screenshots for the change:
This is purely a refactoring. So, UI hasn't been changed in any way.