### PR TITLE
fix: show error message on empty email password

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
@@ -182,7 +182,6 @@ class LoginFragment : Fragment() {
     }
 
     private fun onEmailEntered(enable: Boolean) {
-        rootView.loginButton.isEnabled = enable
         rootView.forgotPassword.isVisible = enable
     }
 

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -76,7 +76,6 @@
                     android:id="@+id/loginButton"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:enabled="false"
                     android:layout_marginTop="@dimen/padding_large"
                     android:layout_marginBottom="@dimen/padding_large"
                     android:padding="@dimen/padding_medium"


### PR DESCRIPTION
Fixes #927 

Changes: Removed the dependency of login button on email verification. IMO the login button should always be enabled so as to show the exact error to the user, otherwise functions like
private fun hasErrors(email: String?, password: String?): Boolean {
        if (email.isNullOrEmpty() || password.isNullOrEmpty()) {
            mutableError.value = "Email or Password cannot be empty!"
            return true
        }
        return false
    }
are of no use.
![videotogif_2019 02 15_18 40 26](https://user-images.githubusercontent.com/38163725/52858996-9f864680-3151-11e9-8573-e4e21c124d8a.gif)