### PR TITLE
Shimmer show correctly.

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -101,7 +101,8 @@ class EventsFragment : Fragment() {
                     rootView.shimmerEvents.stopShimmer()
                 }
                 rootView.shimmerEvents.isVisible = it
-                rootView.eventsRecycler.isVisible = !it
+                eventsRecyclerAdapter.removeAll(it)
+                eventsRecyclerAdapter.notifyDataSetChanged()
             })
 
         eventsViewModel.error

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -101,7 +101,7 @@ class EventsFragment : Fragment() {
                     rootView.shimmerEvents.stopShimmer()
                 }
                 rootView.shimmerEvents.isVisible = it
-                rootView.eventsRecycler.isVisible = !it
+                eventsRecyclerAdapter.removeAll(it)
             })
 
         eventsViewModel.error

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -101,6 +101,7 @@ class EventsFragment : Fragment() {
                     rootView.shimmerEvents.stopShimmer()
                 }
                 rootView.shimmerEvents.isVisible = it
+                rootView.eventsRecycler.isVisible = !it
             })
 
         eventsViewModel.error
@@ -128,7 +129,7 @@ class EventsFragment : Fragment() {
         rootView.retry.setOnClickListener {
             val isNetworkConnected = isNetworkConnected()
             if (eventsViewModel.savedLocation != null && isNetworkConnected) {
-                eventsViewModel.retryLoadLocationEvents()
+                eventsViewModel.loadLocationEvents()
             }
             showNoInternetScreen(isNetworkConnected)
         }
@@ -139,7 +140,7 @@ class EventsFragment : Fragment() {
             if (!isNetworkConnected()) {
                 rootView.swiperefresh.isRefreshing = false
             } else {
-                eventsViewModel.retryLoadLocationEvents()
+                eventsViewModel.loadLocationEvents()
             }
         }
 

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -101,7 +101,7 @@ class EventsFragment : Fragment() {
                     rootView.shimmerEvents.stopShimmer()
                 }
                 rootView.shimmerEvents.isVisible = it
-                eventsRecyclerAdapter.removeAll(it)
+                rootView.eventsRecycler.isVisible = !it
             })
 
         eventsViewModel.error

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsRecyclerAdapter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsRecyclerAdapter.kt
@@ -34,6 +34,10 @@ class EventsRecyclerAdapter : RecyclerView.Adapter<EventViewHolder>() {
         this.events.addAll(eventList)
     }
 
+    fun removeAll(boolean: Boolean) {
+        if (boolean) events.clear()
+    }
+
     fun getPos(id: Long): Int {
         return events.map { it.id }.indexOf(id)
     }

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsRecyclerAdapter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsRecyclerAdapter.kt
@@ -34,10 +34,6 @@ class EventsRecyclerAdapter : RecyclerView.Adapter<EventViewHolder>() {
         this.events.addAll(eventList)
     }
 
-    fun removeAll(boolean: Boolean) {
-        if (boolean) events.clear()
-    }
-
     fun getPos(id: Long): Int {
         return events.map { it.id }.indexOf(id)
     }

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
@@ -36,6 +36,9 @@ class EventsViewModel(private val eventService: EventService, private val prefer
         compositeDisposable.add(eventService.getEventsByLocation(query)
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
+            .doOnSubscribe {
+                mutableShowShimmerEvents.value = true
+            }
             .doFinally {
                 mutableProgress.value = false
                 mutableShowShimmerEvents.value = false
@@ -46,11 +49,6 @@ class EventsViewModel(private val eventService: EventService, private val prefer
                 mutableError.value = "Error fetching events"
             })
         )
-    }
-
-    fun retryLoadLocationEvents() {
-        mutableShowShimmerEvents.value = true
-        loadLocationEvents()
     }
 
     fun loadEvents() {


### PR DESCRIPTION
Fixes #1095 

Changes: Made shimmer load up correctly. Also integrated retryLoadLocationEvents into loadLocationEvents itself. Also fixed a bug where data of previous location was visible when scrolling down while shimmers were visible(check 2nd image).

Screenshots for the change:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/37517284/52877790-0cfd9b80-3181-11e9-9f37-3c64b8ec7e04.gif)


![image](https://user-images.githubusercontent.com/37517284/52877808-18e95d80-3181-11e9-9685-8e74de40f808.png)