### PR TITLE
fix: attendeeframent progress bar

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
@@ -366,37 +366,39 @@ class AttendeeFragment : Fragment() {
             })
 
         rootView.register.setOnClickListener {
-            if (isNetworkConnected(context)) {
-                val attendees = ArrayList<Attendee>()
-                if (singleTicket) {
-                    val pos = ticketIdAndQty?.map { it.second }?.indexOf(1)
-                    val ticket = pos?.let { it1 -> ticketIdAndQty?.get(it1)?.first?.toLong() } ?: -1
-                    val attendee = Attendee(id = attendeeViewModel.getId(),
-                        firstname = firstName.text.toString(),
-                        lastname = lastName.text.toString(),
-                        city = getAttendeeField("city"),
-                        address = getAttendeeField("address"),
-                        state = getAttendeeField("state"),
-                        email = email.text.toString(),
-                        ticket = TicketId(ticket),
-                        event = eventId)
-                    attendees.add(attendee)
-                } else {
-                    attendees.addAll(attendeeRecyclerAdapter.attendeeList)
-                }
+            if (!isNetworkConnected(context)) {
+                Snackbar.make(rootView.attendeeScrollView, "No internet connection!", Snackbar.LENGTH_LONG).show()
+                return@setOnClickListener
+            }
+            val attendees = ArrayList<Attendee>()
+            if (singleTicket) {
+                val pos = ticketIdAndQty?.map { it.second }?.indexOf(1)
+                val ticket = pos?.let { it1 -> ticketIdAndQty?.get(it1)?.first?.toLong() } ?: -1
+                val attendee = Attendee(id = attendeeViewModel.getId(),
+                    firstname = firstName.text.toString(),
+                    lastname = lastName.text.toString(),
+                    city = getAttendeeField("city"),
+                    address = getAttendeeField("address"),
+                    state = getAttendeeField("state"),
+                    email = email.text.toString(),
+                    ticket = TicketId(ticket),
+                    event = eventId)
+                attendees.add(attendee)
+            } else {
+                attendees.addAll(attendeeRecyclerAdapter.attendeeList)
+            }
 
-                if (attendeeViewModel.areAttendeeEmailsValid(attendees)) {
-                    val country = if (country.text.isEmpty()) country.text.toString() else null
-                    attendeeViewModel.createAttendees(attendees, country, paymentOptions[selectedPaymentOption])
+            if (attendeeViewModel.areAttendeeEmailsValid(attendees)) {
+                val country = if (country.text.isEmpty()) country.text.toString() else null
+                attendeeViewModel.createAttendees(attendees, country, paymentOptions[selectedPaymentOption])
 
-                    attendeeViewModel.isAttendeeCreated.observe(this, Observer { isAttendeeCreated ->
-                        if (isAttendeeCreated && selectedPaymentOption ==
-                            paymentOptions.indexOf(getString(R.string.stripe))) {
-                            sendToken()
-                        }
-                    })
-                } else Snackbar.make(rootView.attendeeScrollView, "Invalid email address!", Snackbar.LENGTH_LONG).show()
-            } else Snackbar.make(rootView.attendeeScrollView, "No internet connection!", Snackbar.LENGTH_LONG).show()
+                attendeeViewModel.isAttendeeCreated.observe(this, Observer { isAttendeeCreated ->
+                    if (isAttendeeCreated && selectedPaymentOption ==
+                        paymentOptions.indexOf(getString(R.string.stripe))) {
+                        sendToken()
+                    }
+                })
+            } else Snackbar.make(rootView.attendeeScrollView, "Invalid email address!", Snackbar.LENGTH_LONG).show()
         }
 
         attendeeViewModel.ticketSoldOut

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -1,8 +1,6 @@
 package org.fossasia.openevent.general.event
 
-import android.content.Context
 import android.graphics.Color
-import android.net.ConnectivityManager
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -26,6 +24,7 @@ import kotlinx.android.synthetic.main.fragment_events.view.swiperefresh
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.data.Preference
 import org.fossasia.openevent.general.search.SAVED_LOCATION
+import org.fossasia.openevent.general.utils.Utils.isNetworkConnected
 import org.fossasia.openevent.general.utils.Utils.getAnimFade
 import org.fossasia.openevent.general.utils.Utils.getAnimSlide
 import org.fossasia.openevent.general.utils.extensions.nonNull
@@ -130,10 +129,10 @@ class EventsFragment : Fragment() {
             findNavController(rootView).navigate(R.id.searchLocationFragment, null, getAnimSlide())
         }
 
-        showNoInternetScreen(isNetworkConnected())
+        showNoInternetScreen(isNetworkConnected(context))
 
         rootView.retry.setOnClickListener {
-            val isNetworkConnected = isNetworkConnected()
+            val isNetworkConnected = isNetworkConnected(context)
             if (eventsViewModel.savedLocation != null && isNetworkConnected) {
                 eventsViewModel.retryLoadLocationEvents()
             }
@@ -142,8 +141,8 @@ class EventsFragment : Fragment() {
 
         rootView.swiperefresh.setColorSchemeColors(Color.BLUE)
         rootView.swiperefresh.setOnRefreshListener {
-            showNoInternetScreen(isNetworkConnected())
-            if (!isNetworkConnected()) {
+            showNoInternetScreen(isNetworkConnected(context))
+            if (!isNetworkConnected(context)) {
                 rootView.swiperefresh.isRefreshing = false
             } else {
                 eventsViewModel.retryLoadLocationEvents()
@@ -156,12 +155,6 @@ class EventsFragment : Fragment() {
     private fun showNoInternetScreen(show: Boolean) {
         rootView.homeScreenLL.visibility = if (show) View.VISIBLE else View.GONE
         rootView.noInternetCard.visibility = if (!show) View.VISIBLE else View.GONE
-    }
-
-    private fun isNetworkConnected(): Boolean {
-        val connectivityManager = context?.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
-
-        return connectivityManager?.activeNetworkInfo != null
     }
 
     override fun onStop() {

--- a/app/src/main/java/org/fossasia/openevent/general/utils/Utils.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/utils/Utils.kt
@@ -3,6 +3,7 @@ package org.fossasia.openevent.general.utils
 import android.app.AlertDialog
 import android.content.Context
 import android.graphics.BitmapFactory
+import android.net.ConnectivityManager
 import android.net.Uri
 import android.view.View
 import android.view.animation.AnimationUtils
@@ -42,6 +43,11 @@ object Utils {
             .setMessage(context?.resources?.getString(R.string.no_internet_message))
             .setPositiveButton(context?.resources?.getString(R.string.ok)) { dialog, _ -> dialog.cancel() }
             .show()
+    }
+
+    fun isNetworkConnected(context: Context?): Boolean {
+        val connectivityManager = context?.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+        return connectivityManager?.activeNetworkInfo != null
     }
 
     fun showSoftKeyboard(context: Context?, view: View) {

--- a/app/src/main/res/layout/fragment_attendee.xml
+++ b/app/src/main/res/layout/fragment_attendee.xml
@@ -442,7 +442,6 @@
                     android:layout_gravity="center"
                     android:layout_margin="@dimen/layout_margin_large"
                     android:backgroundTint="@color/colorAccent"
-                    android:enabled="false"
                     android:padding="@dimen/padding_medium"
                     android:text="@string/register"
                     android:textColor="@android:color/white" />


### PR DESCRIPTION
Fixes #956 

Changes: Fixed bug where progressBar would show indefinitely if internet connection is lost in attendee fragment. Added snackbar when internet connection lost and when register button is pressed in attendeefragment. Moved isNetworkConnected to Utils. 

Screenshots for the change:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/37517284/52904196-c8403600-324e-11e9-8bd2-de86121b7211.gif)
