### PR TITLE
fix: Progress bar shows correctly in ordersUnderUserFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
@@ -81,7 +81,9 @@ class OrdersUnderUserFragment : Fragment() {
             ordersUnderUserVM.progress
                 .nonNull()
                 .observe(this, Observer {
-                    rootView.progressBar.isVisible = it
+                    if (ordersRecyclerAdapter.attendeesNumber.size==0 && it) {
+                        rootView.progressBar.isVisible = it
+                    } else rootView.progressBar.isVisible = false
                 })
 
             ordersUnderUserVM.message

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
@@ -81,9 +81,7 @@ class OrdersUnderUserFragment : Fragment() {
             ordersUnderUserVM.progress
                 .nonNull()
                 .observe(this, Observer {
-                    if (ordersRecyclerAdapter.attendeesNumber.size==0 && it) {
-                        rootView.progressBar.isVisible = it
-                    } else rootView.progressBar.isVisible = false
+                    rootView.progressBar.isVisible = it
                 })
 
             ordersUnderUserVM.message

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserVM.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserVM.kt
@@ -45,7 +45,7 @@ class OrdersUnderUserVM(
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .doOnSubscribe {
-                mutableProgress.value = true
+                if (mutableAttendeesNumber.value == null) mutableProgress.value = true
                 mutableNoTickets.value = false
             }.subscribe({
                 order = it

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserVM.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserVM.kt
@@ -45,7 +45,7 @@ class OrdersUnderUserVM(
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .doOnSubscribe {
-                if (mutableAttendeesNumber.value == null) mutableProgress.value = true
+                mutableProgress.value = mutableAttendeesNumber.value == null
                 mutableNoTickets.value = false
             }.subscribe({
                 order = it


### PR DESCRIPTION
Fixes #930 

Changes: Disabled progress bar when coming back from ticketdetails. 

Screenshots for the change:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/37517284/52909495-3d435800-32af-11e9-8dca-df1cdf3b1c88.gif)