### PR TITLE
fix: Added margin in order completed page

### DIFF
--- a/app/src/main/res/layout/fragment_order.xml
+++ b/app/src/main/res/layout/fragment_order.xml
@@ -27,7 +27,8 @@
                 android:layout_gravity="center"
                 android:layout_marginTop="@dimen/layout_margin_extra_large"
                 android:text="@string/order_completed"
-                android:textColor="@color/black" />
+                android:textColor="@color/black"
+                android:layout_marginBottom="@dimen/layout_margin_small"/>
 
             <TextView
                 android:id="@+id/name"


### PR DESCRIPTION
Fixes #1119 

Changes: Added margin between "order completed" and "order name"

Screenshots for the change:

Before:-
![whatsapp image 2019-02-19 at 2 32 39 am](https://user-images.githubusercontent.com/43093724/52976506-cd88b680-33ef-11e9-8b2c-9367b179eb8d.jpeg)

After:-
![whatsapp image 2019-02-19 at 2 32 40 am](https://user-images.githubusercontent.com/43093724/52976510-d4172e00-33ef-11e9-86be-b433efe34be4.jpeg)
