### PR TITLE
fix: Improve UI in fragment_favorite

### DIFF
--- a/app/src/main/res/layout/fragment_favorite.xml
+++ b/app/src/main/res/layout/fragment_favorite.xml
@@ -25,14 +25,14 @@
                    android:layout_width="match_parent"
                    android:layout_height="wrap_content"
                    android:text="@string/nothing_planned_yet"
-                   android:textSize="15sp"
+                   android:textSize="@dimen/text_size_expanded_title"
                    android:layout_gravity="center_horizontal"
                    android:textAlignment="center"/>
                <TextView
                    android:layout_width="match_parent"
                    android:layout_height="wrap_content"
                    android:text="@string/find_something_to_do"
-                   android:textSize="25sp"
+                   android:textSize="@dimen/text_size_extra_large"
                    android:textAlignment="center"/>
 
            </LinearLayout>


### PR DESCRIPTION
Fixes #1122 

Changes: Initially the textsize was too small.
The textsize has been incresed.
Overall UI is improved.

Screenshots for the change:

Before:-
![whatsapp image 2019-02-19 at 2 51 47 am](https://user-images.githubusercontent.com/43093724/52977155-35400100-33f2-11e9-830a-f354f4ab17b7.jpeg)

After:-
![whatsapp image 2019-02-19 at 2 51 47 am 1](https://user-images.githubusercontent.com/43093724/52977161-3cffa580-33f2-11e9-876c-2eb5379c7f27.jpeg)
