### PR TITLE
fix: Fix the welcome screen's portrait layout

### DIFF
--- a/app/src/main/res/layout/fragment_welcome.xml
+++ b/app/src/main/res/layout/fragment_welcome.xml
@@ -55,8 +55,8 @@
             android:paddingBottom="@dimen/padding_small">
 
             <ImageView
-                android:layout_width="@dimen/item_image_view_large"
-                android:layout_height="@dimen/item_image_view_large"
+                android:layout_width="@dimen/item_image_view_medium"
+                android:layout_height="@dimen/item_image_view_medium"
                 android:layout_margin="@dimen/layout_margin_medium"
                 app:srcCompat="@drawable/ic_location_pin"/>
 


### PR DESCRIPTION
Fixes #1124 

Changes: The "Use my current location" button's icon was too large which caused the whole layout to mess up.

This commit reverts the icon size to what it was originally.

Screenshots for the change:
Current layout:
![welcome_screen_current](https://user-images.githubusercontent.com/37890870/52993854-a526a980-343b-11e9-81d4-55347a3e984c.png)
Updated layout:
![welcome_screen_updated](https://user-images.githubusercontent.com/37890870/52993865-ac4db780-343b-11e9-8cfb-d40a208a3267.png)
