### PR TITLE
fix: Rotating screen causes old snackbar to be shown again

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/about/AboutEventViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/about/AboutEventViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
+import org.fossasia.openevent.general.common.SingleLiveEvent
 import org.fossasia.openevent.general.event.Event
 import org.fossasia.openevent.general.event.EventService
 import timber.log.Timber
@@ -18,7 +19,7 @@ class AboutEventViewModel(private val eventService: EventService) : ViewModel() 
     val progressAboutEvent: LiveData<Boolean> = mutableProgressAboutEvent
     private val mutableEvent = MutableLiveData<Event>()
     val event: LiveData<Event> = mutableEvent
-    private val mutableError = MutableLiveData<String>()
+    private val mutableError = SingleLiveEvent<String>()
     val error: LiveData<String> = mutableError
 
     fun loadEvent(id: Long) {

--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
+import org.fossasia.openevent.general.common.SingleLiveEvent
 import timber.log.Timber
 
 const val USER_UPDATED = "User updated successfully!"
@@ -21,7 +22,7 @@ class EditProfileViewModel(
     val progress: LiveData<Boolean> = mutableProgress
     private val mutableUser = MutableLiveData<User>()
     val user: LiveData<User> = mutableUser
-    private val mutableMessage = MutableLiveData<String>()
+    private val mutableMessage = SingleLiveEvent<String>()
     val message: LiveData<String> = mutableMessage
 
     fun isLoggedIn() = authService.isLoggedIn()

--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginViewModel.kt
@@ -22,7 +22,7 @@ class LoginViewModel(
     val progress: LiveData<Boolean> = mutableProgress
     private val mutableUser = MutableLiveData<User>()
     val user: LiveData<User> = mutableUser
-    private val mutableError = MutableLiveData<String>()
+    private val mutableError = SingleLiveEvent<String>()
     val error: LiveData<String> = mutableError
     private val mutableShowNoInternetDialog = MutableLiveData<Boolean>()
     val showNoInternetDialog: LiveData<Boolean> = mutableShowNoInternetDialog

--- a/app/src/main/java/org/fossasia/openevent/general/auth/ProfileViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/ProfileViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
+import org.fossasia.openevent.general.common.SingleLiveEvent
 import timber.log.Timber
 
 class ProfileViewModel(private val authService: AuthService) : ViewModel() {
@@ -16,7 +17,7 @@ class ProfileViewModel(private val authService: AuthService) : ViewModel() {
     val progress: LiveData<Boolean> = mutableProgress
     private val mutableUser = MutableLiveData<User>()
     val user: LiveData<User> = mutableUser
-    private val mutableError = MutableLiveData<String>()
+    private val mutableError = SingleLiveEvent<String>()
     val error: LiveData<String> = mutableError
 
     fun isLoggedIn() = authService.isLoggedIn()

--- a/app/src/main/java/org/fossasia/openevent/general/auth/SignUpViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/SignUpViewModel.kt
@@ -20,7 +20,7 @@ class SignUpViewModel(
 
     private val mutableProgress = MutableLiveData<Boolean>()
     val progress: LiveData<Boolean> = mutableProgress
-    private val mutableError = MutableLiveData<String>()
+    private val mutableError = SingleLiveEvent<String>()
     val error: LiveData<String> = mutableError
     private val mutableSignedUp = MutableLiveData<User>()
     val signedUp: LiveData<User> = mutableSignedUp

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsViewModel.kt
@@ -8,6 +8,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import org.fossasia.openevent.general.auth.User
+import org.fossasia.openevent.general.common.SingleLiveEvent
 import timber.log.Timber
 
 class EventDetailsViewModel(private val eventService: EventService) : ViewModel() {
@@ -18,7 +19,7 @@ class EventDetailsViewModel(private val eventService: EventService) : ViewModel(
     val progress: LiveData<Boolean> = mutableProgress
     private val mutableUser = MutableLiveData<User>()
     val user: LiveData<User> = mutableUser
-    private val mutableError = MutableLiveData<String>()
+    private val mutableError = SingleLiveEvent<String>()
     val error: LiveData<String> = mutableError
     private val mutableEvent = MutableLiveData<Event>()
     val event: LiveData<Event> = mutableEvent

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
+import org.fossasia.openevent.general.common.SingleLiveEvent
 import org.fossasia.openevent.general.data.Preference
 import org.fossasia.openevent.general.search.SAVED_LOCATION
 import timber.log.Timber
@@ -19,7 +20,7 @@ class EventsViewModel(private val eventService: EventService, private val prefer
     val progress: LiveData<Boolean> = mutableProgress
     private val mutableEvents = MutableLiveData<List<Event>>()
     val events: LiveData<List<Event>> = mutableEvents
-    private val mutableError = MutableLiveData<String>()
+    private val mutableError = SingleLiveEvent<String>()
     val error: LiveData<String> = mutableError
     private val mutableShowShimmerEvents = MutableLiveData<Boolean>()
     val showShimmerEvents: LiveData<Boolean> = mutableShowShimmerEvents

--- a/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
+import org.fossasia.openevent.general.common.SingleLiveEvent
 import org.fossasia.openevent.general.event.Event
 import org.fossasia.openevent.general.event.EventService
 import timber.log.Timber
@@ -18,7 +19,7 @@ class SimilarEventsViewModel(private val eventService: EventService) : ViewModel
     val progress: LiveData<Boolean> = mutableProgress
     private val mutableSimilarEvents = MutableLiveData<List<Event>>()
     val similarEvents: LiveData<List<Event>> = mutableSimilarEvents
-    private val mutableError = MutableLiveData<String>()
+    private val mutableError = SingleLiveEvent<String>()
     val error: LiveData<String> = mutableError
 
     var eventId: Long = -1

--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteEventsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteEventsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
+import org.fossasia.openevent.general.common.SingleLiveEvent
 import org.fossasia.openevent.general.event.Event
 import org.fossasia.openevent.general.event.EventService
 import timber.log.Timber
@@ -16,7 +17,7 @@ class FavoriteEventsViewModel(private val eventService: EventService) : ViewMode
 
     private val mutableProgress = MutableLiveData<Boolean>()
     val progress: LiveData<Boolean> = mutableProgress
-    private val mutableError = MutableLiveData<String>()
+    private val mutableError = SingleLiveEvent<String>()
     val error: LiveData<String> = mutableError
     private val mutableEvents = MutableLiveData<List<Event>>()
     val events: LiveData<List<Event>> = mutableEvents

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
+import org.fossasia.openevent.general.common.SingleLiveEvent
 import org.fossasia.openevent.general.data.Network
 import org.fossasia.openevent.general.data.Preference
 import org.fossasia.openevent.general.event.Event
@@ -25,7 +26,7 @@ class SearchViewModel(
     val showShimmerResults: LiveData<Boolean> = mutableShowShimmerResults
     private val mutableEvents = MutableLiveData<List<Event>>()
     val events: LiveData<List<Event>> = mutableEvents
-    private val mutableError = MutableLiveData<String>()
+    private val mutableError = SingleLiveEvent<String>()
     val error: LiveData<String> = mutableError
     private val mutableShowNoInternetError = MutableLiveData<Boolean>()
     val showNoInternetError: LiveData<Boolean> = mutableShowNoInternetError

--- a/app/src/main/java/org/fossasia/openevent/general/social/SocialLinksViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/social/SocialLinksViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
+import org.fossasia.openevent.general.common.SingleLiveEvent
 import timber.log.Timber
 
 class SocialLinksViewModel(private val socialLinksService: SocialLinksService) : ViewModel() {
@@ -16,7 +17,7 @@ class SocialLinksViewModel(private val socialLinksService: SocialLinksService) :
     val progress: LiveData<Boolean> = mutableProgress
     private val mutableSocialLinks = MutableLiveData<List<SocialLink>>()
     val socialLinks: LiveData<List<SocialLink>> = mutableSocialLinks
-    private val mutableError = MutableLiveData<String>()
+    private val mutableError = SingleLiveEvent<String>()
     val error: LiveData<String> = mutableError
 
     fun loadSocialLinks(id: Long) {

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsViewModel.kt
@@ -7,6 +7,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import org.fossasia.openevent.general.auth.AuthHolder
+import org.fossasia.openevent.general.common.SingleLiveEvent
 import org.fossasia.openevent.general.event.Event
 import org.fossasia.openevent.general.event.EventService
 import timber.log.Timber
@@ -22,7 +23,7 @@ class TicketsViewModel(
     private val mutableProgressTickets = MutableLiveData<Boolean>()
     val progressTickets: LiveData<Boolean> = mutableProgressTickets
     val tickets = MutableLiveData<List<Ticket>>()
-    private val mutableError = MutableLiveData<String>()
+    private val mutableError = SingleLiveEvent<String>()
     val error: LiveData<String> = mutableError
     private val mutableEvent = MutableLiveData<Event>()
     val event: LiveData<Event> = mutableEvent


### PR DESCRIPTION

Fixes #1127 

Changes: Earlier, configuration changes(like screen rotation) would trigger the last `SnackBar` to show up again. This was unfortunate as `SnackBar`s are used to represent transient things.

This was happening because `MutableLiveData` was being used instead of `SingleLiveEvent`.

Not all `ViewModel`s had this issue as some were already using `SingleLiveEvent`.

This commit fixes the issue.