### PR TITLE
feat: Added alert dialog when click back button in edit user info fragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
@@ -2,6 +2,7 @@ package org.fossasia.openevent.general.auth
 
 import android.Manifest
 import android.app.Activity
+import android.app.AlertDialog
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
@@ -46,6 +47,10 @@ class EditProfileFragment : Fragment() {
     private val READ_STORAGE = arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
     private val REQUEST_CODE = 1
 
+    private lateinit var userFirstName: String
+    private lateinit var userLastName: String
+    private var avatarUpdated: Boolean = false
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -56,8 +61,8 @@ class EditProfileFragment : Fragment() {
         profileViewModel.user
             .nonNull()
             .observe(this, Observer {
-                val userFirstName = it.firstName.nullToEmpty()
-                val userLastName = it.lastName.nullToEmpty()
+                userFirstName = it.firstName.nullToEmpty()
+                userLastName = it.lastName.nullToEmpty()
                 val imageUrl = it.avatarUrl.nullToEmpty()
                 rootView.firstName.setText(userFirstName)
                 rootView.lastName.setText(userLastName)
@@ -118,10 +123,11 @@ class EditProfileFragment : Fragment() {
             }
 
             Picasso.get()
-                    .load(imageUri)
-                    .placeholder(requireDrawable(requireContext(), R.drawable.ic_person_black))
-                    .transform(CircleTransform())
-                    .into(rootView.profilePhoto)
+                .load(imageUri)
+                .placeholder(requireDrawable(requireContext(), R.drawable.ic_person_black))
+                .transform(CircleTransform())
+                .into(rootView.profilePhoto)
+            avatarUpdated = true
         }
     }
 
@@ -143,7 +149,22 @@ class EditProfileFragment : Fragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             android.R.id.home -> {
-                activity?.onBackPressed()
+                if (!avatarUpdated && rootView.lastName.text.toString() == userLastName &&
+                    rootView.firstName.text.toString() == userFirstName) {
+                    activity?.onBackPressed()
+                } else {
+                    hideSoftKeyboard(context, rootView)
+                    val dialog = AlertDialog.Builder(context)
+                    dialog.setMessage("Your changes have not been saved")
+                    dialog.setNegativeButton("Discard") { _, _ ->
+                        activity?.onBackPressed()
+                    }
+                    dialog.setPositiveButton("Save") { _, _ ->
+                        editProfileViewModel.updateProfile(encodedImage, rootView.firstName.text.toString(),
+                            rootView.lastName.text.toString())
+                    }
+                    dialog.create().show()
+                }
                 true
             }
             else -> super.onOptionsItemSelected(item)


### PR DESCRIPTION
Added alert dialog in edit user profile. The dialog appears when users try to change the data and click back button but don't click Update button first. The dialog confirms whether users want to discard or save changes.

Fixes #1133 

GIF:
<img src="https://i.ibb.co/GpVx0ds/video1550673999.gif" width="200"  />