### PR TITLE
feat: make ImageView aspect ratios same as that of source images

### DIFF
--- a/app/src/main/res/layout/content_event.xml
+++ b/app/src/main/res/layout/content_event.xml
@@ -2,358 +2,380 @@
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nestedContentEventScroll"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/white"
-    android:id="@+id/nestedContentEventScroll"
+    android:orientation="vertical"
     tools:showIn="@layout/fragment_event">
 
-    <FrameLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content">
+
+
+        <ImageView
+            android:id="@+id/logo"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:scaleType="centerCrop"
+            app:layout_constraintDimensionRatio="2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:srcCompat="@drawable/placeholder" />
+
+        <TextView
+            android:id="@+id/eventName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/layout_margin_large"
+            android:layout_marginLeft="@dimen/layout_margin_large"
+            android:layout_marginTop="@dimen/layout_margin_large"
+            android:fontFamily="sans-serif-light"
+            android:textColor="@color/dark_grey"
+            android:textSize="@dimen/text_size_extra_large"
+            app:layout_constraintStart_toStartOf="@+id/logo"
+            app:layout_constraintTop_toBottomOf="@+id/logo"
+            tools:text="Open Source Meetup" />
+
+        <TextView
+            android:id="@+id/eventOrganiserName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/layout_margin_moderate"
+            android:fontFamily="sans-serif-thin"
+            android:text="TextView"
+            android:textColor="@color/dark_grey"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="@+id/eventName"
+            app:layout_constraintTop_toBottomOf="@+id/eventName"
+            tools:text="by FOSSASIA" />
 
         <LinearLayout
-            android:layout_width="match_parent"
+            android:id="@+id/eventTimingLinearLayout"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:layout_marginTop="@dimen/layout_margin_large"
+            android:orientation="horizontal"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="@+id/eventOrganiserName"
+            app:layout_constraintTop_toBottomOf="@+id/eventOrganiserName">
 
             <ImageView
-                android:id="@+id/logo"
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/event_details_image"
-                android:src="@drawable/placeholder"
-                android:scaleType="centerCrop" />
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_margin="@dimen/layout_margin_medium"
+                android:scaleType="fitCenter"
+                app:srcCompat="@drawable/ic_baseline_event_black" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_margin="@dimen/layout_margin_medium"
                 android:orientation="vertical">
 
-                <LinearLayout
-                    android:id="@+id/eventDetailsLinearLayout"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:layout_marginTop="@dimen/layout_margin_large"
-                    android:layout_marginLeft="@dimen/layout_margin_large"
-                    android:layout_marginRight="@dimen/layout_margin_large"
-                    android:layout_marginBottom="@dimen/layout_margin_large"
-                    android:orientation="vertical">
-
-                    <TextView
-                        android:id="@+id/eventName"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:fontFamily="sans-serif-light"
-                        android:textColor="@color/dark_grey"
-                        android:layout_marginBottom="@dimen/divider_margin_top"
-                        android:textSize="@dimen/text_size_extra_large"
-                        tools:text="Event Name" />
-
-                    <TextView
-                        android:id="@+id/eventOrganiserName"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:textStyle="bold"
-                        android:visibility="gone"
-                        android:fontFamily="sans-serif-thin"
-                        android:layout_marginBottom="@dimen/divider_margin_top"
-                        android:textColor="@color/dark_grey"
-                        tools:text="by Organiser Name" />
-
-                    <LinearLayout
-                        android:id="@+id/eventTimingLinearLayout"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/layout_margin_large"
-                        android:orientation="horizontal">
-
-                        <ImageView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="center"
-                            android:layout_margin="@dimen/layout_margin_medium"
-                            android:scaleType="fitCenter"
-                            app:srcCompat="@drawable/ic_baseline_event_black" />
-
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_margin="@dimen/layout_margin_medium"
-                            android:orientation="vertical">
-
-                            <TextView
-                                android:id="@+id/eventDateDetailsFirst"
-                                android:textColor="@color/dark_grey"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                tools:text="Tuesday June 5" />
-
-                            <TextView
-                                android:id="@+id/eventDateDetailsSecond"
-                                android:layout_width="wrap_content"
-                                android:textColor="@color/dark_grey"
-                                android:layout_height="wrap_content"
-                                tools:text="Wed June 5" />
-
-                        </LinearLayout>
-
-                    </LinearLayout>
-
-                    <LinearLayout
-                        android:id="@+id/eventLocationLinearLayout"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:visibility="visible"
-                        android:layout_marginBottom="@dimen/layout_margin_large"
-                        android:orientation="horizontal">
-
-                        <ImageView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_margin="@dimen/layout_margin_medium"
-                            app:srcCompat="@drawable/ic_location_on_black" />
-
-                        <TextView
-                            android:id="@+id/eventLocationTextView"
-                            android:layout_width="wrap_content"
-                            android:layout_margin="@dimen/layout_margin_medium"
-                            android:layout_height="wrap_content"
-                            android:textColor="@color/dark_grey"
-                            tools:text="Location" />
-                    </LinearLayout>
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/layout_margin_small"
-                        android:orientation="horizontal">
-
-                        <ImageView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_margin="@dimen/layout_margin_medium"
-                            app:srcCompat="@drawable/ic_baseline_refund" />
-
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_margin="@dimen/layout_margin_medium"
-                            android:orientation="vertical">
-
-                            <TextView
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/refund_Policy"
-                                android:textColor="@color/dark_grey"
-                                tools:text="Refund Policy" />
-
-                            <TextView
-                                android:id="@+id/refundPolicy"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:ellipsize="end"
-                                android:lines="2"
-                                android:textColor="@color/dark_grey"
-                                tools:text="No refunds" />
-                        </LinearLayout>
-
-                    </LinearLayout>
-                </LinearLayout>
-
-                <LinearLayout
-                    android:id="@+id/aboutEventContainer"
-                    android:layout_width="match_parent"
+                <TextView
+                    android:id="@+id/eventDateDetailsFirst"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    tools:visibility="visible"
-                    android:visibility="visible"
-                    android:orientation="vertical">
-                    <View
-                        android:layout_width="match_parent"
-                        android:layout_height="@dimen/event_details_divider"
-                        android:layout_marginBottom="@dimen/layout_margin_extra_large"
-                        android:layout_marginLeft="@dimen/layout_margin_large"
-                        android:layout_marginRight="@dimen/layout_margin_large"
-                        android:background="@color/grey" />
+                    android:textColor="@color/dark_grey"
+                    tools:text="Tuesday June 5" />
 
-                    <TextView
-                        android:id="@+id/aboutHeader"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="@dimen/layout_margin_large"
-                        android:layout_marginRight="@dimen/layout_margin_large"
-                        android:layout_marginBottom="@dimen/divider_margin_top"
-                        android:text="@string/about"
-                        android:textSize="@dimen/event_details_headers"
-                        android:textColor="@color/dark_grey" />
-
-                    <TextView
-                        android:id="@+id/eventDescription"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="@dimen/layout_margin_large"
-                        android:layout_marginRight="@dimen/layout_margin_large"
-                        android:lines="4"
-                        android:ellipsize="end"
-                        android:layout_marginBottom="@dimen/layout_margin_large"
-                        android:textColor="@color/light_grey"
-                        tools:text="Description" />
-
-                    <TextView
-                        android:id="@+id/seeMore"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="@dimen/layout_margin_large"
-                        android:layout_marginRight="@dimen/layout_margin_large"
-                        android:layout_marginBottom="@dimen/layout_margin_extra_large"
-                        android:visibility="gone"
-                        android:textStyle="bold"
-                        android:textColor="@color/dark_grey"
-                        android:text="@string/see_more" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:id="@+id/locationContainer"
-                    android:layout_width="match_parent"
+                <TextView
+                    android:id="@+id/eventDateDetailsSecond"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    tools:visibility="visible"
-                    android:orientation="vertical">
-                    <View
-                        android:layout_width="match_parent"
-                        android:layout_height="@dimen/event_details_divider"
-                        android:layout_marginBottom="@dimen/layout_margin_extra_large"
-                        android:layout_marginLeft="@dimen/layout_margin_large"
-                        android:layout_marginRight="@dimen/layout_margin_large"
-                        android:background="@color/grey" />
-
-                    <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/divider_margin_top"
-                        android:layout_marginLeft="@dimen/layout_margin_large"
-                        android:layout_marginRight="@dimen/layout_margin_large"
-                        android:text="@string/location"
-                        android:textSize="@dimen/event_details_headers"
-                        android:textColor="@color/dark_grey" />
-
-                    <TextView
-                        android:id="@+id/locationUnderMap"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:textStyle="bold"
-                        android:visibility="gone"
-                        android:textColor="@color/dark_grey"
-                        android:layout_marginLeft="@dimen/layout_margin_large"
-                        android:layout_marginBottom="@dimen/divider_margin_top"
-                        android:layout_marginRight="@dimen/layout_margin_large"
-                        tools:text="location" />
-
-                    <ImageView
-                        android:id="@+id/imageMap"
-                        android:layout_width="match_parent"
-                        android:layout_height="@dimen/home_logo_width"
-                        android:visibility="gone"
-                        android:layout_marginBottom="@dimen/details_header_margin_top"
-                        android:src="@drawable/placeholder" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:id="@+id/organizerContainer"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    tools:visibility="visible"
-                    android:orientation="vertical">
-                    <View
-                        android:layout_width="match_parent"
-                        android:layout_height="@dimen/event_details_divider"
-                        android:layout_marginBottom="@dimen/layout_margin_extra_large"
-                        android:layout_marginLeft="@dimen/layout_margin_large"
-                        android:layout_marginRight="@dimen/layout_margin_large"
-                        android:background="@color/grey" />
-
-                    <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/layout_margin_large"
-                        android:layout_marginLeft="@dimen/layout_margin_large"
-                        android:layout_marginRight="@dimen/layout_margin_large"
-                        android:text="@string/organizer"
-                        android:textSize="@dimen/event_details_headers"
-                        android:textColor="@color/dark_grey" />
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_marginLeft="@dimen/layout_margin_large"
-                        android:layout_marginRight="@dimen/layout_margin_large"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal">
-                        <LinearLayout
-                            android:layout_width="0dp"
-                            android:layout_weight="0.2"
-                            android:layout_height="wrap_content">
-                            <ImageView
-                                android:id="@+id/logoIcon"
-                                android:layout_width="@dimen/logo_icon_width"
-                                android:layout_height="@dimen/logo_icon_height"
-                                android:layout_gravity="center_horizontal"
-                                android:layout_marginBottom="@dimen/layout_margin_small"
-                                android:scaleType="centerCrop"
-                                app:srcCompat="@drawable/ic_account_circle_grey" />
-                        </LinearLayout>
-
-                        <LinearLayout
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:orientation="vertical">
-
-                            <TextView
-                                android:id="@+id/organizerName"
-                                android:textSize="@dimen/event_details_headers"
-                                android:layout_width="wrap_content"
-                                android:textColor="@color/light_grey"
-                                android:layout_marginBottom="@dimen/layout_margin_medium"
-                                android:layout_height="wrap_content" />
-
-                            <TextView
-                                android:id="@+id/eventOrganiserDescription"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:lines="3"
-                                android:layout_marginBottom="@dimen/layout_margin_small"
-                                android:ellipsize="end"
-                                android:textColor="@color/light_grey"
-                                tools:text="Description" />
-                        </LinearLayout>
-                    </LinearLayout>
-
-                    <FrameLayout
-                        android:id="@+id/frameContainerSocial"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:paddingLeft="@dimen/padding_large"
-                        android:paddingTop="@dimen/padding_small" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:id="@+id/similarEventsContainer"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    tools:visibility="visible"
-                    android:orientation="vertical">
-
-                    <FrameLayout
-                        android:id="@+id/frameContainerSimilarEvents"
-                        android:layout_width="match_parent"
-                        android:layout_marginBottom="@dimen/layout_margin_extra_large"
-                        android:layout_height="wrap_content">
-                    </FrameLayout>
-                </LinearLayout>
+                    android:textColor="@color/dark_grey"
+                    tools:text="Wed June 5" />
 
             </LinearLayout>
 
         </LinearLayout>
-    </FrameLayout>
+
+        <LinearLayout
+            android:id="@+id/eventLocationLinearLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/layout_margin_large"
+            android:orientation="horizontal"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="@+id/eventTimingLinearLayout"
+            app:layout_constraintTop_toBottomOf="@+id/eventTimingLinearLayout">
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/layout_margin_medium"
+                app:srcCompat="@drawable/ic_location_on_black" />
+
+            <TextView
+                android:id="@+id/eventLocationTextView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/layout_margin_medium"
+                android:textColor="@color/dark_grey"
+                tools:text="Location" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/linearLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/layout_margin_large"
+            android:orientation="horizontal"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="@+id/eventLocationLinearLayout"
+            app:layout_constraintTop_toBottomOf="@+id/eventLocationLinearLayout">
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/layout_margin_medium"
+                app:srcCompat="@drawable/ic_baseline_refund" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/layout_margin_medium"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/refund_Policy"
+                    android:textColor="@color/dark_grey"
+                    tools:text="Refund Policy" />
+
+                <TextView
+                    android:id="@+id/refundPolicy"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:lines="2"
+                    android:textColor="@color/dark_grey"
+                    tools:text="No refunds" />
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/aboutEventContainer"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/layout_margin_large"
+            android:orientation="vertical"
+            android:visibility="visible"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/linearLayout"
+            tools:visibility="visible">
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/event_details_divider"
+                android:layout_marginLeft="@dimen/layout_margin_large"
+                android:layout_marginRight="@dimen/layout_margin_large"
+                android:layout_marginBottom="@dimen/layout_margin_extra_large"
+                android:background="@color/grey" />
+
+            <TextView
+                android:id="@+id/aboutHeader"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/layout_margin_large"
+                android:layout_marginRight="@dimen/layout_margin_large"
+                android:layout_marginBottom="@dimen/divider_margin_top"
+                android:text="@string/about"
+                android:textColor="@color/dark_grey"
+                android:textSize="@dimen/event_details_headers" />
+
+            <TextView
+                android:id="@+id/eventDescription"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/layout_margin_large"
+                android:layout_marginRight="@dimen/layout_margin_large"
+                android:layout_marginBottom="@dimen/layout_margin_large"
+                android:ellipsize="end"
+                android:lines="4"
+                android:textColor="@color/light_grey"
+                tools:text="Description" />
+
+            <TextView
+                android:id="@+id/seeMore"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/layout_margin_large"
+                android:layout_marginRight="@dimen/layout_margin_large"
+                android:layout_marginBottom="@dimen/layout_margin_extra_large"
+                android:text="@string/see_more"
+                android:textColor="@color/dark_grey"
+                android:textStyle="bold"
+                android:visibility="gone" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/locationContainer"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/aboutEventContainer"
+            tools:visibility="visible">
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/event_details_divider"
+                android:layout_marginLeft="@dimen/layout_margin_large"
+                android:layout_marginRight="@dimen/layout_margin_large"
+                android:layout_marginBottom="@dimen/layout_margin_extra_large"
+                android:background="@color/grey" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/layout_margin_large"
+                android:layout_marginRight="@dimen/layout_margin_large"
+                android:layout_marginBottom="@dimen/divider_margin_top"
+                android:text="@string/location"
+                android:textColor="@color/dark_grey"
+                android:textSize="@dimen/event_details_headers" />
+
+            <TextView
+                android:id="@+id/locationUnderMap"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/layout_margin_large"
+                android:layout_marginRight="@dimen/layout_margin_large"
+                android:layout_marginBottom="@dimen/divider_margin_top"
+                android:textColor="@color/dark_grey"
+                android:textStyle="bold"
+                android:visibility="gone"
+                tools:text="location" />
+
+            <ImageView
+                android:id="@+id/imageMap"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/home_logo_width"
+                android:layout_marginBottom="@dimen/details_header_margin_top"
+                android:src="@drawable/placeholder"
+                android:visibility="gone" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/organizerContainer"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/layout_margin_large"
+            android:orientation="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/locationContainer"
+            tools:visibility="visible">
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/event_details_divider"
+                android:layout_marginLeft="@dimen/layout_margin_large"
+                android:layout_marginRight="@dimen/layout_margin_large"
+                android:layout_marginBottom="@dimen/layout_margin_extra_large"
+                android:background="@color/grey" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/layout_margin_large"
+                android:layout_marginRight="@dimen/layout_margin_large"
+                android:layout_marginBottom="@dimen/layout_margin_large"
+                android:text="@string/organizer"
+                android:textColor="@color/dark_grey"
+                android:textSize="@dimen/event_details_headers" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/layout_margin_large"
+                android:layout_marginRight="@dimen/layout_margin_large"
+                android:orientation="horizontal">
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0.2">
+
+                    <ImageView
+                        android:id="@+id/logoIcon"
+                        android:layout_width="@dimen/logo_icon_width"
+                        android:layout_height="@dimen/logo_icon_height"
+                        android:layout_gravity="center_horizontal"
+                        android:layout_marginBottom="@dimen/layout_margin_small"
+                        android:scaleType="centerCrop"
+                        app:srcCompat="@drawable/ic_account_circle_grey" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/organizerName"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/layout_margin_medium"
+                        android:textColor="@color/light_grey"
+                        android:textSize="@dimen/event_details_headers" />
+
+                    <TextView
+                        android:id="@+id/eventOrganiserDescription"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/layout_margin_small"
+                        android:ellipsize="end"
+                        android:lines="3"
+                        android:textColor="@color/light_grey"
+                        tools:text="Description" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <FrameLayout
+                android:id="@+id/frameContainerSocial"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingLeft="@dimen/padding_large"
+                android:paddingTop="@dimen/padding_small" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/similarEventsContainer"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/organizerContainer"
+            tools:visibility="visible">
+
+            <FrameLayout
+                android:id="@+id/frameContainerSimilarEvents"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/layout_margin_extra_large"></FrameLayout>
+        </LinearLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/item_card_events.xml
+++ b/app/src/main/res/layout/item_card_events.xml
@@ -1,118 +1,115 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/allEventsCard"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@android:color/white">
+    android:layout_margin="@dimen/layout_margin_medium"
+    app:cardBackgroundColor="@android:color/white"
+    app:cardCornerRadius="@dimen/card_corner_radius"
+    app:cardElevation="@dimen/card_elevation">
 
-    <androidx.cardview.widget.CardView
-        android:id="@+id/allEventsCard"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/layout_margin_medium"
-        app:cardBackgroundColor="@android:color/white"
-        app:cardCornerRadius="@dimen/card_corner_radius"
-        app:cardElevation="@dimen/card_elevation">
+        android:layout_height="match_parent">
+
+
+        <ImageView
+            android:id="@+id/eventImage"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:scaleType="centerCrop"
+            app:layout_constraintDimensionRatio="2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:srcCompat="@drawable/placeholder" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:layout_width="@dimen/fab_width"
-            android:layout_height="@dimen/fab_height"
             android:id="@+id/shareFab"
-            android:layout_gravity="end"
-            android:layout_marginTop="@dimen/fab_margin_top"
-            android:layout_marginRight="80dp"
-            android:scaleType="center"
-            app:elevation="@dimen/fab_elevation"
-            app:backgroundTint="@android:color/white"
-            app:srcCompat="@drawable/ic_share_grey"
-            android:background="@android:color/white" />
-
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:layout_width="@dimen/fab_width"
             android:layout_height="@dimen/fab_height"
-            android:id="@+id/favoriteFab"
-            android:layout_gravity="end"
-            android:layout_marginTop="@dimen/fab_margin_top"
-            android:layout_marginRight="@dimen/fab_margin_right"
+            android:layout_marginEnd="80dp"
+            android:layout_marginRight="80dp"
+            android:background="@android:color/white"
             android:scaleType="center"
-            app:elevation="@dimen/fab_elevation"
             app:backgroundTint="@android:color/white"
-            app:srcCompat="@drawable/ic_baseline_favorite_border"
-            android:background="@android:color/white" />
+            app:elevation="@dimen/fab_elevation"
+            app:layout_constraintBottom_toBottomOf="@+id/eventImage"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/eventImage"
+            app:srcCompat="@drawable/ic_share_grey" />
 
-        <LinearLayout
-            android:layout_width="match_parent"
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/favoriteFab"
+            android:layout_width="@dimen/fab_width"
+            android:layout_height="@dimen/fab_height"
+            android:layout_marginEnd="30dp"
+            android:layout_marginRight="@dimen/fab_margin_right"
+            android:background="@android:color/white"
+            android:scaleType="center"
+            app:backgroundTint="@android:color/white"
+            app:elevation="@dimen/fab_elevation"
+            app:layout_constraintBottom_toBottomOf="@+id/eventImage"
+            app:layout_constraintEnd_toEndOf="@+id/eventImage"
+            app:layout_constraintTop_toBottomOf="@+id/eventImage"
+            app:srcCompat="@drawable/ic_baseline_favorite_border" />
+
+        <TextView
+            android:id="@+id/month"
+            android:layout_width="45dp"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:orientation="vertical">
+            android:layout_marginStart="@dimen/layout_margin_small"
+            android:layout_marginLeft="@dimen/layout_margin_small"
+            android:layout_marginTop="@dimen/layout_margin_extra_small"
+            android:textAlignment="center"
+            android:textAllCaps="true"
+            android:textColor="@color/colorPrimaryDark"
+            app:layout_constraintStart_toStartOf="@+id/eventImage"
+            app:layout_constraintTop_toTopOf="@+id/eventName"
+            tools:text="Jan" />
 
-            <ImageView
-                android:id="@+id/eventImage"
-                android:layout_width="match_parent"
-                android:layout_height="140dp"
-                android:scaleType="centerCrop"
-                android:src="@drawable/placeholder" />
+        <TextView
+            android:id="@+id/date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/black"
+            app:layout_constraintEnd_toEndOf="@+id/month"
+            app:layout_constraintStart_toStartOf="@+id/month"
+            app:layout_constraintTop_toBottomOf="@+id/month"
+            tools:text="15" />
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_marginTop="@dimen/layout_margin_medium"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
+        <TextView
+            android:id="@+id/eventName"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/layout_margin_medium"
+            android:layout_marginLeft="@dimen/layout_margin_medium"
+            android:layout_marginEnd="@dimen/layout_margin_medium"
+            android:layout_marginRight="@dimen/layout_margin_medium"
+            android:textColor="@color/black"
+            android:textSize="20sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/month"
+            app:layout_constraintTop_toBottomOf="@+id/shareFab"
+            tools:text="Open Source Meetup" />
 
-                <LinearLayout
-                    android:layout_width="45dp"
-                    android:layout_height="match_parent"
-                    android:layout_marginEnd="@dimen/padding_small"
-                    android:layout_marginRight="@dimen/padding_small"
-                    android:gravity="center_horizontal"
-                    android:orientation="vertical"
-                    android:paddingTop="@dimen/padding_medium">
+        <TextView
+            android:id="@+id/locationName"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/layout_margin_small"
+            android:layout_marginEnd="@dimen/layout_margin_medium"
+            android:layout_marginRight="@dimen/layout_margin_medium"
+            android:layout_marginBottom="@dimen/layout_margin_extra_large"
+            android:textSize="@dimen/text_size_small"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/eventName"
+            app:layout_constraintTop_toBottomOf="@+id/eventName"
+            tools:text="Jaipur, Rajasthan, India" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-                    <TextView
-                        android:id="@+id/month"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:textColor="@color/colorPrimaryDark"
-                        android:layout_marginTop="3dp"
-                        android:textSize="@dimen/text_size_medium"
-                        tools:text="JAN" />
-
-                    <TextView
-                        android:id="@+id/date"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:textColor="@color/black"
-                        android:layout_marginBottom="@dimen/layout_margin_medium"
-                        android:textSize="@dimen/text_size_medium"
-                        tools:text="15" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:orientation="vertical"
-                    android:paddingBottom="@dimen/padding_large"
-                    android:paddingTop="@dimen/padding_medium">
-
-                    <TextView
-                        android:id="@+id/eventName"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/layout_margin_small"
-                        android:textColor="@color/black"
-                        android:textSize="20sp"
-                        tools:text="Event Name" />
-
-                    <TextView
-                        android:id="@+id/locationName"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/layout_margin_large"
-                        android:textSize="@dimen/text_size_small"
-                        tools:text="Location Name" />
-
-                </LinearLayout>
-            </LinearLayout>
-        </LinearLayout>
-    </androidx.cardview.widget.CardView>
-</LinearLayout>
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/item_card_similar_events.xml
+++ b/app/src/main/res/layout/item_card_similar_events.xml
@@ -1,122 +1,116 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="wrap_content"
+    android:id="@+id/allEventsCard"
+    android:layout_width="250dp"
     android:layout_height="wrap_content"
-    android:background="@android:color/white">
+    android:layout_margin="@dimen/layout_margin_medium"
+    app:cardBackgroundColor="@android:color/white"
+    app:cardCornerRadius="@dimen/card_corner_radius"
+    app:cardElevation="@dimen/card_elevation">
 
-    <androidx.cardview.widget.CardView
-        android:id="@+id/allEventsCard"
-        android:layout_width="250dp"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/layout_margin_medium"
-        app:cardBackgroundColor="@android:color/white"
-        app:cardCornerRadius="@dimen/card_corner_radius"
-        app:cardElevation="@dimen/card_elevation">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+
+        <ImageView
+            android:id="@+id/eventImage"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:scaleType="centerCrop"
+            app:layout_constraintDimensionRatio="2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:srcCompat="@drawable/placeholder" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:layout_width="@dimen/fab_width"
-            android:layout_height="@dimen/fab_height"
             android:id="@+id/shareFab"
-            android:layout_gravity="end"
-            android:layout_marginTop="@dimen/fab_margin_top"
-            android:layout_marginRight="80dp"
-            android:scaleType="center"
-            app:elevation="@dimen/fab_elevation"
-            app:backgroundTint="@android:color/white"
-            app:srcCompat="@drawable/ic_share_grey"
-            android:background="@android:color/white" />
-
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:layout_width="@dimen/fab_width"
             android:layout_height="@dimen/fab_height"
-            android:id="@+id/favoriteFab"
-            android:layout_gravity="end"
-            android:layout_marginTop="@dimen/fab_margin_top"
-            android:layout_marginRight="@dimen/fab_margin_right"
+            android:layout_marginEnd="80dp"
+            android:layout_marginRight="80dp"
+            android:background="@android:color/white"
             android:scaleType="center"
-            app:elevation="@dimen/fab_elevation"
             app:backgroundTint="@android:color/white"
-            app:srcCompat="@drawable/ic_baseline_favorite_border"
-            android:background="@android:color/white" />
+            app:elevation="@dimen/fab_elevation"
+            app:layout_constraintBottom_toBottomOf="@+id/eventImage"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/eventImage"
+            app:srcCompat="@drawable/ic_share_grey" />
 
-        <LinearLayout
-            android:layout_width="match_parent"
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/favoriteFab"
+            android:layout_width="@dimen/fab_width"
+            android:layout_height="@dimen/fab_height"
+            android:layout_marginEnd="30dp"
+            android:layout_marginRight="@dimen/fab_margin_right"
+            android:background="@android:color/white"
+            android:scaleType="center"
+            app:backgroundTint="@android:color/white"
+            app:elevation="@dimen/fab_elevation"
+            app:layout_constraintBottom_toBottomOf="@+id/eventImage"
+            app:layout_constraintEnd_toEndOf="@+id/eventImage"
+            app:layout_constraintTop_toBottomOf="@+id/eventImage"
+            app:srcCompat="@drawable/ic_baseline_favorite_border" />
+
+        <TextView
+            android:id="@+id/month"
+            android:layout_width="45dp"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:orientation="vertical">
+            android:layout_marginStart="@dimen/layout_margin_small"
+            android:layout_marginLeft="@dimen/layout_margin_small"
+            android:layout_marginTop="@dimen/layout_margin_extra_small"
+            android:textAlignment="center"
+            android:textAllCaps="true"
+            android:textColor="@color/colorPrimaryDark"
+            app:layout_constraintStart_toStartOf="@+id/eventImage"
+            app:layout_constraintTop_toTopOf="@+id/eventName"
+            tools:text="Jan" />
 
-            <ImageView
-                android:id="@+id/eventImage"
-                android:layout_width="match_parent"
-                android:layout_height="140dp"
-                android:scaleType="centerCrop"
-                android:src="@drawable/placeholder" />
+        <TextView
+            android:id="@+id/date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/black"
+            app:layout_constraintEnd_toEndOf="@+id/month"
+            app:layout_constraintStart_toStartOf="@+id/month"
+            app:layout_constraintTop_toBottomOf="@+id/month"
+            tools:text="15" />
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_marginTop="@dimen/divider_margin_top"
-                android:layout_height="110dp"
-                android:orientation="horizontal">
+        <TextView
+            android:id="@+id/eventName"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/layout_margin_medium"
+            android:layout_marginLeft="@dimen/layout_margin_medium"
+            android:layout_marginEnd="@dimen/layout_margin_medium"
+            android:layout_marginRight="@dimen/layout_margin_medium"
+            android:textColor="@color/black"
+            android:textSize="20sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/month"
+            app:layout_constraintTop_toBottomOf="@+id/shareFab"
+            tools:text="Open Source Meetup" />
 
-                <LinearLayout
-                    android:layout_width="45dp"
-                    android:layout_height="match_parent"
-                    android:layout_marginEnd="@dimen/padding_small"
-                    android:layout_marginRight="@dimen/padding_small"
-                    android:gravity="center_horizontal"
-                    android:orientation="vertical"
-                    android:paddingTop="@dimen/padding_medium">
+        <TextView
+            android:id="@+id/locationName"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/layout_margin_small"
+            android:layout_marginEnd="@dimen/layout_margin_medium"
+            android:layout_marginRight="@dimen/layout_margin_medium"
+            android:layout_marginBottom="@dimen/layout_margin_extreme_large"
+            android:lines="1"
+            android:textSize="@dimen/text_size_small"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/eventName"
+            app:layout_constraintTop_toBottomOf="@+id/eventName"
+            tools:text="Jaipur, Rajasthan, India" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-                    <TextView
-                        android:id="@+id/month"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:textColor="@color/colorPrimaryDark"
-                        android:layout_marginTop="3dp"
-                        android:textSize="@dimen/text_size_medium"
-                        tools:text="JAN" />
-
-                    <TextView
-                        android:id="@+id/date"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:textColor="@color/black"
-                        android:layout_marginBottom="@dimen/layout_margin_medium"
-                        android:textSize="@dimen/text_size_medium"
-                        tools:text="15" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:orientation="vertical"
-                    android:paddingRight="@dimen/padding_large"
-                    android:paddingBottom="@dimen/padding_medium"
-                    android:paddingTop="@dimen/padding_medium">
-
-                    <TextView
-                        android:id="@+id/eventName"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/layout_margin_small"
-                        android:textColor="@color/black"
-                        android:textSize="20sp"
-                        android:ellipsize="end"
-                        android:maxLines="2"
-                        tools:text="Event Name" />
-
-                    <TextView
-                        android:id="@+id/locationName"
-                        android:lines="1"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/layout_margin_large"
-                        android:textSize="@dimen/text_size_small"
-                        tools:text="Location Name" />
-
-                </LinearLayout>
-            </LinearLayout>
-        </LinearLayout>
-    </androidx.cardview.widget.CardView>
-</LinearLayout>
+</androidx.cardview.widget.CardView>


### PR DESCRIPTION
Fixes #1135 

Changes: The `ImageView`s in `item_card_events.xml`, `item_card_similar_events.xml` and `content_event.xml` that display event images have width/height ratio of 2:1 which is the same as that of the images they display.

Earlier, since the ratios of `ImageView`s and images were different, the images were clipped. This was clearly noticeable on some images.

This change involved converting those layouts to `ConstraintLayout` because `ConstraintLayout` allows setting ratios.

Screenshots for the change:

![matched_ratio1](https://user-images.githubusercontent.com/37890870/53166503-735c4100-35fb-11e9-9148-cdfd0578874b.png)
![matched_ratio2](https://user-images.githubusercontent.com/37890870/53166506-735c4100-35fb-11e9-8bcf-431ee9f7ebdd.png)