### PR TITLE
fix: "See more" button disappear #1337

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -176,11 +176,13 @@ class EventDetailsFragment : Fragment() {
         if (!event.description.isNullOrEmpty()) {
             setTextField(rootView.eventDescription, event.description)
 
-            if (rootView.eventDescription.lineCount > LINE_COUNT) {
-                rootView.seeMore.visibility = View.VISIBLE
-                // start about fragment
-                rootView.eventDescription.setOnClickListener(aboutEventOnClickListener)
-                rootView.seeMore.setOnClickListener(aboutEventOnClickListener)
+            rootView.eventDescription.post {
+                if (rootView.eventDescription.lineCount > LINE_COUNT) {
+                    rootView.seeMore.visibility = View.VISIBLE
+                    // start about fragment
+                    rootView.eventDescription.setOnClickListener(aboutEventOnClickListener)
+                    rootView.seeMore.setOnClickListener(aboutEventOnClickListener)
+                }
             }
         } else {
             aboutEventContainer.visibility = View.GONE


### PR DESCRIPTION
Fixes #1137 

### Changes: 
When the EventDetailFragment comes back from AboutFragment, the text doesn't count the line because it has to render the text view first. So that's why "See more" button disappear, I changed it by using post method on the text view. It will start to check for lines of text to see whether to display "See more" or not only after rendering the text view

### Screenshots for the change:
<img src="https://i.ibb.co/CQDW7vW/video1550743521.gif" width="200"  />

### Notes
I made this change in the #1140 pull request but I screwed in branching and using Git so I close that pull request and make new one here. Sorry for the inconvienience, I'm still new and learning to make pull request properly