### PR TITLE
fix: After coming back from result detail, search result come back to the top, not current position #1150

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -75,6 +75,9 @@ class EventsFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
+        if (this::rootView.isInitialized) {
+            return rootView
+        }
         rootView = inflater.inflate(R.layout.fragment_events, container, false)
 
         if (preference.getString(SAVED_LOCATION).isNullOrEmpty()) {

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
@@ -39,6 +39,9 @@ class SearchResultsFragment : Fragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        if (this::rootView.isInitialized) {
+            return rootView
+        }
         rootView = inflater.inflate(R.layout.fragment_search_results, container, false)
 
         val thisActivity = activity

--- a/app/src/main/res/layout/fragment_events.xml
+++ b/app/src/main/res/layout/fragment_events.xml
@@ -103,7 +103,6 @@
                             android:scrollbars="vertical" />
                     </FrameLayout>
                 </LinearLayout>
-
                 <include layout="@layout/content_no_internet" />
             </LinearLayout>
         </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_events.xml
+++ b/app/src/main/res/layout/fragment_events.xml
@@ -103,6 +103,7 @@
                             android:scrollbars="vertical" />
                     </FrameLayout>
                 </LinearLayout>
+
                 <include layout="@layout/content_no_internet" />
             </LinearLayout>
         </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Fixes #1150 

Changes:
I checked if the view is already initialized. If it is, I reuse the view of search result, not reload the whole thing again. I also realized that the events fragment have the same problem so I make the same change

Screenshots for the change:
<img src="https://i.ibb.co/X2rZRHB/ezgif-1-6b74063aa1be.gif" width="200"  />