### PR TITLE
fix: After coming back from result detail, search result come back to the top, not current position #1150

### DIFF
--- a/app/src/main/res/layout/fragment_search_results.xml
+++ b/app/src/main/res/layout/fragment_search_results.xml
@@ -29,6 +29,7 @@
     </LinearLayout>
 
     <androidx.core.widget.NestedScrollView
+        android:id="@+id/searchResultsNestedScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"


### PR DESCRIPTION
Details: 
After coming from EventDetailsFragment, the SearchResultFragment doesn't retain the old position. Adding id for NestedScrollView will make Android automatically retain the current position

Fixes: #1150