### PR TITLE
fix: data loss on rotating EditProfileFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
@@ -38,7 +38,6 @@ import java.io.FileNotFoundException
 
 class EditProfileFragment : Fragment() {
 
-    private val profileViewModel by viewModel<ProfileViewModel>()
     private val editProfileViewModel by viewModel<EditProfileViewModel>()
     private lateinit var rootView: View
     private var permissionGranted = false
@@ -58,25 +57,19 @@ class EditProfileFragment : Fragment() {
     ): View? {
         rootView = inflater.inflate(R.layout.fragment_edit_profile, container, false)
 
-        profileViewModel.user
-            .nonNull()
-            .observe(this, Observer {
-                userFirstName = it.firstName.nullToEmpty()
-                userLastName = it.lastName.nullToEmpty()
-                val imageUrl = it.avatarUrl.nullToEmpty()
-                rootView.firstName.setText(userFirstName)
-                rootView.lastName.setText(userLastName)
-                if (!imageUrl.isEmpty()) {
-                    val drawable = requireDrawable(requireContext(), R.drawable.ic_account_circle_grey)
-                    Picasso.get()
-                        .load(imageUrl)
-                        .placeholder(drawable)
-                        .transform(CircleTransform())
-                        .into(rootView.profilePhoto)
-                }
-            })
-        profileViewModel.fetchProfile()
-
+        userFirstName = arguments?.getString(USER_FIRSTNAME_KEY).nullToEmpty()
+        userLastName = arguments?.getString(USER_LASTNAME_KEY).nullToEmpty()
+        val avatarUrl = arguments?.getString(USER_AVATAR_KEY).nullToEmpty()
+        rootView.firstName.setText(userFirstName)
+        rootView.lastName.setText(userLastName)
+        if (!avatarUrl.isEmpty()) {
+            val drawable = requireDrawable(requireContext(), R.drawable.ic_account_circle_grey)
+            Picasso.get()
+                .load(avatarUrl)
+                .placeholder(drawable)
+                .transform(CircleTransform())
+                .into(rootView.profilePhoto)
+        }
         editProfileViewModel.progress
             .nonNull()
             .observe(this, Observer {

--- a/app/src/main/java/org/fossasia/openevent/general/auth/ProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/ProfileFragment.kt
@@ -34,6 +34,10 @@ import org.fossasia.openevent.general.utils.extensions.nonNull
 import org.fossasia.openevent.general.utils.nullToEmpty
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
+const val USER_FIRSTNAME_KEY = "userFirstname"
+const val USER_LASTNAME_KEY = "userLastname"
+const val USER_AVATAR_KEY = "userAvatar"
+
 class ProfileFragment : Fragment() {
     private val profileViewModel by viewModel<ProfileViewModel>()
 
@@ -93,7 +97,11 @@ class ProfileFragment : Fragment() {
                         .into(rootView.avatar)
 
                 rootView.editProfileButton.setOnClickListener {
-                    findNavController(rootView).navigate(R.id.editProfileFragment, null, getAnimFade())
+                    val bundle = Bundle()
+                    bundle.putString(USER_FIRSTNAME_KEY, profileViewModel.user.value?.firstName.nullToEmpty())
+                    bundle.putString(USER_LASTNAME_KEY, profileViewModel.user.value?.lastName.nullToEmpty())
+                    bundle.putString(USER_AVATAR_KEY, profileViewModel.user.value?.avatarUrl.nullToEmpty())
+                    findNavController(rootView).navigate(R.id.editProfileFragment, bundle, getAnimFade())
                 }
             })
 


### PR DESCRIPTION
Details:
In here, I deleted the use of ProfileViewModel because it is only used to fetch the data in the beginning and set the edit text to original firstname/lastname. So whenever a user rotates the screen, a ViewModel is created again and fetch the data again -> editText follows those changes and keep resetting the text to the original firstname/lastname.

Instead, I initially pass the data from ProfileFragment so that we don't have to fetch the data from the server again. Text in the EditText is automatically retained now.

Fixes #1188 

Screenshots for the change:
<img src="https://i.ibb.co/26P02bt/52951165-2294655973887853-192684619584241664-n.png" width="200">
<img src="https://i.ibb.co/s1cn6QF/52977667-248493802766801-7365091489199685632-n.png" height="200">