### PR TITLE
fix: Hide no events available text when events are being loaded

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -61,6 +61,7 @@ class EventsFragment : Fragment() {
             .observe(this, Observer {
                 eventsRecyclerAdapter.addAll(it)
                 eventsRecyclerAdapter.notifyDataSetChanged()
+                showEmptyMessage(eventsRecyclerAdapter.itemCount)
                 Timber.d("Fetched events of size %s", eventsRecyclerAdapter.itemCount)
             })
 
@@ -117,7 +118,6 @@ class EventsFragment : Fragment() {
                 if (it) {
                     eventsRecyclerAdapter.removeAll()
                     eventsRecyclerAdapter.notifyDataSetChanged()
-                    showEmptyMessage(eventsRecyclerAdapter.itemCount)
                 }
             })
 

--- a/app/src/main/res/layout/fragment_events.xml
+++ b/app/src/main/res/layout/fragment_events.xml
@@ -93,7 +93,8 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/no_events_message"
-                            android:layout_gravity="center"/>
+                            android:layout_gravity="center"
+                            android:visibility="gone" />
                         <ProgressBar
                             android:id="@+id/progressBar"
                             android:layout_width="wrap_content"


### PR DESCRIPTION
Fixes #1192

Changes: 

Now, the message "Sorry, there are no events available" would not be displayed while events are being loaded.

Screenshots for the change:

![img_20190227_200701](https://user-images.githubusercontent.com/35566748/53497966-5b892f00-3acb-11e9-99a8-9ef4b493abfc.png)