### PR TITLE
feat: Add toggle feature to see more organizer detail in EventDetailsFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -40,6 +40,7 @@ import kotlinx.android.synthetic.main.content_event.view.nestedContentEventScrol
 import kotlinx.android.synthetic.main.content_event.view.organizerName
 import kotlinx.android.synthetic.main.content_event.view.refundPolicy
 import kotlinx.android.synthetic.main.content_event.view.seeMore
+import kotlinx.android.synthetic.main.content_event.view.seeMoreOrganizer
 import kotlinx.android.synthetic.main.fragment_event.view.eventCoordinatorLayout
 import kotlinx.android.synthetic.main.fragment_event.view.buttonTickets
 import org.fossasia.openevent.general.CircleTransform
@@ -69,6 +70,7 @@ class EventDetailsFragment : Fragment() {
     private lateinit var eventShare: Event
     private var currency: String? = null
     private val LINE_COUNT: Int = 3
+    private val LINE_COUNT_ORGANIZER: Int = 2
     private var menuActionBar: Menu? = null
     private var title: String = ""
     private var runOnce: Boolean = true
@@ -153,7 +155,7 @@ class EventDetailsFragment : Fragment() {
         // Organizer Section
         if (!event.organizerName.isNullOrEmpty()) {
             rootView.eventOrganiserName.text = "by " + event.organizerName.nullToEmpty()
-            setTextField(rootView.eventOrganiserDescription, event.organizerDescription?.stripHtml())
+            setTextField(rootView.eventOrganiserDescription, event.organizerDescription?.stripHtml()?.trim())
             rootView.organizerName.text = event.organizerName.nullToEmpty()
             rootView.eventOrganiserName.visibility = View.VISIBLE
             organizerContainer.visibility = View.VISIBLE
@@ -163,6 +165,26 @@ class EventDetailsFragment : Fragment() {
                     .placeholder(requireDrawable(requireContext(), R.drawable.ic_person_black))
                     .transform(CircleTransform())
                     .into(rootView.logoIcon)
+
+            val organizerDescriptionListener = View.OnClickListener {
+                if (rootView.seeMoreOrganizer.text == getString(R.string.see_more)) {
+                    rootView.seeMoreOrganizer.text = getString(R.string.see_less)
+                    rootView.eventOrganiserDescription.minLines = 0
+                    rootView.eventOrganiserDescription.maxLines = Int.MAX_VALUE
+                } else {
+                    rootView.seeMoreOrganizer.text = getString(R.string.see_more)
+                    rootView.eventOrganiserDescription.setLines(3)
+                }
+            }
+
+            rootView.eventOrganiserDescription.post {
+                if (rootView.eventOrganiserDescription.lineCount > LINE_COUNT_ORGANIZER) {
+                    rootView.seeMoreOrganizer.visibility = View.VISIBLE
+                    // Set up toggle organizer description
+                    rootView.seeMoreOrganizer.setOnClickListener(organizerDescriptionListener)
+                    rootView.eventOrganiserDescription.setOnClickListener(organizerDescriptionListener)
+                }
+            }
         }
 
         currency = Currency.getInstance(event.paymentCurrency).symbol

--- a/app/src/main/res/layout/content_event.xml
+++ b/app/src/main/res/layout/content_event.xml
@@ -346,6 +346,16 @@
                         android:lines="3"
                         android:textColor="@color/light_grey"
                         tools:text="Description" />
+
+                    <TextView
+                        android:id="@+id/seeMoreOrganizer"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/see_more"
+                        android:textColor="@color/dark_grey"
+                        android:lines="3"
+                        android:textStyle="bold"
+                        android:visibility="gone" />
                 </LinearLayout>
             </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="report_event">Report Event</string>
     <string name="about">About</string>
     <string name="see_more">See more</string>
+    <string name="see_less">See less</string>
     <string name="event_host_details">Event host details</string>
     <string name="organizer">Organizer</string>
     <string name="location">Location</string>


### PR DESCRIPTION
Detail: I check for the number of line in the details of the event organizer, and then decide whether to set the "See more" of eventOrganizerDescription visibility. I add a click listener to toggle the text view of eventOrganizerDescription to show more/less information

Fixes #1202 

Screenshots for the change:
<img src="https://i.imgur.com/djjMhed.png" width="200"/>
<img src="https://i.imgur.com/QV9uSrl.png" width="200"/>