### PR TITLE
refactor: Migrate EventDetailsFragment to use SafeArgs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -152,8 +152,8 @@ dependencies {
     implementation 'com.journeyapps:zxing-android-embedded:3.6.0'
 
     //Navigation
-    implementation 'android.arch.navigation:navigation-fragment:1.0.0-rc02'
-    implementation 'android.arch.navigation:navigation-ui:1.0.0-rc02'
+    implementation 'android.arch.navigation:navigation-fragment-ktx:1.0.0-rc02'
+    implementation 'android.arch.navigation:navigation-ui-ktx:1.0.0-rc02'
 
     testImplementation 'junit:junit:4.12'
     testImplementation "io.mockk:mockk:1.9.1"

--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
@@ -64,11 +64,11 @@ import kotlinx.android.synthetic.main.fragment_attendee.view.yearText
 import kotlinx.android.synthetic.main.fragment_attendee.view.acceptCheckbox
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.attendees.forms.CustomForm
+import org.fossasia.openevent.general.event.EVENT_ID
 import org.fossasia.openevent.general.event.Event
 import org.fossasia.openevent.general.event.EventId
 import org.fossasia.openevent.general.event.EventUtils
 import org.fossasia.openevent.general.order.Charge
-import org.fossasia.openevent.general.ticket.EVENT_ID
 import org.fossasia.openevent.general.ticket.TICKET_ID_AND_QTY
 import org.fossasia.openevent.general.ticket.TicketDetailsRecyclerAdapter
 import org.fossasia.openevent.general.ticket.TicketId
@@ -490,7 +490,7 @@ class AttendeeFragment : Fragment() {
         attendeeViewModel.paymentCompleted.value = false
         // Initialise Order Completed Fragment
         val bundle = Bundle()
-        bundle.putLong("EVENT_ID", id)
+        bundle.putLong(EVENT_ID, id)
         findNavController(rootView).navigate(R.id.orderCompletedFragment, bundle, getAnimFade())
     }
 

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -99,9 +99,13 @@ class EventsFragment : Fragment() {
 
         val recyclerViewClickListener = object : RecyclerViewClickListener {
             override fun onClick(eventID: Long) {
-                val bundle = Bundle()
-                bundle.putLong(EVENT_ID, eventID)
-                findNavController(rootView).navigate(R.id.eventDetailsFragment, bundle, getAnimFade())
+                EventDetailsFragmentArgs.Builder()
+                    .setEventId(eventID)
+                    .build()
+                    .toBundle()
+                    .also { bundle ->
+                        findNavController(rootView).navigate(R.id.eventDetailsFragment, bundle, getAnimFade())
+                    }
             }
         }
         eventsRecyclerAdapter.setListener(recyclerViewClickListener)

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrderCompletedFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrderCompletedFragment.kt
@@ -23,9 +23,9 @@ import kotlinx.android.synthetic.main.fragment_order.view.share
 import kotlinx.android.synthetic.main.fragment_order.view.time
 import kotlinx.android.synthetic.main.fragment_order.view.view
 import org.fossasia.openevent.general.R
+import org.fossasia.openevent.general.event.EVENT_ID
 import org.fossasia.openevent.general.event.Event
 import org.fossasia.openevent.general.event.EventUtils
-import org.fossasia.openevent.general.ticket.EVENT_ID
 import org.fossasia.openevent.general.utils.extensions.nonNull
 import org.fossasia.openevent.general.utils.stripHtml
 import org.koin.androidx.viewmodel.ext.android.viewModel

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsFragment.kt
@@ -16,7 +16,7 @@ import kotlinx.android.synthetic.main.fragment_order_details.view.orderDetailCoo
 import kotlinx.android.synthetic.main.fragment_order_details.view.orderDetailsRecycler
 import kotlinx.android.synthetic.main.fragment_order_details.view.progressBar
 import org.fossasia.openevent.general.R
-import org.fossasia.openevent.general.ticket.EVENT_ID
+import org.fossasia.openevent.general.event.EVENT_ID
 import org.fossasia.openevent.general.utils.Utils.getAnimFade
 import org.fossasia.openevent.general.utils.extensions.nonNull
 import org.koin.androidx.viewmodel.ext.android.viewModel

--- a/app/src/main/java/org/fossasia/openevent/general/social/SocialLinksFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/social/SocialLinksFragment.kt
@@ -16,6 +16,7 @@ import kotlinx.android.synthetic.main.fragment_social_links.socialLinksCoordinat
 import kotlinx.android.synthetic.main.fragment_social_links.view.progressBarSocial
 import kotlinx.android.synthetic.main.fragment_social_links.view.socialLinksRecycler
 import org.fossasia.openevent.general.R
+import org.fossasia.openevent.general.event.EVENT_ID
 import org.fossasia.openevent.general.utils.extensions.nonNull
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import timber.log.Timber
@@ -25,7 +26,6 @@ class SocialLinksFragment : Fragment() {
     private val socialLinksViewModel by viewModel<SocialLinksViewModel>()
     private lateinit var rootView: View
     private var id: Long = -1
-    private val EVENT_ID: String = "EVENT_ID"
     private lateinit var linearLayoutManager: LinearLayoutManager
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.navigation.Navigation.findNavController
+import androidx.navigation.fragment.navArgs
 import com.google.android.material.snackbar.Snackbar
 import org.fossasia.openevent.general.auth.SNACKBAR_MESSAGE
 import kotlinx.android.synthetic.main.fragment_tickets.ticketsCoordinatorLayout
@@ -27,6 +28,7 @@ import kotlinx.android.synthetic.main.fragment_tickets.view.ticketTableHeader
 import kotlinx.android.synthetic.main.fragment_tickets.view.ticketsRecycler
 import kotlinx.android.synthetic.main.fragment_tickets.view.time
 import org.fossasia.openevent.general.R
+import org.fossasia.openevent.general.event.EVENT_ID
 import org.fossasia.openevent.general.event.Event
 import org.fossasia.openevent.general.event.EventUtils
 import org.fossasia.openevent.general.utils.Utils.getAnimFade
@@ -35,27 +37,20 @@ import org.fossasia.openevent.general.utils.extensions.nonNull
 import org.fossasia.openevent.general.utils.nullToEmpty
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
-const val EVENT_ID: String = "EVENT_ID"
-const val CURRENCY: String = "CURRENCY"
+const val CURRENCY: String = "currency"
 const val TICKET_ID_AND_QTY: String = "TICKET_ID_AND_QTY"
 
 class TicketsFragment : Fragment() {
     private val ticketsRecyclerAdapter: TicketsRecyclerAdapter = TicketsRecyclerAdapter()
     private val ticketsViewModel by viewModel<TicketsViewModel>()
-    private var id: Long = -1
-    private var currency: String? = null
+    private val safeArgs: TicketsFragmentArgs by navArgs()
     private lateinit var rootView: View
     private lateinit var linearLayoutManager: LinearLayoutManager
     private var ticketIdAndQty = ArrayList<Pair<Int, Int>>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val bundle = this.arguments
-        if (bundle != null) {
-            id = bundle.getLong(EVENT_ID, -1)
-            currency = bundle.getString(CURRENCY, null)
-        }
-        ticketsRecyclerAdapter.setCurrency(currency)
+        ticketsRecyclerAdapter.setCurrency(safeArgs.currency)
 
         val ticketSelectedListener = object : TicketSelectedListener {
             override fun onSelected(ticketId: Int, quantity: Int) {
@@ -129,8 +124,8 @@ class TicketsFragment : Fragment() {
                 rootView.ticketInfoTextView.isGone = ticketTableVisible
             })
 
-        ticketsViewModel.loadEvent(id)
-        ticketsViewModel.loadTickets(id)
+        ticketsViewModel.loadEvent(safeArgs.eventId)
+        ticketsViewModel.loadTickets(safeArgs.eventId)
 
         return rootView
     }
@@ -146,7 +141,7 @@ class TicketsFragment : Fragment() {
 
     private fun redirectToAttendee() {
         val bundle = Bundle()
-        bundle.putLong(EVENT_ID, id)
+        bundle.putLong(EVENT_ID, safeArgs.eventId)
         bundle.putSerializable(TICKET_ID_AND_QTY, ticketIdAndQty)
         findNavController(rootView).navigate(R.id.attendeeFragment, bundle, getAnimSlide())
     }

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -77,7 +77,14 @@
         android:id="@+id/eventDetailsFragment"
         android:name="org.fossasia.openevent.general.event.EventDetailsFragment"
         android:label="EventDetailsFragment"
-        tools:layout="@layout/fragment_event" />
+        tools:layout="@layout/fragment_event">
+
+        <argument
+            android:name="eventId"
+            app:argType="long"
+            android:defaultValue="-1L"/>
+
+    </fragment>
     <fragment
         android:id="@+id/aboutEventFragment"
         android:name="org.fossasia.openevent.general.about.AboutEventFragment"
@@ -87,7 +94,19 @@
         android:id="@+id/ticketsFragment"
         android:name="org.fossasia.openevent.general.ticket.TicketsFragment"
         android:label="TicketsFragment"
-        tools:layout="@layout/fragment_tickets" />
+        tools:layout="@layout/fragment_tickets">
+
+        <argument
+            android:name="eventId"
+            app:argType="long"
+            android:defaultValue="-1L"/>
+
+        <argument
+            android:name="currency"
+            app:argType="string"
+            app:nullable="true"
+            android:defaultValue="@null"/>
+    </fragment>
     <fragment
         android:id="@+id/attendeeFragment"
         android:name="org.fossasia.openevent.general.attendees.AttendeeFragment"


### PR DESCRIPTION
Fixes #1198 

Changes: Migrates the EventDetailsFragment to use Safe args instead of working with raw bundles. Arguments have been added to the navigation graph XML file, along with a more idiomatic Kotlin approach to creating argument bundles for related fragments. The delegate function navArgs has been used to retrieve the arguments for this fragment 