### PR TITLE
fix: Refactor class name

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/di/Modules.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/di/Modules.kt
@@ -46,7 +46,7 @@ import org.fossasia.openevent.general.order.OrderApi
 import org.fossasia.openevent.general.order.OrderCompletedViewModel
 import org.fossasia.openevent.general.order.OrderDetailsViewModel
 import org.fossasia.openevent.general.order.OrderService
-import org.fossasia.openevent.general.order.OrdersUnderUserVM
+import org.fossasia.openevent.general.order.OrdersUnderUserViewModel
 import org.fossasia.openevent.general.paypal.Paypal
 import org.fossasia.openevent.general.paypal.PaypalApi
 import org.fossasia.openevent.general.search.GeoLocationViewModel
@@ -142,7 +142,7 @@ val viewModelModule = module {
     viewModel { SettingsViewModel(get()) }
     viewModel { SimilarEventsViewModel(get()) }
     viewModel { OrderCompletedViewModel(get()) }
-    viewModel { OrdersUnderUserVM(get(), get(), get()) }
+    viewModel { OrdersUnderUserViewModel(get(), get(), get()) }
     viewModel { OrderDetailsViewModel(get(), get()) }
     viewModel { EditProfileViewModel(get(), get()) }
     viewModel { GeoLocationViewModel(get()) }

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
@@ -32,7 +32,7 @@ const val ORDERS: String = "orders"
 class OrdersUnderUserFragment : Fragment() {
 
     private lateinit var rootView: View
-    private val ordersUnderUserVM by viewModel<OrdersUnderUserVM>()
+    private val ordersUnderUserVM by viewModel<OrdersUnderUserViewModel>()
     private val ordersRecyclerAdapter: OrdersRecyclerAdapter = OrdersRecyclerAdapter()
     private lateinit var linearLayoutManager: LinearLayoutManager
 

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserViewModel.kt
@@ -12,7 +12,7 @@ import org.fossasia.openevent.general.event.Event
 import org.fossasia.openevent.general.event.EventService
 import timber.log.Timber
 
-class OrdersUnderUserVM(
+class OrdersUnderUserViewModel(
     private val orderService: OrderService,
     private val eventService: EventService,
     private val authHolder: AuthHolder


### PR DESCRIPTION
Fixes #1217 
Changes: Refactored "OrdersUnderUserVM.kt" to "OrdersUnderUserViewModel.kt"
Now it makes perfect sense and easier to understand.