### PR TITLE
fix: Added title in toolbar of fragment_search_time

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchTimeFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchTimeFragment.kt
@@ -36,7 +36,7 @@ class SearchTimeFragment : Fragment() {
 
         val thisActivity = activity
         if (thisActivity is AppCompatActivity) {
-            thisActivity.supportActionBar?.title = ""
+            thisActivity.supportActionBar?.title = "Choose Time"
             thisActivity.supportActionBar?.setDisplayHomeAsUpEnabled(true)
         }
         setHasOptionsMenu(true)


### PR DESCRIPTION
Fixes #1219 
Changes: Added the title for toolbar.

Screenshots for the change:
Before:-
![whatsapp image 2019-03-04 at 7 17 33 am](https://user-images.githubusercontent.com/43093724/53706102-a51ca580-3e4e-11e9-80c5-606a409f69cf.jpeg)

After:-
![whatsapp image 2019-03-04 at 7 17 33 am 1](https://user-images.githubusercontent.com/43093724/53706109-ab128680-3e4e-11e9-9b14-96cec1b4a4a3.jpeg)
