### PR TITLE
feat: add stetho to app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -152,6 +152,11 @@ dependencies {
     implementation 'android.arch.navigation:navigation-fragment:1.0.0-beta02'
     implementation 'android.arch.navigation:navigation-ui:1.0.0-beta02'
 
+    //Stetho
+    debugImplementation 'com.facebook.stetho:stetho:1.3.1'
+    debugImplementation 'com.facebook.stetho:stetho-urlconnection:1.3.1'
+    debugImplementation 'com.facebook.stetho:stetho-okhttp3:1.5.0'
+
     testImplementation 'junit:junit:4.12'
     testImplementation "io.mockk:mockk:1.9.1"
     testImplementation 'org.threeten:threetenbp:1.3.8'

--- a/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.NavigationUI.setupWithNavController
+import com.facebook.stetho.Stetho
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.activity_main.navigation
 import kotlinx.android.synthetic.main.activity_main.navigationAuth
@@ -21,6 +22,7 @@ class MainActivity : AppCompatActivity() {
     private var currentFragmentId: Int = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        Stetho.initializeWithDefaults(this)
         setTheme(R.style.AppTheme)
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)


### PR DESCRIPTION
Fixes #1138

Changes: Integration of stetho, an Open Source debug library developed by the Facebook team. When enabled developers gain access to the Chrome Developers Tools, thus it is possible to have a rich, interactive debugging experience.

Screenshots for the change: No visible changes.
When Stetho is launched, an HTTP WebSockets server that sends all debugging information through a USB connection to the browser is opened. This information can be accessed through chrome://inspect