### PR TITLE
fix: Hide organizer name when empty

### DIFF
--- a/app/src/main/res/layout/content_event.xml
+++ b/app/src/main/res/layout/content_event.xml
@@ -50,7 +50,8 @@
             android:textStyle="bold"
             app:layout_constraintStart_toStartOf="@+id/eventName"
             app:layout_constraintTop_toBottomOf="@+id/eventName"
-            tools:text="by FOSSASIA" />
+            tools:text="by FOSSASIA"
+            android:visibility="gone" />
 
         <LinearLayout
             android:id="@+id/eventTimingLinearLayout"


### PR DESCRIPTION
Fixes #1243 

Changes: 

Changed default visibility of organizer name to 'gone'. When the organizer name exists, then it would be handled:

https://github.com/fossasia/open-event-android/blob/a5d757ede19037c5bbf419f6f8806454935591de/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt#L157