### PR TITLE
fix: edit text retention in EditProfileFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
@@ -64,8 +64,12 @@ class EditProfileFragment : Fragment() {
                 userFirstName = it.firstName.nullToEmpty()
                 userLastName = it.lastName.nullToEmpty()
                 val imageUrl = it.avatarUrl.nullToEmpty()
-                rootView.firstName.setText(userFirstName)
-                rootView.lastName.setText(userLastName)
+                if (rootView.firstName.text.isBlank()) {
+                    rootView.firstName.setText(userFirstName)
+                }
+                if (rootView.lastName.text.isBlank()) {
+                    rootView.lastName.setText(userLastName)
+                }
                 if (!imageUrl.isEmpty()) {
                     val drawable = requireDrawable(requireContext(), R.drawable.ic_account_circle_grey)
                     Picasso.get()


### PR DESCRIPTION
Details:
I checked if the EditText already contains text -> if it is then it shouldn't reset the text when rotating

Fixes #652 

Screenshots for the change:
<img src="https://i.ibb.co/NjdY88z/ezgif-1-3751bc4ad94a.gif" alt="ezgif-1-3751bc4ad94a" width="200">