### PR TITLE
fix: fully display number of tickets TextView

### DIFF
--- a/app/src/main/res/layout/item_card_order.xml
+++ b/app/src/main/res/layout/item_card_order.xml
@@ -84,7 +84,6 @@
                 android:maxLines="1"
                 android:ellipsize="end"
                 android:textColor="@color/colorPrimary"
-                android:layout_marginBottom="@dimen/layout_margin_large"
                 tools:text="See 5 tickets" />
 
         </LinearLayout>


### PR DESCRIPTION
Details:
Remove unnecessary margin_bottom

Fixes #1261 

Screenshots for the change:
<img src="https://i.ibb.co/cxZjvWn/54432628-441459593060949-9183872579843129344-n.png" alt="54432628-441459593060949-9183872579843129344-n" border="0">