### PR TITLE
fix: Selected image get rotate in edit profile (#1270)

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/RotateBitmap.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/RotateBitmap.kt
@@ -1,0 +1,114 @@
+package org.fossasia.openevent.general
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import android.net.Uri
+import androidx.exifinterface.media.ExifInterface
+import java.io.IOException
+
+/**
+ * Handle the image rotation
+ */
+
+class RotateBitmap {
+
+    private var context: Context? = null
+
+    /**
+     * This method is responsible for solving the rotation issue if exist. Also scale the images to
+     * 1024x1024 resolution
+     *
+     * @param selectedImage The Image URI
+     * @return Bitmap image results
+     * @throws IOException
+     */
+    @Throws(IOException::class)
+    fun handleSamplingAndRotationBitmap(context: Context, selectedImage: Uri): Bitmap? {
+        this.context = context
+        val MAX_HEIGHT = 1024
+        val MAX_WIDTH = 1024
+
+        // First decode with inJustDecodeBounds=true to check dimensions
+        val options = BitmapFactory.Options()
+        options.inJustDecodeBounds = true
+        var imageStream = context.contentResolver.openInputStream(selectedImage)
+        BitmapFactory.decodeStream(imageStream, null, options)
+        imageStream?.close()
+
+        // Calculate inSampleSize
+        options.inSampleSize = calculateInSampleSize(options, MAX_WIDTH, MAX_HEIGHT)
+
+        // Decode bitmap with inSampleSize set
+        options.inJustDecodeBounds = false
+        imageStream = context.contentResolver.openInputStream(selectedImage)
+        var img = BitmapFactory.decodeStream(imageStream, null, options)
+
+        img = rotateImageIfRequired(img, selectedImage)
+        return img
+    }
+
+    @Throws(IOException::class)
+    private fun rotateImageIfRequired(img: Bitmap?, selectedImage: Uri): Bitmap? {
+
+        val input = context?.contentResolver?.openInputStream(selectedImage)
+        val ei = input?.let { ExifInterface(it) }
+        val orientation = ei?.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+        return when (orientation) {
+            ExifInterface.ORIENTATION_ROTATE_90 -> rotateImage(img, 90)
+            ExifInterface.ORIENTATION_ROTATE_180 -> rotateImage(img, 180)
+            ExifInterface.ORIENTATION_ROTATE_270 -> rotateImage(img, 270)
+            else -> img
+        }
+    }
+
+    companion object {
+
+        private fun rotateImage(img: Bitmap?, degree: Int): Bitmap? {
+            val matrix = Matrix()
+            matrix.postRotate(degree.toFloat())
+            val rotatedImg = img?.let { Bitmap.createBitmap(it, 0, 0, img.width, img.height, matrix, true) }
+            img?.recycle()
+            return rotatedImg
+        }
+
+        private fun calculateInSampleSize(
+            options: BitmapFactory.Options,
+            reqWidth: Int,
+            reqHeight: Int
+        ): Int {
+            // Raw height and width of image
+            val height = options.outHeight
+            val width = options.outWidth
+            var inSampleSize = 1
+
+            if (height > reqHeight || width > reqWidth) {
+
+                // Calculate ratios of height and width to requested height and width
+                val heightRatio = Math.round(height.toFloat() / reqHeight.toFloat())
+                val widthRatio = Math.round(width.toFloat() / reqWidth.toFloat())
+
+                // Choose the smallest ratio as inSampleSize value, this will guarantee a final image
+                // with both dimensions larger than or equal to the requested height and width.
+                inSampleSize = if (heightRatio < widthRatio) heightRatio else widthRatio
+
+                // This offers some additional logic in case the image has a strange
+                // aspect ratio. For example, a panorama may have a much larger
+                // width than height. In these cases the total pixels might still
+                // end up being too large to fit comfortably in memory, so we should
+                // be more aggressive with sample down the image (=larger inSampleSize).
+
+                val totalPixels = (width * height).toFloat()
+
+                // Anything more than 2x the requested pixels we'll sample down further
+                val totalReqPixelsCap = (reqWidth * reqHeight * 2).toFloat()
+
+                while (totalPixels / (inSampleSize * inSampleSize) > totalReqPixelsCap) {
+                    inSampleSize++
+                }
+            }
+            return inSampleSize
+        }
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileViewModel.kt
@@ -10,6 +10,7 @@ import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.common.SingleLiveEvent
 import org.fossasia.openevent.general.data.Resource
 import timber.log.Timber
+import java.io.File
 
 class EditProfileViewModel(
     private val authService: AuthService,
@@ -25,10 +26,17 @@ class EditProfileViewModel(
     val user: LiveData<User> = mutableUser
     private val mutableMessage = SingleLiveEvent<String>()
     val message: LiveData<String> = mutableMessage
+    private var updatedImageTemp = MutableLiveData<File>()
+    var avatarUpdated = false
+    var encodedImage: String? = null
 
     fun isLoggedIn() = authService.isLoggedIn()
 
-    fun updateProfile(encodedImage: String?, firstName: String, lastName: String) {
+    /**
+     *  @param firstName updated firstName
+     *  @param lastName updated lastName
+     */
+    fun updateProfile(firstName: String, lastName: String) {
         if (encodedImage.isNullOrEmpty()) {
             updateUser(null, firstName, lastName)
             return
@@ -51,7 +59,7 @@ class EditProfileViewModel(
             }
     }
 
-    fun updateUser(url: String?, firstName: String, lastName: String) {
+    private fun updateUser(url: String?, firstName: String, lastName: String) {
         val id = authHolder.getId()
         if (firstName.isEmpty() || lastName.isEmpty()) {
             mutableMessage.value = resource.getString(R.string.provide_name_message)
@@ -79,6 +87,14 @@ class EditProfileViewModel(
                 mutableMessage.value = resource.getString(R.string.user_update_error_message)
                 Timber.e(it, "Error updating user!")
             }
+    }
+
+    fun setUpdatedTempFile(file: File) {
+        updatedImageTemp.value = file
+    }
+
+    fun getUpdatedTempFile(): MutableLiveData<File> {
+        return updatedImageTemp
     }
 
     override fun onCleared() {

--- a/app/src/main/java/org/fossasia/openevent/general/auth/ProfileViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/ProfileViewModel.kt
@@ -21,7 +21,6 @@ class ProfileViewModel(private val authService: AuthService, private val resourc
     val user: LiveData<User> = mutableUser
     private val mutableError = SingleLiveEvent<String>()
     val error: LiveData<String> = mutableError
-    val avatarPicked = MutableLiveData<String>()
 
     fun isLoggedIn() = authService.isLoggedIn()
 


### PR DESCRIPTION
Fixes #1270 

Changes: 
Created RotateBitmap.kt file to prevent image from rotation
In EditProfileViewModel, created avatarUpdated, encodedImage, updatedImageTemp variable to retain the image.

Screenshots for the change:
![Screenshot_20190311-160521_Eventyay Attendee](https://user-images.githubusercontent.com/24875315/54117856-c0bc1900-4417-11e9-852f-367f47d8ae3b.jpg)
