### PR TITLE
fix: stop reloading old image when rotating on EditProfileFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.net.Uri
 import android.os.Bundle
 import android.util.Base64
 import android.view.LayoutInflater
@@ -71,7 +72,7 @@ class EditProfileFragment : Fragment() {
                 if (rootView.lastName.text.isBlank()) {
                     rootView.lastName.setText(userLastName)
                 }
-                if (!imageUrl.isEmpty()) {
+                if (!imageUrl.isEmpty() && !avatarUpdated) {
                     val drawable = requireDrawable(requireContext(), R.drawable.ic_account_circle_grey)
                     Picasso.get()
                         .load(imageUrl)
@@ -80,6 +81,16 @@ class EditProfileFragment : Fragment() {
                         .into(rootView.profilePhoto)
                 }
             })
+        profileViewModel.avatarPicked.observe(this, Observer {
+            if (it != null) {
+                Picasso.get()
+                    .load(Uri.parse(it))
+                    .placeholder(requireDrawable(requireContext(), R.drawable.ic_account_circle_grey))
+                    .transform(CircleTransform())
+                    .into(rootView.profilePhoto)
+                this.avatarUpdated = true
+            }
+        })
         profileViewModel.fetchProfile()
 
         editProfileViewModel.progress
@@ -136,6 +147,7 @@ class EditProfileFragment : Fragment() {
                 .transform(CircleTransform())
                 .into(rootView.profilePhoto)
             avatarUpdated = true
+            profileViewModel.avatarPicked.value = imageUri.toString()
         }
     }
 

--- a/app/src/main/java/org/fossasia/openevent/general/auth/ProfileViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/ProfileViewModel.kt
@@ -19,6 +19,7 @@ class ProfileViewModel(private val authService: AuthService) : ViewModel() {
     val user: LiveData<User> = mutableUser
     private val mutableError = SingleLiveEvent<String>()
     val error: LiveData<String> = mutableError
+    var avatarPicked = MutableLiveData<String>()
 
     fun isLoggedIn() = authService.isLoggedIn()
 

--- a/app/src/main/java/org/fossasia/openevent/general/auth/ProfileViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/ProfileViewModel.kt
@@ -19,7 +19,7 @@ class ProfileViewModel(private val authService: AuthService) : ViewModel() {
     val user: LiveData<User> = mutableUser
     private val mutableError = SingleLiveEvent<String>()
     val error: LiveData<String> = mutableError
-    var avatarPicked = MutableLiveData<String>()
+    val avatarPicked = MutableLiveData<String>()
 
     fun isLoggedIn() = authService.isLoggedIn()
 


### PR DESCRIPTION
Details:
When the screen is rotated, if a new image is chosen, the URI of that image is saved on onSaveInstanceState and then reload when the view is created after rotating

Fixes #1016 (The part where EditText is not retained in 1016 issue is already resolved in other PR and merged)

Screenshots for the change:
<img src="https://i.ibb.co/HnstcNf/ezgif-1-8760744c06f9.gif" width="300">