### PR TITLE
fix: App Crash on LoginFragment (double tap)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,6 +87,7 @@ dependencies {
     def roomVersion = '2.1.0-alpha04'
     def ktx_version = "1.0.0"
     def ktx2_version = "2.0.0"
+    def nav_version = "2.0.0"
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.multidex:multidex:2.0.1'
@@ -152,8 +153,9 @@ dependencies {
     implementation 'com.journeyapps:zxing-android-embedded:3.6.0'
 
     //Navigation
-    implementation 'android.arch.navigation:navigation-fragment-ktx:1.0.0-rc02'
-    implementation 'android.arch.navigation:navigation-ui-ktx:1.0.0-rc02'
+    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version" // For Kotlin use
+    // navigation-fragment-ktx
+    implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
     testImplementation 'junit:junit:4.12'
     testImplementation "io.mockk:mockk:1.9.2"

--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
@@ -211,8 +211,9 @@ class LoginFragment : Fragment() {
     }
 
     private fun showSnackbar() {
-        safeArgs.snackbarMessage?.let { textSnackbar ->
-            Snackbar.make(rootView.loginCoordinatorLayout, textSnackbar, Snackbar.LENGTH_SHORT).show()
+        val snackMessage = safeArgs.snackbarMessage
+        if (snackMessage != "not-set") {
+            Snackbar.make(rootView.loginCoordinatorLayout, snackMessage, Snackbar.LENGTH_SHORT).show()
         }
     }
 }

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -208,8 +208,8 @@
         <argument
             android:name="snackbarMessage"
             app:argType="string"
-            app:nullable="true"
-            android:defaultValue="@null"/>
+            app:nullable="false"
+            android:defaultValue="not-set"/>
     </fragment>
     <fragment
         android:id="@+id/signUpFragment"


### PR DESCRIPTION
Fixes #1242 

Changes: 
Made the default snackbar message non null. Which was the reason 

Screenshots for the change:
<img src="https://user-images.githubusercontent.com/24780524/54229767-01f11d80-452b-11e9-954e-1c94cdffecd8.gif" width=360>
