### PR TITLE
 feat: display snackbar with undo action on removing liked event

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
@@ -133,9 +133,15 @@ class FavoriteFragment : Fragment() {
 
         val favFabClickListener: FavoriteFabClickListener = object : FavoriteFabClickListener {
             override fun onClick(event: Event, itemPosition: Int) {
-                favoriteEventViewModel.setFavorite(event.id, !event.favorite)
-                event.favorite = !event.favorite
+                favoriteEventViewModel.setFavorite(event.id, false)
                 favoriteEventsRecyclerAdapter.notifyItemChanged(itemPosition)
+
+                Snackbar.make(favoriteCoordinatorLayout,
+                    getString(R.string.removed_from_liked, event.name), Snackbar.LENGTH_SHORT)
+                    .setAction(getString(R.string.undo)) {
+                        favoriteEventViewModel.setFavorite(event.id, true)
+                        favoriteEventsRecyclerAdapter.notifyItemChanged(itemPosition)
+                    }.show()
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,7 +51,7 @@
     <string name="settings">Settings</string>
     <string name="login">Login</string>
     <string name="forgot_password">I forgot my password</string>
-    <string name="email_sent_message">We just send you an email with a link to reset\nyour password </string>
+    <string name="email_sent_message">We just sent you an email with a link to reset\nyour password </string>
     <string name="email_sent_alert">Check your email!</string>
     <string name="sign_up">Sign Up</string>
     <string name="email_id" translatable="false">example@gmail.com</string>
@@ -103,7 +103,7 @@
     <string name="subtotal">Subtotal</string>
     <string name="view">(view)</string>
     <string name="hide">(hide)</string>
-    <string name="no_tickets_message">Invalid Quantity. Please enter a quantity of 1 and more</string>
+    <string name="no_tickets_message">Invalid Quantity. Please enter a quantity of 1 or more</string>
     <string name="whoops">Whoops!</string>
     <string name="ok">ok</string>
     <string name="view_ticket">View</string>
@@ -198,6 +198,8 @@
     <string name="sign_in_canceled">Sign In canceled!</string>
     <string name="sign_up_success">Sign Up Success!</string>
     <string name="cannot_fetch_location">Cannot fetch location!</string>
+    <string name="removed_from_liked">Removed %1$s from liked events</string>
+    <string name="undo">Undo</string>
 
     <!--welcome fragment-->
     <string name="start_text_1">Where \ndo you \ngo out?</string>


### PR DESCRIPTION
fixes Issue #1282 by displaying a snackbar message when a liked event is removed.
    The snackbar also has an Undo option which undos the remove operation and the event is displayed again in the RecyclerView

Changes: 
Display snackbar message that liked event has been removed
The snackbar has an undo action button which can undo the remove operation

Also fixed 2 grammatical errors in strings.xml

Screenshots for the change:


![ezgif com-video-to-gif](https://user-images.githubusercontent.com/22665789/54865190-b1c65680-4d87-11e9-99ba-200a53016385.gif)
