### PR TITLE
fix: Retain ticket details' visibility after screen rotation

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
@@ -306,14 +306,15 @@ class AttendeeFragment : Fragment() {
             })
 
         rootView.view.setOnClickListener {
-            if (rootView.view.text == "(view)") {
-                rootView.ticketDetails.visibility = View.VISIBLE
-                rootView.view.text = "(hide)"
-            } else {
-                rootView.ticketDetails.visibility = View.GONE
-                rootView.view.text = "(view)"
-            }
+            attendeeViewModel.updateTicketDetailsVisibility()
         }
+
+        attendeeViewModel.ticketDetailsVisibility
+            .nonNull()
+            .observe(this, Observer {
+                rootView.view.text = if (it) getString(R.string.hide) else getString(R.string.view)
+                rootView.ticketDetails.visibility = if (it) View.VISIBLE else View.GONE
+            })
 
         attendeeViewModel.message
             .nonNull()

--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
@@ -306,7 +306,12 @@ class AttendeeFragment : Fragment() {
             })
 
         rootView.view.setOnClickListener {
-            attendeeViewModel.updateTicketDetailsVisibility()
+            val currentVisibility: Boolean? = attendeeViewModel.ticketDetailsVisibility.value
+            if (currentVisibility == null) {
+                attendeeViewModel.ticketDetailsVisibility.value = false
+            } else {
+                attendeeViewModel.ticketDetailsVisibility.value = !currentVisibility
+            }
         }
 
         attendeeViewModel.ticketDetailsVisibility

--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeViewModel.kt
@@ -57,6 +57,7 @@ class AttendeeViewModel(
     private val mutableQtyList = MutableLiveData<ArrayList<Int>>()
     val qtyList: LiveData<ArrayList<Int>> = mutableQtyList
     val paymentCompleted = MutableLiveData<Boolean>()
+    val ticketDetailsVisibility = MutableLiveData<Boolean>()
     private val mutableTickets = MutableLiveData<MutableList<Ticket>>()
     val tickets: LiveData<MutableList<Ticket>> = mutableTickets
     private val mutableForms = MutableLiveData<List<CustomForm>>()
@@ -141,6 +142,14 @@ class AttendeeViewModel(
                 Timber.e(it, "Error Loading tickets!")
             })
         )
+    }
+
+    fun updateTicketDetailsVisibility() {
+        if (ticketDetailsVisibility.value == null) {
+            ticketDetailsVisibility.value = false
+        } else {
+            ticketDetailsVisibility.value = !ticketDetailsVisibility.value!!
+        }
     }
 
     fun ticketDetails(ticketIdAndQty: List<Pair<Int, Int>>?) {

--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeViewModel.kt
@@ -144,14 +144,6 @@ class AttendeeViewModel(
         )
     }
 
-    fun updateTicketDetailsVisibility() {
-        if (ticketDetailsVisibility.value == null) {
-            ticketDetailsVisibility.value = false
-        } else {
-            ticketDetailsVisibility.value = !ticketDetailsVisibility.value!!
-        }
-    }
-
     fun ticketDetails(ticketIdAndQty: List<Pair<Int, Int>>?) {
         val ticketIds = ArrayList<Int>()
         ticketIdAndQty?.forEach {

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -152,4 +152,5 @@
     <string name="invalid_confirm_password_message">Mật khẩu xác nhận lần hai không trùng với lần đầu!</string>
     <string name="timeZone_title">Sử dụng múi giờ của sự kiện.</string>
     <string name="timeZone_summary">Múi giờ của bạn sẽ được sử dụng khi khóa lại.</string>
+    <string name="hide">(giấu)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,7 @@
     <string name="item">Item</string>
     <string name="subtotal">Subtotal</string>
     <string name="view">(view)</string>
+    <string name="hide">(hide)</string>
     <string name="no_tickets_message">Invalid Quantity. Please enter a quantity of 1 and more</string>
     <string name="whoops">Whoops!</string>
     <string name="ok">ok</string>


### PR DESCRIPTION
Details:
Ticket Details Visibility is subscribed to the View Model as a boolean so that it survives after screen rotation

Fixes #1286 

Screenshots for the change:
<img src="https://i.ibb.co/nMsHCCK/ezgif-1-eb3e22aec921.gif" width="300">