### PR TITLE
feat: Add remove favorite event animation

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteEventsRecyclerAdapter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteEventsRecyclerAdapter.kt
@@ -31,6 +31,10 @@ class FavoriteEventsRecyclerAdapter : RecyclerView.Adapter<EventViewHolder>() {
         this.events.addAll(eventList)
     }
 
+    fun remove(position: Int) {
+        events.removeAt(position)
+    }
+
     fun getPos(id: Long): Int {
         return events.map { it.id }.indexOf(id)
     }

--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
@@ -34,6 +34,7 @@ class FavoriteFragment : Fragment() {
     private val favoriteEventsRecyclerAdapter: FavoriteEventsRecyclerAdapter = FavoriteEventsRecyclerAdapter()
     private val favoriteEventViewModel by viewModel<FavoriteEventsViewModel>()
     private lateinit var rootView: View
+    private var favoriteListFetched: Boolean = false
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -79,10 +80,10 @@ class FavoriteFragment : Fragment() {
         }
         val favoriteFabClickListener = object : FavoriteFabListener {
             override fun onClick(event: Event, isFavorite: Boolean) {
-                val id = favoriteEventsRecyclerAdapter.getPos(event.id)
-                favoriteEventViewModel.setFavorite(event.id, !isFavorite)
-                event.favorite = !event.favorite
-                favoriteEventsRecyclerAdapter.notifyItemChanged(id)
+                val pos = favoriteEventsRecyclerAdapter.getPos(event.id)
+                favoriteEventsRecyclerAdapter.remove(pos)
+                favoriteEventsRecyclerAdapter.notifyItemRemoved(pos)
+                favoriteEventViewModel.setFavorite(event.id, false)
                 showEmptyMessage(favoriteEventsRecyclerAdapter.itemCount)
             }
         }
@@ -92,11 +93,14 @@ class FavoriteFragment : Fragment() {
         favoriteEventViewModel.events
             .nonNull()
             .observe(this, Observer {
-                favoriteEventsRecyclerAdapter.addAll(it)
-                favoriteEventsRecyclerAdapter.notifyDataSetChanged()
-                showEmptyMessage(favoriteEventsRecyclerAdapter.itemCount)
+                if (!favoriteListFetched) {
+                    favoriteListFetched = true
+                    favoriteEventsRecyclerAdapter.addAll(it)
+                    favoriteEventsRecyclerAdapter.notifyDataSetChanged()
+                    showEmptyMessage(favoriteEventsRecyclerAdapter.itemCount)
 
-                Timber.d("Fetched events of size %s", favoriteEventsRecyclerAdapter.itemCount)
+                    Timber.d("Fetched events of size %s", favoriteEventsRecyclerAdapter.itemCount)
+                }
             })
 
         favoriteEventViewModel.error

--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
@@ -34,7 +34,7 @@ class FavoriteFragment : Fragment() {
     private val favoriteEventsRecyclerAdapter: FavoriteEventsRecyclerAdapter = FavoriteEventsRecyclerAdapter()
     private val favoriteEventViewModel by viewModel<FavoriteEventsViewModel>()
     private lateinit var rootView: View
-    private var favoriteListFetched: Boolean = false
+    private var favoriteListFetched = false
 
     override fun onCreateView(
         inflater: LayoutInflater,


### PR DESCRIPTION
Details:
There is a problem in the FavoriteFragment: The way it updates the favorite event list is wrong. Basically, when an event is clicked on the favorite icon, it is not removed from the adapter events' list. But as we call `favoriteEventViewModel.setFavorite(event.id, false)`, it is removed by the viewModel. And then the viewModel.events change so it notifies the code below inside FavoriteFragment:
```
favoriteEventViewModel.events
            .nonNull()
            .observe(this, Observer {
                favoriteEventsRecyclerAdapter.addAll(it)
                favoriteEventsRecyclerAdapter.notifyDataSetChanged()
                showEmptyMessage(favoriteEventsRecyclerAdapter.itemCount)

                Timber.d("Fetched events of size %s", favoriteEventsRecyclerAdapter.itemCount)
            })
```
As the result, the whole event list is fetched again.

I fixed this by making sure the viewModel only fetch the list once, remove the favorite event properly from the adapter and use notifyItemRemoved(), not notifyItemChanged() to make the animations.



Fixes #1285 

Screenshots for the change:
<img src="https://i.ibb.co/tZyWYpL/ezgif-1-2a7c16263b09.gif" width="300">