### PR TITLE
fix: Stop reloading events after rotating screen

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -36,6 +36,8 @@ import timber.log.Timber
 const val EVENTS: String = "events"
 const val SIMILAR_EVENTS: String = "similarEvents"
 const val EVENT_DATE_FORMAT: String = "eventDateFormat"
+const val RELOADING_EVENTS: Int = 0
+const val INITIAL_FETCHING_EVENTS: Int = 1
 
 class EventsFragment : Fragment() {
     private val eventsRecyclerAdapter: EventsRecyclerAdapter = EventsRecyclerAdapter()
@@ -133,7 +135,7 @@ class EventsFragment : Fragment() {
 
         eventsViewModel.loadLocation()
         rootView.locationTextView.text = eventsViewModel.savedLocation
-        eventsViewModel.loadLocationEvents()
+        eventsViewModel.loadLocationEvents(INITIAL_FETCHING_EVENTS)
 
         rootView.locationTextView.setOnClickListener {
             findNavController(rootView).navigate(R.id.searchLocationFragment, null, getAnimSlide())
@@ -144,7 +146,7 @@ class EventsFragment : Fragment() {
         rootView.retry.setOnClickListener {
             val isNetworkConnected = isNetworkConnected(context)
             if (eventsViewModel.savedLocation != null && isNetworkConnected) {
-                eventsViewModel.loadLocationEvents()
+                eventsViewModel.loadLocationEvents(RELOADING_EVENTS)
             }
             showNoInternetScreen(isNetworkConnected)
         }
@@ -155,7 +157,7 @@ class EventsFragment : Fragment() {
             if (!isNetworkConnected(context)) {
                 rootView.swiperefresh.isRefreshing = false
             } else {
-                eventsViewModel.loadLocationEvents()
+                eventsViewModel.loadLocationEvents(RELOADING_EVENTS)
             }
         }
 

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
@@ -31,25 +31,27 @@ class EventsViewModel(private val eventService: EventService, private val prefer
         savedLocation = preference.getString(SAVED_LOCATION)
     }
 
-    fun loadLocationEvents() {
+    fun loadLocationEvents(loadingTag: Int) {
         val query = "[{\"name\":\"location-name\",\"op\":\"ilike\",\"val\":\"%$savedLocation%\"}]"
 
-        compositeDisposable.add(eventService.getEventsByLocation(query)
-            .subscribeOn(Schedulers.io())
-            .observeOn(AndroidSchedulers.mainThread())
-            .doOnSubscribe {
-                mutableShowShimmerEvents.value = true
-            }
-            .doFinally {
-                mutableProgress.value = false
-                mutableShowShimmerEvents.value = false
-            }.subscribe({
-                mutableEvents.value = it
-            }, {
-                Timber.e(it, "Error fetching events")
-                mutableError.value = "Error fetching events"
-            })
-        )
+        if (loadingTag == RELOADING_EVENTS || (loadingTag == INITIAL_FETCHING_EVENTS && mutableEvents.value == null)) {
+            compositeDisposable.add(eventService.getEventsByLocation(query)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .doOnSubscribe {
+                    mutableShowShimmerEvents.value = true
+                }
+                .doFinally {
+                    mutableProgress.value = false
+                    mutableShowShimmerEvents.value = false
+                }.subscribe({
+                    mutableEvents.value = it
+                }, {
+                    Timber.e(it, "Error fetching events")
+                    mutableError.value = "Error fetching events"
+                })
+            )
+        }
     }
 
     fun loadEvents() {


### PR DESCRIPTION
Details:
I add tags on loading events (RELOADING OR INITIAL LOADING). The events' list is only loaded again if the tag is RELOADING or INITIAL LOADING + the event list is not loaded before.

Fixes #1295 

Screenshots for the change:
<img src="https://i.imgur.com/QaocC0E.gif" width="250">