### PR TITLE
fix: display storage permission snackbar only once in EditProfileFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
@@ -14,6 +14,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
@@ -86,6 +87,9 @@ class EditProfileFragment : Fragment() {
             .observe(this, Observer {
                 rootView.progressBar.isVisible = it
             })
+
+        permissionGranted = (ContextCompat.checkSelfPermission(requireContext(),
+            Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED)
 
         rootView.profilePhoto.setOnClickListener {
             if (permissionGranted) {


### PR DESCRIPTION
 Fixes Issue #1304. The snackbar for permission to access external storage is now shown only once after granting the permission and not any time after that while changing profile photo. This has been done by checking the permission status beforehand

Changes: 
`permissionGranted = (ContextCompat.checkSelfPermission(requireContext(),
            Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED)
`

The variable permissionGranted has been initialized to the status of the permission rather than checking it at the time of clicking the profile picture and subsequently displaying the permission snackbar.

Screenshots for the change:
![pr new](https://user-images.githubusercontent.com/22665789/54341273-7cbb5500-465f-11e9-80ca-ffd11db1cf06.gif)
