### PR TITLE
fix: Empty organizer section in Ticket Details (#1308)

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsViewHolder.kt
@@ -16,6 +16,7 @@ import kotlinx.android.synthetic.main.item_card_order_details.view.name
 import kotlinx.android.synthetic.main.item_card_order_details.view.orderIdentifier
 import kotlinx.android.synthetic.main.item_card_order_details.view.organizer
 import kotlinx.android.synthetic.main.item_card_order_details.view.qrCodeView
+import kotlinx.android.synthetic.main.item_card_order_details.view.organizerLabel
 import org.fossasia.openevent.general.attendees.Attendee
 import org.fossasia.openevent.general.event.Event
 import org.fossasia.openevent.general.event.EventUtils
@@ -41,8 +42,12 @@ class OrderDetailsViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
             itemView.location.text = event.locationName
             itemView.date.text = "$formattedDate\n$formattedTime $timezone"
             itemView.eventSummary.text = event.description?.stripHtml()
-            itemView.organizer.text = event.organizerName
 
+            if (event.organizerName.isNullOrEmpty()) {
+                itemView.organizerLabel.visibility = View.GONE
+            } else {
+                itemView.organizer.text = event.organizerName
+            }
             itemView.map.setOnClickListener {
                 val mapUrl = loadMapUrl(event)
                 val mapIntent = Intent(Intent.ACTION_VIEW, Uri.parse(mapUrl))

--- a/app/src/main/res/layout-land/item_card_order_details.xml
+++ b/app/src/main/res/layout-land/item_card_order_details.xml
@@ -203,6 +203,7 @@
                     android:layout_margin="@dimen/layout_margin_medium"
                     android:scaleType="centerCrop" />
                 <TextView
+                    android:id="@+id/organizerLabel"
                     android:paddingTop="@dimen/padding_medium"
                     android:layout_gravity="center"
                     android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_card_order_details.xml
+++ b/app/src/main/res/layout/item_card_order_details.xml
@@ -179,6 +179,7 @@
                 tools:text="@string/event_details" />
 
             <TextView
+                android:id="@+id/organizerLabel"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/organizer"


### PR DESCRIPTION
Fixes #1308 

Changes: hide organizer label when there is no information about the organizer

Screenshots for the change:
![WhatsApp Image 2019-03-14 at 11 52 43 PM(1)](https://user-images.githubusercontent.com/24875315/54382274-adc67480-46b5-11e9-8403-193755fdc465.jpeg)
![WhatsApp Image 2019-03-14 at 11 52 43 PM](https://user-images.githubusercontent.com/24875315/54382276-adc67480-46b5-11e9-97e2-58c34224c2f0.jpeg)

