### PR TITLE
feat: Share event details along with image

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,5 +27,14 @@
         <meta-data
             android:name="com.stripe.android.API_KEY"
             android:value="${STRIPE_API_TOKEN}"/>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_provider"/>
+        </provider>
     </application>
 </manifest>

--- a/app/src/main/java/org/fossasia/openevent/general/common/RecyclerViewCallbacks.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/common/RecyclerViewCallbacks.kt
@@ -26,15 +26,3 @@ interface FavoriteFabClickListener {
      */
     fun onClick(event: Event, itemPosition: Int)
 }
-
-/**
- * The callback interface for Share FAB clicks
- */
-interface ShareFabClickListener {
-    /**
-     * The function to be invoked when the fab is clicked
-     *
-     * @param event The event object for which the fab was clicked
-     */
-    fun onClick(event: Event)
-}

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -18,6 +18,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.Navigation.findNavController
 import androidx.navigation.fragment.navArgs
+import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
 import kotlinx.android.synthetic.main.content_event.aboutEventContainer
 import kotlinx.android.synthetic.main.content_event.locationContainer
@@ -63,6 +64,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 import timber.log.Timber
 import java.util.Currency
 import org.fossasia.openevent.general.utils.Utils.setToolbar
+import java.lang.Exception
 
 const val EVENT_ID = "eventId"
 const val EVENT_TOPIC_ID = "eventTopicId"
@@ -264,9 +266,17 @@ class EventDetailsFragment : Fragment() {
         // Set Cover Image
         event.originalImageUrl?.let {
             Picasso.get()
-                    .load(it)
-                    .placeholder(R.drawable.header)
-                    .into(rootView.eventImage)
+                .load(it)
+                .placeholder(R.drawable.header)
+                .into(rootView.eventImage, object : Callback {
+                    override fun onSuccess() {
+                        rootView.eventImage.tag = "image_loading_successful"
+                    }
+
+                    override fun onError(e: Exception?) {
+                        Timber.e(e)
+                    }
+                })
         }
 
         // Add event to Calendar
@@ -298,12 +308,8 @@ class EventDetailsFragment : Fragment() {
                 true
             }
             R.id.event_share -> {
-                val sendIntent = Intent()
-                sendIntent.action = Intent.ACTION_SEND
-                sendIntent.putExtra(Intent.EXTRA_TEXT, EventUtils.getSharableInfo(eventShare))
-                sendIntent.type = "text/plain"
-                rootView.context.startActivity(Intent.createChooser(sendIntent, "Share Event Details"))
-                true
+                EventUtils.share(eventShare, rootView.eventImage)
+                return true
             }
             else -> super.onOptionsItemSelected(item)
         }
@@ -414,5 +420,10 @@ class EventDetailsFragment : Fragment() {
         for (i in 0..(menuItemSize - 1)) {
             menuActionBar?.getItem(i)?.isVisible = !show
         }
+    }
+
+    override fun onDestroy() {
+        Picasso.get().cancelRequest(rootView.eventImage)
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventViewHolder.kt
@@ -2,6 +2,7 @@ package org.fossasia.openevent.general.event
 
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
+import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
 import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.item_card_events.view.date
@@ -14,9 +15,9 @@ import kotlinx.android.synthetic.main.item_card_events.view.shareFab
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.common.EventClickListener
 import org.fossasia.openevent.general.common.FavoriteFabClickListener
-import org.fossasia.openevent.general.common.ShareFabClickListener
 import org.fossasia.openevent.general.favorite.FAVORITE_EVENT_DATE_FORMAT
 import timber.log.Timber
+import java.lang.Exception
 
 /**
  * The [RecyclerView.ViewHolder] class for Event items list in [EventsFragment]
@@ -31,8 +32,6 @@ class EventViewHolder(override val containerView: View) : RecyclerView.ViewHolde
 
     var eventClickListener: EventClickListener? = null
     var favFabClickListener: FavoriteFabClickListener? = null
-    var shareFabClickListener: ShareFabClickListener? = null
-
     /**
      * The function to bind the given data on the items in this recycler view.
      *
@@ -43,7 +42,6 @@ class EventViewHolder(override val containerView: View) : RecyclerView.ViewHolde
         event: Event,
         dateFormat: String
     ) {
-        containerView.eventImage.setImageResource(R.drawable.header)
         containerView.eventName.text = event.name
         containerView.locationName.text = event.locationName
 
@@ -63,7 +61,15 @@ class EventViewHolder(override val containerView: View) : RecyclerView.ViewHolde
             Picasso.get()
                 .load(url)
                 .placeholder(R.drawable.header)
-                .into(containerView.eventImage)
+                .into(containerView.eventImage, object : Callback {
+                    override fun onSuccess() {
+                        containerView.eventImage.tag = "image_loading_success"
+                    }
+
+                    override fun onError(e: Exception?) {
+                        Timber.e(e)
+                    }
+                })
         }
 
         containerView.setOnClickListener {
@@ -72,8 +78,7 @@ class EventViewHolder(override val containerView: View) : RecyclerView.ViewHolde
         }
 
         containerView.shareFab.setOnClickListener {
-            shareFabClickListener?.onClick(event)
-                ?: Timber.e("Share Fab Click listener on ${this::class.java.canonicalName} is null")
+            EventUtils.share(event, itemView.eventImage)
         }
 
         containerView.favoriteFab.setOnClickListener {

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -1,6 +1,5 @@
 package org.fossasia.openevent.general.event
 
-import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -27,7 +26,6 @@ import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.ScrollToTop
 import org.fossasia.openevent.general.common.EventClickListener
 import org.fossasia.openevent.general.common.FavoriteFabClickListener
-import org.fossasia.openevent.general.common.ShareFabClickListener
 import org.fossasia.openevent.general.data.Preference
 import org.fossasia.openevent.general.di.Scopes
 import org.fossasia.openevent.general.search.SAVED_LOCATION
@@ -165,18 +163,6 @@ class EventsFragment : Fragment(), ScrollToTop {
             }
         }
 
-        val shareFabClickListener: ShareFabClickListener = object : ShareFabClickListener {
-            override fun onClick(event: Event) {
-                Intent().apply {
-                    action = Intent.ACTION_SEND
-                    type = "text/plain"
-                    putExtra(Intent.EXTRA_TEXT, EventUtils.getSharableInfo(event))
-                }.also { intent ->
-                    startActivity(Intent.createChooser(intent, "Share Event Details"))
-                }
-            }
-        }
-
         val favFabClickListener: FavoriteFabClickListener = object : FavoriteFabClickListener {
             override fun onClick(event: Event, itemPosition: Int) {
                 eventsViewModel.setFavorite(event.id, !event.favorite)
@@ -187,7 +173,6 @@ class EventsFragment : Fragment(), ScrollToTop {
 
         eventsListAdapter.apply {
             onEventClick = eventClickListener
-            onShareFabClick = shareFabClickListener
             onFavFabClick = favFabClickListener
         }
     }

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsListAdapter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsListAdapter.kt
@@ -10,7 +10,6 @@ import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.common.EventClickListener
 import org.fossasia.openevent.general.common.EventsDiffCallback
 import org.fossasia.openevent.general.common.FavoriteFabClickListener
-import org.fossasia.openevent.general.common.ShareFabClickListener
 
 /**
  * The RecyclerView adapter class for displaying lists of Events.
@@ -28,7 +27,6 @@ class EventsListAdapter(
 
     var onEventClick: EventClickListener? = null
     var onFavFabClick: FavoriteFabClickListener? = null
-    var onShareFabClick: ShareFabClickListener? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): EventViewHolder {
         val eventView = when (eventLayout) {
@@ -49,7 +47,6 @@ class EventsListAdapter(
         holder.apply {
             bind(event, EVENT_DATE_FORMAT)
             eventClickListener = onEventClick
-            shareFabClickListener = onShareFabClick
             favFabClickListener = onFavFabClick
         }
     }

--- a/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsFragment.kt
@@ -1,6 +1,5 @@
 package org.fossasia.openevent.general.event.topic
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -23,10 +22,8 @@ import org.fossasia.openevent.general.di.Scopes
 import org.fossasia.openevent.general.event.Event
 import org.fossasia.openevent.general.common.EventClickListener
 import org.fossasia.openevent.general.event.EventDetailsFragmentArgs
-import org.fossasia.openevent.general.event.EventUtils
 import org.fossasia.openevent.general.event.EventsListAdapter
 import org.fossasia.openevent.general.common.FavoriteFabClickListener
-import org.fossasia.openevent.general.common.ShareFabClickListener
 import org.fossasia.openevent.general.event.EventLayoutType
 import org.fossasia.openevent.general.utils.Utils.getAnimSlide
 import org.fossasia.openevent.general.utils.extensions.nonNull
@@ -113,18 +110,6 @@ class SimilarEventsFragment : Fragment() {
             }
         }
 
-        val shareFabClickListener: ShareFabClickListener = object : ShareFabClickListener {
-            override fun onClick(event: Event) {
-                Intent().apply {
-                    action = Intent.ACTION_SEND
-                    type = "text/plain"
-                    putExtra(Intent.EXTRA_TEXT, EventUtils.getSharableInfo(event))
-                }.also { intent ->
-                    startActivity(Intent.createChooser(intent, "Share Event Details"))
-                }
-            }
-        }
-
         val favFabClickListener: FavoriteFabClickListener = object : FavoriteFabClickListener {
             override fun onClick(event: Event, itemPosition: Int) {
                 similarEventsViewModel.setFavorite(event.id, !event.favorite)
@@ -135,7 +120,6 @@ class SimilarEventsFragment : Fragment() {
 
         similarEventsListAdapter.apply {
             onEventClick = eventClickListener
-            onShareFabClick = shareFabClickListener
             onFavFabClick = favFabClickListener
         }
 

--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteEventsRecyclerAdapter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteEventsRecyclerAdapter.kt
@@ -14,7 +14,6 @@ import org.fossasia.openevent.general.common.EventClickListener
 import org.fossasia.openevent.general.event.EventViewHolder
 import org.fossasia.openevent.general.common.EventsDiffCallback
 import org.fossasia.openevent.general.common.FavoriteFabClickListener
-import org.fossasia.openevent.general.common.ShareFabClickListener
 
 /**
  * The RecyclerView adapter class for displaying favorite events list
@@ -30,7 +29,6 @@ class FavoriteEventsRecyclerAdapter(
 
     var onEventClick: EventClickListener? = null
     var onFavFabClick: FavoriteFabClickListener? = null
-    var onShareFabClick: ShareFabClickListener? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): EventViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.item_card_favorite_event, parent, false)
@@ -48,7 +46,6 @@ class FavoriteEventsRecyclerAdapter(
             bind(event, FAVORITE_EVENT_DATE_FORMAT)
             eventClickListener = onEventClick
             favFabClickListener = onFavFabClick
-            shareFabClickListener = onShareFabClick
         }
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
@@ -1,6 +1,5 @@
 package org.fossasia.openevent.general.favorite
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -26,9 +25,7 @@ import org.fossasia.openevent.general.di.Scopes
 import org.fossasia.openevent.general.event.Event
 import org.fossasia.openevent.general.common.EventClickListener
 import org.fossasia.openevent.general.event.EventDetailsFragmentArgs
-import org.fossasia.openevent.general.event.EventUtils
 import org.fossasia.openevent.general.common.FavoriteFabClickListener
-import org.fossasia.openevent.general.common.ShareFabClickListener
 import org.fossasia.openevent.general.data.Preference
 import org.fossasia.openevent.general.search.SAVED_LOCATION
 import org.fossasia.openevent.general.search.SearchResultsFragmentArgs
@@ -130,18 +127,6 @@ class FavoriteFragment : Fragment() {
             }
         }
 
-        val shareFabClickListener: ShareFabClickListener = object : ShareFabClickListener {
-            override fun onClick(event: Event) {
-                Intent().apply {
-                    action = Intent.ACTION_SEND
-                    type = "text/plain"
-                    putExtra(Intent.EXTRA_TEXT, EventUtils.getSharableInfo(event))
-                }.also { intent ->
-                    startActivity(Intent.createChooser(intent, "Share Event Details"))
-                }
-            }
-        }
-
         val favFabClickListener: FavoriteFabClickListener = object : FavoriteFabClickListener {
             override fun onClick(event: Event, itemPosition: Int) {
                 favoriteEventViewModel.setFavorite(event.id, false)
@@ -158,7 +143,6 @@ class FavoriteFragment : Fragment() {
 
         favoriteEventsRecyclerAdapter.apply {
             onEventClick = eventClickListener
-            onShareFabClick = shareFabClickListener
             onFavFabClick = favFabClickListener
         }
     }

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
@@ -1,6 +1,5 @@
 package org.fossasia.openevent.general.search
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.MenuItem
@@ -30,9 +29,7 @@ import org.fossasia.openevent.general.di.Scopes
 import org.fossasia.openevent.general.event.Event
 import org.fossasia.openevent.general.common.EventClickListener
 import org.fossasia.openevent.general.event.EventDetailsFragmentArgs
-import org.fossasia.openevent.general.event.EventUtils
 import org.fossasia.openevent.general.common.FavoriteFabClickListener
-import org.fossasia.openevent.general.common.ShareFabClickListener
 import org.fossasia.openevent.general.favorite.FavoriteEventsRecyclerAdapter
 import org.fossasia.openevent.general.utils.Utils.getAnimFade
 import org.fossasia.openevent.general.utils.extensions.nonNull
@@ -150,18 +147,6 @@ class SearchResultsFragment : Fragment() {
             }
         }
 
-        val shareFabClickListener: ShareFabClickListener = object : ShareFabClickListener {
-            override fun onClick(event: Event) {
-                Intent().apply {
-                    action = Intent.ACTION_SEND
-                    type = "text/plain"
-                    putExtra(Intent.EXTRA_TEXT, EventUtils.getSharableInfo(event))
-                }.also { intent ->
-                    startActivity(Intent.createChooser(intent, "Share Event Details"))
-                }
-            }
-        }
-
         val favFabClickListener: FavoriteFabClickListener = object : FavoriteFabClickListener {
             override fun onClick(event: Event, itemPosition: Int) {
                 searchViewModel.setFavorite(event.id, !event.favorite)
@@ -172,7 +157,6 @@ class SearchResultsFragment : Fragment() {
 
         favoriteEventsRecyclerAdapter.apply {
             onEventClick = eventClickListener
-            onShareFabClick = shareFabClickListener
             onFavFabClick = favFabClickListener
         }
     }

--- a/app/src/main/res/xml/file_provider.xml
+++ b/app/src/main/res/xml/file_provider.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path
+        name="share_image"
+        path="." />
+</paths>


### PR DESCRIPTION
Fixes: #1315 

Changes:
Share event details along with event image
Added file_provider.xml to use cache event image URI  to work with API 24+

Screenshot
![WhatsApp Image 2019-03-16 at 12 58 18 AM](https://user-images.githubusercontent.com/24875315/54459201-f4869e00-478b-11e9-8c83-b30f2d6b3e93.jpeg)

PS: I used placeholder image as event image for a testing purpose.
