### PR TITLE
chore: revert requested string changes

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,7 +102,7 @@
     <string name="item">Item</string>
     <string name="subtotal">Subtotal</string>
     <string name="view">(view)</string>
-    <string name="hide" translatable="false">(hide)</string>
+    <string name="hide">(hide)</string>
     <string name="no_tickets_message">Invalid Quantity. Please enter a quantity of 1 and more</string>
     <string name="whoops">Whoops!</string>
     <string name="ok">ok</string>
@@ -114,9 +114,9 @@
     <string name="card_number">Card Number</string>
     <string name="card_type">Card Type</string>
     <string name="expiration_date">Expiration Date</string>
-    <string name="cvc" translatable="false">CVC</string>
-    <string name="postal_code" translatable="false">Postal Code</string>
-    <string name="payment_info" translatable="false">Payment Info</string>
+    <string name="cvc">CVC</string>
+    <string name="postal_code">Postal Code</string>
+    <string name="payment_info">Payment Info</string>
     <string name="not_you">Not you? </string>
     <string name="sign_out">Sign out</string>
     <string name="all_fees">All fees included in price</string>
@@ -130,11 +130,11 @@
     <string name="date">Date</string>
     <string name="order_identifier">Order Identifier</string>
     <string name="event_summary">Event Summary</string>
-    <string name="organizer_preview" translatable="false">Mario</string>
+    <string name="organizer_preview">Mario</string>
     <string name="event_summary_preview">Very nice</string>
     <string name="order_identifier_preview" translatable="false">3456789</string>
     <string name="location_preview" translatable="false">Singapore</string>
-    <string name="date_preview" translatable="false">Thu,June 14</string>
+    <string name="date_preview">Thu,June 14</string>
     <string name="event_preview" translatable="false">FOSSASIA summit</string>
     <string name="name_preview" translatable="false">Nikit Bhandari</string>
 
@@ -161,7 +161,7 @@
     <string name="timeZone_summary">Your timezone is used when disabled.</string>
     <string name="privacy">Privacy</string>
     <string name="key_privacy">privacy</string>
-    <string name="cookie_policy" translatable="false">Cookie Policy</string>
+    <string name="cookie_policy">Cookie Policy</string>
     <string name="key_cookie_policy" translatable="false">cookie_policy</string>
     <string name="title_terms_of_service">Terms of Service</string>
     <string name="key_terms_of_service" translatable="false">terms_of_service</string>
@@ -186,7 +186,7 @@
     <string name="privacy_text">privacy policy</string>
     <string name="privacy_policy" translatable="false">https://eventyay.com/privacy-policy/</string>
     <string name="terms_of_service" translatable="false">https://eventyay.com/terms/</string>
-    <string name="stripe" translatable="false">Stripe</string>
+    <string name="stripe">Stripe</string>
     <string name="paypal" translatable="false">PayPal</string>
     <string name="country">Country</string>
 


### PR DESCRIPTION
Fixes #1329 

Changes: 
PR #1324 was merged as it was a required PR but it had some additional unwanted changes which were made so that the Travis build passes. This PR aims to revert these changes and check the status of Travis build

Removed the `translatable = "false"` property from strings 

