### PR TITLE
fix: refresh events on location change

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -133,9 +133,12 @@ class EventsFragment : Fragment() {
                 rootView.swiperefresh.isRefreshing = it
             })
 
-        eventsViewModel.loadLocation()
+        if (eventsViewModel.loadLocation()) {
+            eventsViewModel.loadLocationEvents(RELOADING_EVENTS)
+        } else {
+            eventsViewModel.loadLocationEvents(INITIAL_FETCHING_EVENTS)
+        }
         rootView.locationTextView.text = eventsViewModel.savedLocation
-        eventsViewModel.loadLocationEvents(INITIAL_FETCHING_EVENTS)
 
         rootView.locationTextView.setOnClickListener {
             findNavController(rootView).navigate(R.id.searchLocationFragment, null, getAnimSlide())

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
@@ -27,8 +27,15 @@ class EventsViewModel(private val eventService: EventService, private val prefer
 
     var savedLocation: String? = null
 
-    fun loadLocation() {
-        savedLocation = preference.getString(SAVED_LOCATION)
+    /**
+     * Returns true if the location has changed from before
+     */
+    fun loadLocation(): Boolean {
+        val newLocation = preference.getString(SAVED_LOCATION)
+
+        if (newLocation == savedLocation) return false
+        savedLocation = newLocation
+        return true
     }
 
     fun loadLocationEvents(loadingTag: Int) {


### PR DESCRIPTION
 Fixes #1331 

Changes: 
- In the EventsViewModel, the method that updates the savedLocation has been modified to now return a Boolean value: true if the location has changed, false otherwise. 

- This boolean is used in onCreateView() method(which is called on returning from SearchLocationFragment). If the location has changed, then the events are reloaded. Otherwise the initial fetch is made. 

- Note that if there is no change in location then this initial fetch is not repeated due to following if statement in the EventsViewModel (mutableEvents.value is not null)
`if (loadingTag == RELOADING_EVENTS || (loadingTag == INITIAL_FETCHING_EVENTS && mutableEvents.value == null)) `
       
Screenshots for the change:
![PR 1332](https://user-images.githubusercontent.com/22665789/54492730-03399600-48ef-11e9-9ff6-a8c50acdad94.gif)
