### PR TITLE
feat: improve no internet layout for SearchResultsFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
@@ -16,7 +16,8 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.fragment_search_results.view.searchRootLayout
 import kotlinx.android.synthetic.main.fragment_search_results.view.eventsRecycler
 import kotlinx.android.synthetic.main.fragment_search_results.view.shimmerSearch
-import kotlinx.android.synthetic.main.fragment_search_results.view.errorTextView
+import kotlinx.android.synthetic.main.content_no_internet.view.retry
+import kotlinx.android.synthetic.main.content_no_internet.view.noInternetCard
 import kotlinx.android.synthetic.main.fragment_search_results.view.noSearchResults
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.event.Event
@@ -109,7 +110,7 @@ class SearchResultsFragment : Fragment() {
                 Snackbar.make(rootView.searchRootLayout, it, Snackbar.LENGTH_LONG).show()
             })
 
-        rootView.errorTextView.setOnClickListener {
+        rootView.retry.setOnClickListener {
             performSearch(safeArgs)
         }
 
@@ -129,7 +130,7 @@ class SearchResultsFragment : Fragment() {
     }
 
     private fun showNoInternetError(show: Boolean) {
-        rootView.errorTextView.visibility = if (show) View.VISIBLE else View.GONE
+        rootView.noInternetCard.visibility = if (show) View.VISIBLE else View.GONE
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/res/layout/fragment_search_results.xml
+++ b/app/src/main/res/layout/fragment_search_results.xml
@@ -62,17 +62,7 @@
                 </LinearLayout>
             </com.facebook.shimmer.ShimmerFrameLayout>
 
-            <TextView
-                android:id="@+id/errorTextView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/layout_margin_extreme_large"
-                android:gravity="center_horizontal"
-                android:text="@string/error_message"
-                android:textColor="@color/black"
-                android:textSize="@dimen/text_size_large"
-                android:textStyle="bold"
-                android:visibility="gone" />
+            <include layout="@layout/content_no_internet" />
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/eventsRecycler"


### PR DESCRIPTION
Fixes #1339 

Changes:
The no internet layout used in EventsFragment has now been added to the SearchResultsFragment also making the UI more consistent. This new layout replaces the previously used TextView

Screenshots for the change:

![PR 1340](https://user-images.githubusercontent.com/22665789/54552922-2dff1980-49d7-11e9-8bc3-f38b59af3e15.gif)
