### PR TITLE
fix: making search in EventsFragment works again

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
@@ -24,7 +24,7 @@ class EventsViewModel(private val eventService: EventService, private val prefer
     val error: LiveData<String> = mutableError
     private val mutableShowShimmerEvents = MutableLiveData<Boolean>()
     val showShimmerEvents: LiveData<Boolean> = mutableShowShimmerEvents
-    private var lastSearch = String()
+    private var lastSearch = ""
 
     var savedLocation: String? = null
 

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
@@ -24,6 +24,7 @@ class EventsViewModel(private val eventService: EventService, private val prefer
     val error: LiveData<String> = mutableError
     private val mutableShowShimmerEvents = MutableLiveData<Boolean>()
     val showShimmerEvents: LiveData<Boolean> = mutableShowShimmerEvents
+    private var lastSearch = String()
 
     var savedLocation: String? = null
 
@@ -34,7 +35,8 @@ class EventsViewModel(private val eventService: EventService, private val prefer
     fun loadLocationEvents(loadingTag: Int) {
         val query = "[{\"name\":\"location-name\",\"op\":\"ilike\",\"val\":\"%$savedLocation%\"}]"
 
-        if (loadingTag == RELOADING_EVENTS || (loadingTag == INITIAL_FETCHING_EVENTS && mutableEvents.value == null)) {
+        if (loadingTag == RELOADING_EVENTS || (loadingTag == INITIAL_FETCHING_EVENTS &&
+                lastSearch != savedLocation)) {
             compositeDisposable.add(eventService.getEventsByLocation(query)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
@@ -44,6 +46,7 @@ class EventsViewModel(private val eventService: EventService, private val prefer
                 .doFinally {
                     mutableProgress.value = false
                     mutableShowShimmerEvents.value = false
+                    lastSearch = savedLocation ?: ""
                 }.subscribe({
                     mutableEvents.value = it
                 }, {


### PR DESCRIPTION
**Details:**
Add a String to store the last search so that if a new search come, it reloads events again
Fixes #1349

**Screenshots for the change:**
Search works again, doesn't need to swipe down to reload
<img src="https://i.ibb.co/q9MtRyp/ezgif-2-91c657b2ee36.gif" width="300">
When rotating screen, the events are still retained
<img src="https://i.ibb.co/YTb9Js8/ezgif-2-b46b336324e6.gif" width="300">