### PR TITLE
fix: Retain search results after rotating screens

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchViewModel.kt
@@ -44,6 +44,11 @@ class SearchViewModel(
     }
 
     fun loadEvents(location: String, time: String) {
+        if (mutableEvents.value != null) {
+            mutableShowShimmerResults.value = false
+            mutableShowNoInternetError.value = false
+            return
+        }
         if (!isConnected()) return
         preference.putString(SAVED_LOCATION, location)
         val query: String = when {


### PR DESCRIPTION
Details:
If there are already search results, they are reused, and the search query is not called again in the view model

Fixes #1347

Screenshots for the change:
<img src="https://i.ibb.co/cy6v2Bh/ezgif-2-c48baeb1c6e2.gif" width="300">