### PR TITLE
refactor: Migrate project to use viewLifecycleOwner in fragments to observe livedata wherever it makes sense 

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/about/AboutEventFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/about/AboutEventFragment.kt
@@ -34,16 +34,6 @@ class AboutEventFragment : Fragment(), AppBarLayout.OnOffsetChangedListener {
     private var title: String = ""
     private val safeArgs: AboutEventFragmentArgs by navArgs()
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        aboutEventViewModel.event
-            .nonNull()
-            .observe(this, Observer {
-                loadEvent(it)
-            })
-    }
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         rootView = layoutInflater.inflate(R.layout.fragment_about_event, container, false)
 
@@ -54,17 +44,23 @@ class AboutEventFragment : Fragment(), AppBarLayout.OnOffsetChangedListener {
         }
         setHasOptionsMenu(true)
 
+        aboutEventViewModel.event
+            .nonNull()
+            .observe(viewLifecycleOwner, Observer {
+                loadEvent(it)
+            })
+
         rootView.appBar.addOnOffsetChangedListener(this)
 
         aboutEventViewModel.error
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 Snackbar.make(rootView, it, Snackbar.LENGTH_SHORT).show()
             })
 
         aboutEventViewModel.progressAboutEvent
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 rootView.progressBarAbout.isVisible = it
             })
 

--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
@@ -193,7 +193,7 @@ class AttendeeFragment : Fragment() {
         paymentOptions.add(getString(R.string.stripe))
         attendeeViewModel.paymentSelectorVisibility
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 if (it) {
                     rootView.paymentSelector.visibility = View.VISIBLE
                 } else {
@@ -314,7 +314,7 @@ class AttendeeFragment : Fragment() {
         }
         attendeeViewModel.qtyList
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 ticketsRecyclerAdapter.setQty(it)
             })
 
@@ -329,40 +329,40 @@ class AttendeeFragment : Fragment() {
 
         attendeeViewModel.ticketDetailsVisibility
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 rootView.view.text = if (it) getString(R.string.hide) else getString(R.string.view)
                 rootView.ticketDetails.visibility = if (it) View.VISIBLE else View.GONE
             })
 
         attendeeViewModel.message
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 Snackbar.make(rootView, it, Snackbar.LENGTH_LONG).show()
             })
 
         attendeeViewModel.progress
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 rootView.progressBarAttendee.isVisible = it
                 rootView.register.isEnabled = !it
             })
 
         attendeeViewModel.event
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 loadEventDetails(it)
             })
 
         attendeeViewModel.totalAmount
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 amount = it
             })
 
         attendeeRecyclerAdapter.eventId = eventId
         attendeeViewModel.tickets
             .nonNull()
-            .observe(this, Observer { tickets ->
+            .observe(viewLifecycleOwner, Observer { tickets ->
                 ticketsRecyclerAdapter.addAll(tickets)
                 ticketsRecyclerAdapter.notifyDataSetChanged()
                 if (!singleTicket)
@@ -377,13 +377,13 @@ class AttendeeFragment : Fragment() {
 
         attendeeViewModel.totalQty
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 rootView.qty.text = " — $it items"
             })
 
         attendeeViewModel.countryVisibility
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 if (singleTicket) {
                     rootView.countryPickerContainer.visibility = if (it) View.VISIBLE else View.GONE
                 }
@@ -391,7 +391,7 @@ class AttendeeFragment : Fragment() {
 
         attendeeViewModel.paymentCompleted
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 if (it)
                     openOrderCompletedFragment()
             })
@@ -401,7 +401,7 @@ class AttendeeFragment : Fragment() {
 
         attendeeViewModel.attendee
             .nonNull()
-            .observe(this, Observer { user ->
+            .observe(viewLifecycleOwner, Observer { user ->
                 helloUser.text = "Hello ${user.firstName.nullToEmpty()}"
                 firstName.text = Editable.Factory.getInstance().newEditable(user.firstName.nullToEmpty())
                 lastName.text = Editable.Factory.getInstance().newEditable(user.lastName.nullToEmpty())
@@ -422,7 +422,7 @@ class AttendeeFragment : Fragment() {
 
         attendeeViewModel.forms
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 if (singleTicket)
                     fillInformationSection(it)
                 attendeeRecyclerAdapter.setCustomForm(it)
@@ -465,7 +465,7 @@ class AttendeeFragment : Fragment() {
                 val country = rootView.countryPicker.selectedItem.toString()
                 attendeeViewModel.createAttendees(attendees, country, paymentOptions[selectedPaymentOption])
 
-                attendeeViewModel.isAttendeeCreated.observe(this, Observer { isAttendeeCreated ->
+                attendeeViewModel.isAttendeeCreated.observe(viewLifecycleOwner, Observer { isAttendeeCreated ->
                     if (isAttendeeCreated && selectedPaymentOption ==
                         paymentOptions.indexOf(getString(R.string.stripe))) {
                         sendToken()
@@ -476,7 +476,7 @@ class AttendeeFragment : Fragment() {
 
         attendeeViewModel.ticketSoldOut
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 showTicketSoldOutDialog(it)
             })
 

--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
@@ -62,7 +62,7 @@ class EditProfileFragment : Fragment() {
 
         profileViewModel.user
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 userFirstName = it.firstName.nullToEmpty()
                 userLastName = it.lastName.nullToEmpty()
                 val imageUrl = it.avatarUrl.nullToEmpty()
@@ -95,7 +95,7 @@ class EditProfileFragment : Fragment() {
 
         editProfileViewModel.progress
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 rootView.progressBar.isVisible = it
             })
 
@@ -118,7 +118,7 @@ class EditProfileFragment : Fragment() {
 
         editProfileViewModel.message
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 Snackbar.make(rootView.editProfileCoordinatorLayout, it, Snackbar.LENGTH_LONG).show()
                 if (it == USER_UPDATED) {
                     activity?.onBackPressed()

--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
@@ -71,43 +71,43 @@ class LoginFragment : Fragment() {
 
         smartAuthViewModel.id
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 email.text = SpannableStringBuilder(it)
             })
 
         smartAuthViewModel.password
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 password.text = SpannableStringBuilder(it)
             })
 
         loginViewModel.progress
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 progressDialog.show(it)
             })
 
         smartAuthViewModel.progress
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 progressDialog.show(it)
             })
 
         loginViewModel.showNoInternetDialog
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 Utils.showNoInternetDialog(context)
             })
 
         loginViewModel.error
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 Snackbar.make(rootView.loginCoordinatorLayout, it, Snackbar.LENGTH_LONG).show()
             })
 
         loginViewModel.loggedIn
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 loginViewModel.fetchProfile()
             })
 
@@ -133,7 +133,7 @@ class LoginFragment : Fragment() {
 
         loginViewModel.requestTokenSuccess
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 if (it) {
                     rootView.sentEmailLayout.visibility = View.VISIBLE
                     rootView.loginLayout.visibility = View.GONE
@@ -151,13 +151,13 @@ class LoginFragment : Fragment() {
 
         loginViewModel.isCorrectEmail
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 onEmailEntered(it)
             })
 
         loginViewModel.areFieldsCorrect
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 loginButton.isEnabled = it
             })
 
@@ -177,7 +177,7 @@ class LoginFragment : Fragment() {
 
         loginViewModel.user
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 smartAuthViewModel.saveCredential(activity, email.text.toString(), password.text.toString())
                 popBackStack()
             })

--- a/app/src/main/java/org/fossasia/openevent/general/auth/ProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/ProfileFragment.kt
@@ -72,19 +72,19 @@ class ProfileFragment : Fragment() {
 
         profileViewModel.progress
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 rootView.progressBar.isVisible = it
             })
 
         profileViewModel.error
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 Snackbar.make(rootView.profileCoordinatorLayout, it, Snackbar.LENGTH_SHORT).show()
             })
 
         profileViewModel.user
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 rootView.name.text = "${it.firstName.nullToEmpty()} ${it.lastName.nullToEmpty()}"
                 rootView.email.text = it.email
                 emailSettings = it.email

--- a/app/src/main/java/org/fossasia/openevent/general/auth/SignUpFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/SignUpFragment.kt
@@ -82,25 +82,25 @@ class SignUpFragment : Fragment() {
 
         signUpViewModel.progress
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 progressDialog.show(it)
             })
 
         signUpViewModel.showNoInternetDialog
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 Utils.showNoInternetDialog(context)
             })
 
         signUpViewModel.error
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 Snackbar.make(rootView.signupNestedScrollView, it, Snackbar.LENGTH_LONG).show()
             })
 
         signUpViewModel.signedUp
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 Snackbar.make(
                     rootView.signupNestedScrollView, R.string.sign_up_success, Snackbar.LENGTH_SHORT
                 ).show()
@@ -109,7 +109,7 @@ class SignUpFragment : Fragment() {
 
         signUpViewModel.loggedIn
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 smartAuthViewModel.saveCredential(
                     activity, usernameSignUp.text.toString(),
                     passwordSignUp.text.toString())
@@ -118,7 +118,7 @@ class SignUpFragment : Fragment() {
 
         signUpViewModel.areFieldsCorrect
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 signUpButton.isEnabled = it
             })
 

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -120,7 +120,7 @@ class EventDetailsFragment : Fragment() {
 
         eventViewModel.error
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 Snackbar.make(rootView.eventCoordinatorLayout, it, Snackbar.LENGTH_LONG).show()
             })
 

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -72,12 +72,6 @@ class EventsFragment : Fragment() {
                 showEmptyMessage(list.size)
                 Timber.d("Fetched events of size %s", eventsListAdapter.itemCount)
             })
-
-        eventsViewModel.error
-            .nonNull()
-            .observe(this, Observer {
-                Snackbar.make(eventsNestedScrollView, it, Snackbar.LENGTH_LONG).show()
-            })
     }
 
     override fun onCreateView(
@@ -107,7 +101,7 @@ class EventsFragment : Fragment() {
 
         eventsViewModel.showShimmerEvents
             .nonNull()
-            .observe(this, Observer { shouldShowShimmer ->
+            .observe(viewLifecycleOwner, Observer { shouldShowShimmer ->
                 if (shouldShowShimmer) {
                     rootView.shimmerEvents.startShimmer()
                     eventsListAdapter.clear()
@@ -119,8 +113,15 @@ class EventsFragment : Fragment() {
 
         eventsViewModel.progress
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 rootView.swiperefresh.isRefreshing = it
+            })
+
+
+        eventsViewModel.error
+            .nonNull()
+            .observe(viewLifecycleOwner, Observer {
+                Snackbar.make(eventsNestedScrollView, it, Snackbar.LENGTH_LONG).show()
             })
 
         eventsViewModel.loadLocation()

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -117,7 +117,6 @@ class EventsFragment : Fragment() {
                 rootView.swiperefresh.isRefreshing = it
             })
 
-
         eventsViewModel.error
             .nonNull()
             .observe(viewLifecycleOwner, Observer {

--- a/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsFragment.kt
@@ -59,7 +59,7 @@ class SimilarEventsFragment : Fragment() {
 
         similarEventsViewModel.similarEvents
             .nonNull()
-            .observe(this, Observer { eventsList ->
+            .observe(viewLifecycleOwner, Observer { eventsList ->
                 similarEventsListAdapter.submitList(eventsList)
                 handleVisibility(eventsList)
                 Timber.d("Fetched similar events of size %s", similarEventsListAdapter.itemCount)
@@ -67,13 +67,13 @@ class SimilarEventsFragment : Fragment() {
 
         similarEventsViewModel.error
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 Snackbar.make(rootView.similarEventsCoordinatorLayout, it, Snackbar.LENGTH_LONG).show()
             })
 
         similarEventsViewModel.progress
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 progressBar.isVisible = it
             })
 

--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
@@ -82,7 +82,7 @@ class FavoriteFragment : Fragment() {
 
         favoriteEventViewModel.events
             .nonNull()
-            .observe(this, Observer { list ->
+            .observe(viewLifecycleOwner, Observer { list ->
                 favoriteEventsRecyclerAdapter.submitList(list)
                 showEmptyMessage(favoriteEventsRecyclerAdapter.itemCount)
                 Timber.d("Fetched events of size %s", favoriteEventsRecyclerAdapter.itemCount)
@@ -90,13 +90,13 @@ class FavoriteFragment : Fragment() {
 
         favoriteEventViewModel.error
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 Snackbar.make(favoriteCoordinatorLayout, it, Snackbar.LENGTH_LONG).show()
             })
 
         favoriteEventViewModel.progress
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 rootView.favoriteProgressBar.isIndeterminate = it
                 rootView.favoriteProgressBar.isVisible = it
             })

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrderCompletedFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrderCompletedFragment.kt
@@ -51,14 +51,14 @@ class OrderCompletedFragment : Fragment() {
         orderCompletedViewModel.loadEvent(safeArgs.eventId)
         orderCompletedViewModel.event
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 loadEventDetails(it)
                 eventShare = it
             })
 
         orderCompletedViewModel.message
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 Snackbar.make(rootView.orderCoordinatorLayout, it, Snackbar.LENGTH_LONG).show()
             })
 

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsFragment.kt
@@ -87,13 +87,13 @@ class OrderDetailsFragment : Fragment() {
 
         orderDetailsViewModel.progress
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 rootView.progressBar.isVisible = it
             })
 
         orderDetailsViewModel.message
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 Snackbar.make(rootView.orderDetailCoordinatorLayout, it, Snackbar.LENGTH_LONG).show()
             })
 

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
@@ -80,13 +80,13 @@ class OrdersUnderUserFragment : Fragment() {
 
             ordersUnderUserVM.progress
                 .nonNull()
-                .observe(this, Observer {
+                .observe(viewLifecycleOwner, Observer {
                     rootView.progressBar.isVisible = it
                 })
 
             ordersUnderUserVM.message
                 .nonNull()
-                .observe(this, Observer {
+                .observe(viewLifecycleOwner, Observer {
                     Snackbar.make(
                         rootView.ordersUnderUserCoordinatorLayout, it, Snackbar.LENGTH_LONG
                     ).show()
@@ -94,19 +94,19 @@ class OrdersUnderUserFragment : Fragment() {
 
             ordersUnderUserVM.noTickets
                 .nonNull()
-                .observe(this, Observer {
+                .observe(viewLifecycleOwner, Observer {
                     showNoTicketsScreen(it)
                 })
 
             ordersUnderUserVM.attendeesNumber
                 .nonNull()
-                .observe(this, Observer {
+                .observe(viewLifecycleOwner, Observer {
                     ordersRecyclerAdapter.setAttendeeNumber(it)
                 })
 
             ordersUnderUserVM.eventAndOrderIdentifier
                 .nonNull()
-                .observe(this, Observer {
+                .observe(viewLifecycleOwner, Observer {
                     ordersRecyclerAdapter.addAllPairs(it)
                     ordersRecyclerAdapter.notifyDataSetChanged()
                     Timber.d("Fetched events of size %s", ordersRecyclerAdapter.itemCount)

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchLocationFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchLocationFragment.kt
@@ -42,7 +42,7 @@ class SearchLocationFragment : Fragment() {
         }
         setHasOptionsMenu(true)
 
-        geoLocationViewModel.currentLocationVisibility.observe(this, Observer {
+        geoLocationViewModel.currentLocationVisibility.observe(viewLifecycleOwner, Observer {
             rootView.currentLocation.visibility = View.GONE
         })
 
@@ -52,7 +52,7 @@ class SearchLocationFragment : Fragment() {
             rootView.locationProgressBar.visibility = View.VISIBLE
         }
 
-        geoLocationViewModel.location.observe(this, Observer { location ->
+        geoLocationViewModel.location.observe(viewLifecycleOwner, Observer { location ->
             searchLocationViewModel.saveSearch(location)
             redirectToMain()
         })

--- a/app/src/main/java/org/fossasia/openevent/general/social/SocialLinksFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/social/SocialLinksFragment.kt
@@ -34,21 +34,6 @@ class SocialLinksFragment : Fragment() {
         if (bundle != null) {
             id = bundle.getLong(EVENT_ID, -1)
         }
-
-        socialLinksViewModel.socialLinks
-            .nonNull()
-            .observe(this, Observer {
-                socialLinksRecyclerAdapter.addAll(it)
-                handleVisibility(it)
-                socialLinksRecyclerAdapter.notifyDataSetChanged()
-                Timber.d("Fetched social-links of size %s", socialLinksRecyclerAdapter.itemCount)
-            })
-
-        socialLinksViewModel.error
-            .nonNull()
-            .observe(this, Observer {
-                Snackbar.make(socialLinksCoordinatorLayout, it, Snackbar.LENGTH_LONG).show()
-            })
     }
 
     override fun onCreateView(
@@ -69,10 +54,25 @@ class SocialLinksFragment : Fragment() {
 
         socialLinksViewModel.progress
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 rootView.progressBarSocial.isVisible = it
             })
 
+        socialLinksViewModel.socialLinks
+            .nonNull()
+            .observe(viewLifecycleOwner, Observer {
+                socialLinksRecyclerAdapter.addAll(it)
+                handleVisibility(it)
+                socialLinksRecyclerAdapter.notifyDataSetChanged()
+                Timber.d("Fetched social-links of size %s", socialLinksRecyclerAdapter.itemCount)
+            })
+
+        socialLinksViewModel.error
+            .nonNull()
+            .observe(viewLifecycleOwner, Observer {
+                Snackbar.make(socialLinksCoordinatorLayout, it, Snackbar.LENGTH_LONG).show()
+            })
+        
         socialLinksViewModel.loadSocialLinks(id)
 
         return rootView

--- a/app/src/main/java/org/fossasia/openevent/general/social/SocialLinksFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/social/SocialLinksFragment.kt
@@ -72,7 +72,7 @@ class SocialLinksFragment : Fragment() {
             .observe(viewLifecycleOwner, Observer {
                 Snackbar.make(socialLinksCoordinatorLayout, it, Snackbar.LENGTH_LONG).show()
             })
-        
+
         socialLinksViewModel.loadSocialLinks(id)
 
         return rootView

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
@@ -55,12 +55,6 @@ class TicketsFragment : Fragment() {
         }
         ticketsRecyclerAdapter.setSelectListener(ticketSelectedListener)
 
-        ticketsViewModel.error
-            .nonNull()
-            .observe(this, Observer {
-                Snackbar.make(ticketsCoordinatorLayout, it, Snackbar.LENGTH_LONG).show()
-            })
-
         ticketsViewModel.event
             .nonNull()
             .observe(this, Observer {
@@ -97,7 +91,7 @@ class TicketsFragment : Fragment() {
 
         ticketsViewModel.progressTickets
             .nonNull()
-            .observe(this, Observer {
+            .observe(viewLifecycleOwner, Observer {
                 rootView.progressBarTicket.isVisible = it
                 rootView.ticketTableHeader.isGone = it
                 rootView.register.isGone = it
@@ -113,11 +107,17 @@ class TicketsFragment : Fragment() {
 
         ticketsViewModel.ticketTableVisibility
             .nonNull()
-            .observe(this, Observer { ticketTableVisible ->
+            .observe(viewLifecycleOwner, Observer { ticketTableVisible ->
                 rootView.ticketTableHeader.isVisible = ticketTableVisible
                 rootView.register.isVisible = ticketTableVisible
                 rootView.ticketsRecycler.isVisible = ticketTableVisible
                 rootView.ticketInfoTextView.isGone = ticketTableVisible
+            })
+
+        ticketsViewModel.error
+            .nonNull()
+            .observe(viewLifecycleOwner, Observer {
+                Snackbar.make(ticketsCoordinatorLayout, it, Snackbar.LENGTH_LONG).show()
             })
 
         ticketsViewModel.loadEvent(safeArgs.eventId)


### PR DESCRIPTION
Fixes #1326 

Changes: Change every fragment in the app that uses LiveData in some capacity to use the `viewLifecycleOwner` property wherever it seems appropriate. To decide where it makes sense to change the Lifecycle owner in a live data subscription, I looked at what actions are being invoked in the observer. If they are purely UI related events, I have changed it to `viewLifecycleOwner`.

* I have tried to make as little changes as possible. Wherever a LiveData object was being observed solely for the purpose of controlling UI events (Snackbars, errors, etc), I have changed the Observer to use the fragment's view lifecycle instead.

* I have tested the app after each commit to ensure nothing is being broken because of these changes.

* In some places where UI events were being controlled by a live data observable but the subscription was being made in the Fragment's `onCreate()` method, I have moved the observer to `onCreateView()`.