### PR TITLE
fix: show previously loaded events on rotation + internet loss

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -131,19 +131,19 @@ class EventsFragment : Fragment() {
             findNavController(rootView).navigate(R.id.searchLocationFragment, null, getAnimSlide())
         }
 
-        showNoInternetScreen(isNetworkConnected(context))
+        showNoInternetScreen(!isNetworkConnected(context) && eventsViewModel.events.value.isNullOrEmpty())
 
         rootView.retry.setOnClickListener {
             val isNetworkConnected = isNetworkConnected(context)
             if (eventsViewModel.savedLocation != null && isNetworkConnected) {
                 eventsViewModel.loadLocationEvents(RELOADING_EVENTS)
             }
-            showNoInternetScreen(isNetworkConnected)
+            showNoInternetScreen(!isNetworkConnected)
         }
 
         rootView.swiperefresh.setColorSchemeColors(Color.BLUE)
         rootView.swiperefresh.setOnRefreshListener {
-            showNoInternetScreen(isNetworkConnected(context))
+            showNoInternetScreen(!isNetworkConnected(context))
             if (!isNetworkConnected(context)) {
                 rootView.swiperefresh.isRefreshing = false
             } else {
@@ -196,8 +196,8 @@ class EventsFragment : Fragment() {
     }
 
     private fun showNoInternetScreen(show: Boolean) {
-        rootView.homeScreenLL.visibility = if (show) View.VISIBLE else View.GONE
-        rootView.noInternetCard.visibility = if (!show) View.VISIBLE else View.GONE
+        rootView.homeScreenLL.visibility = if (!show) View.VISIBLE else View.GONE
+        rootView.noInternetCard.visibility = if (show) View.VISIBLE else View.GONE
     }
 
     private fun showEmptyMessage(itemCount: Int) {


### PR DESCRIPTION
Fixes: #1341

Changes:
1) EventsFragment in onCreateView, a check is made to display no internet card only if pre loaded events are not present and internet is not available
2) The boolean argument for showNoInternetScreen has been flipped for consistency i.e. when the argument is true, then NoInternet screen is displayed

Screenshots for the change:

![PR 1377](https://user-images.githubusercontent.com/22665789/54835771-d3bccc00-4ce8-11e9-8e49-5f21a766f0ea.gif)
