### PR TITLE
feat: Add LinearSnapHelper to OrderDetailsFragment to enable snapping of tickets on the screen

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsFragment.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.navigation.Navigation.findNavController
 import androidx.navigation.fragment.navArgs
+import androidx.recyclerview.widget.LinearSnapHelper
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.fragment_order_details.view.orderDetailCoordinatorLayout
 import kotlinx.android.synthetic.main.fragment_order_details.view.orderDetailsRecycler
@@ -70,6 +71,7 @@ class OrderDetailsFragment : Fragment() {
         linearLayoutManager = LinearLayoutManager(context)
         linearLayoutManager.orientation = LinearLayoutManager.HORIZONTAL
         rootView.orderDetailsRecycler.layoutManager = linearLayoutManager
+        LinearSnapHelper().attachToRecyclerView(rootView.orderDetailsRecycler)
 
         val eventDetailsListener = object : OrderDetailsRecyclerAdapter.EventDetailsListener {
             override fun onClick(eventID: Long) {


### PR DESCRIPTION
Fixes #1376 

Changes: Add LinearSnapHelper to the recycler view

Screenshots for the change:
![snaphelper](https://user-images.githubusercontent.com/24315306/54832650-91908c00-4ce2-11e9-993c-64e66b4ee882.gif)
