### PR TITLE
fix: App crash on switching between login and signup fragments

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -93,6 +93,7 @@ dependencies {
     def roomVersion = "2.1.0-alpha04"
     def ktx_version = "1.0.0"
     def ktx2_version = "2.0.0"
+    def nav_version = "2.1.0-alpha01"
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.multidex:multidex:2.0.1'
@@ -158,8 +159,8 @@ dependencies {
     implementation 'com.journeyapps:zxing-android-embedded:3.6.0'
 
     //Navigation
-    implementation 'android.arch.navigation:navigation-fragment-ktx:1.0.0'
-    implementation 'android.arch.navigation:navigation-ui-ktx:1.0.0'
+    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version" // For Kotlin use navigation-fragment-ktx
+    implementation "androidx.navigation:navigation-ui-ktx:$nav_version" // For Kotlin use navigation-ui-ktx
 
     // Stetho
     debugImplementation 'com.facebook.stetho:stetho:1.5.1'


### PR DESCRIPTION
Fixes #1242 

Changes: Updated navigation architecture components. This was caused by a bug in the api used. Check these links:
https://issuetracker.google.com/issues/128531879
https://developer.android.com/jetpack/androidx/releases/navigation