### PR TITLE
fix: display emptyview in FavoriteFragment when list is empty

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
@@ -84,8 +84,8 @@ class FavoriteFragment : Fragment() {
             .nonNull()
             .observe(viewLifecycleOwner, Observer { list ->
                 favoriteEventsRecyclerAdapter.submitList(list)
-                showEmptyMessage(favoriteEventsRecyclerAdapter.itemCount)
-                Timber.d("Fetched events of size %s", favoriteEventsRecyclerAdapter.itemCount)
+                showEmptyMessage(list.size)
+                Timber.d("Fetched events of size %s", list.size)
             })
 
         favoriteEventViewModel.error


### PR DESCRIPTION
Fixes #1384. 

The emptyview is now displayed when the list becomes empty due to removal of all the favorite events

Changes:

The size of the list being used to determine if emptyview is to be displayed has been changed from using 
the size of A to size of B. 
- A is the `favoriteEventsRecyclerAdapter.itemCount`
- B is the new list of events obtained by observing on `favoriteEventViewModel.events`

Old code:
`favoriteEventsRecyclerAdapter.submitList(list)
 showEmptyMessage(favoriteEventsRecyclerAdapter.itemCount)`
 
On using `submitList`, the list is asynchronously updated and hence in the next line, the `itemCount` obtained is the old not yet updated item count. Therefore I have replaced `favoriteEventsRecyclerAdapter.itemCount` with `list.size` where list is the parameter from observing on `favoriteEventViewModel.events`

Excerpt from documentation of `submitList`

**Pass a new List to the AdapterHelper. Adapter updates will be computed on a background thread.
If a List is already present, a diff will be computed asynchronously on a background thread.**

Screenshots for the change:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/22665789/54866660-e395e800-4d9c-11e9-930d-7a35e5b934d1.gif)
