### PR TITLE
feat: Navigation icon clicked scroll to top

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
@@ -40,6 +40,14 @@ class MainActivity : AppCompatActivity() {
     private fun setupBottomNavigationMenu(navController: NavController) {
         setupWithNavController(navigation, navController)
         setupWithNavController(navigationAuth, navController)
+
+        navigation.setOnNavigationItemReselectedListener {
+            val hostFragment = supportFragmentManager.findFragmentById(R.id.frameContainer)
+            if (hostFragment is NavHostFragment) {
+                val currentFragment = hostFragment.childFragmentManager.fragments.first()
+                if (currentFragment is ScrollToTop) currentFragment.scrollToTop()
+            }
+        }
     }
 
     private fun handleNavigationVisibility(id: Int) {
@@ -92,4 +100,8 @@ class MainActivity : AppCompatActivity() {
         else
             super.onActivityResult(requestCode, resultCode, data)
     }
+}
+
+interface ScrollToTop {
+    fun scrollToTop()
 }

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -23,7 +23,9 @@ import kotlinx.android.synthetic.main.fragment_events.view.progressBar
 import kotlinx.android.synthetic.main.fragment_events.view.shimmerEvents
 import kotlinx.android.synthetic.main.fragment_events.view.swiperefresh
 import kotlinx.android.synthetic.main.fragment_events.view.noEventsMessage
+import kotlinx.android.synthetic.main.fragment_events.view.eventsNestedScrollView
 import org.fossasia.openevent.general.R
+import org.fossasia.openevent.general.ScrollToTop
 import org.fossasia.openevent.general.common.EventClickListener
 import org.fossasia.openevent.general.common.FavoriteFabClickListener
 import org.fossasia.openevent.general.common.ShareFabClickListener
@@ -52,7 +54,7 @@ const val EVENT_DATE_FORMAT: String = "eventDateFormat"
 const val RELOADING_EVENTS: Int = 0
 const val INITIAL_FETCHING_EVENTS: Int = 1
 
-class EventsFragment : Fragment() {
+class EventsFragment : Fragment(), ScrollToTop {
     private val eventsViewModel by viewModel<EventsViewModel>()
     private lateinit var rootView: View
     private val preference = Preference()
@@ -208,4 +210,6 @@ class EventsFragment : Fragment() {
         rootView.swiperefresh?.setOnRefreshListener(null)
         super.onStop()
     }
+
+    override fun scrollToTop() = rootView.eventsNestedScrollView.smoothScrollTo(0, 0)
 }

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
@@ -17,7 +17,9 @@ import kotlinx.android.synthetic.main.fragment_orders_under_user.noTicketsScreen
 import kotlinx.android.synthetic.main.fragment_orders_under_user.view.ordersUnderUserCoordinatorLayout
 import kotlinx.android.synthetic.main.fragment_orders_under_user.view.ordersRecycler
 import kotlinx.android.synthetic.main.fragment_orders_under_user.view.shimmerSearch
+import kotlinx.android.synthetic.main.fragment_orders_under_user.view.ordersNestedScrollView
 import org.fossasia.openevent.general.R
+import org.fossasia.openevent.general.ScrollToTop
 import org.fossasia.openevent.general.auth.LoginFragmentArgs
 import org.fossasia.openevent.general.utils.Utils
 import org.fossasia.openevent.general.utils.Utils.getAnimFade
@@ -25,7 +27,7 @@ import org.fossasia.openevent.general.utils.extensions.nonNull
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import timber.log.Timber
 
-class OrdersUnderUserFragment : Fragment() {
+class OrdersUnderUserFragment : Fragment(), ScrollToTop {
 
     private lateinit var rootView: View
     private val ordersUnderUserVM by viewModel<OrdersUnderUserViewModel>()
@@ -132,4 +134,6 @@ class OrdersUnderUserFragment : Fragment() {
                 findNavController(rootView).navigate(R.id.loginFragment, bundle, getAnimFade())
             }
     }
+
+    override fun scrollToTop() = rootView.ordersNestedScrollView.smoothScrollTo(0, 0)
 }

--- a/app/src/main/res/layout/fragment_orders_under_user.xml
+++ b/app/src/main/res/layout/fragment_orders_under_user.xml
@@ -7,6 +7,7 @@
     android:layout_height="match_parent">
 
     <androidx.core.widget.NestedScrollView
+        android:id="@+id/ordersNestedScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="@dimen/layout_margin_medium"


### PR DESCRIPTION
Details:
- In the MainActivity, bottom navigation callback on actionReselectedListener is called to handle scroll link to the top of the current fragment (EventsFragment and OrdersUnderUserFragment)

Fixes #1387 

Screenshots for the change:
<img src="https://i.ibb.co/T11cDH1/ezgif-2-920725f843b8.gif" width="300"/>