### PR TITLE
feat: Add ripple effect on item when clicking on bottom navigation

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -35,7 +35,6 @@
             android:layout_gravity="bottom"
             android:background="?android:attr/windowBackground"
             android:foreground="?attr/selectableItemBackground"
-            app:itemBackground="@android:color/white"
             app:itemIconTint="@color/navigation_item"
             app:itemTextColor="@color/navigation_item"
             app:labelVisibilityMode="labeled"
@@ -48,7 +47,6 @@
             android:layout_gravity="bottom"
             android:background="@android:color/white"
             android:foreground="?attr/selectableItemBackground"
-            app:itemBackground="@android:color/white"
             app:itemIconTint="@color/navigation_item"
             app:itemTextColor="@color/navigation_item"
             app:menu="@menu/navigation_auth" />


### PR DESCRIPTION
Details:
Setting the background on BottomNavigationView will make the ripple effect disappear.
Reference: https://stackoverflow.com/questions/40316411/bottomnavigationview-shadow-and-ripple-effect

Fixes #1392

Screenshots for the change:
<img src="https://i.ibb.co/b6xn15v/ezgif-2-89dc6854416d.gif" width="300">