### PR TITLE
fix: app crash due to IllegalArgumentException in SearchFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchFragment.kt
@@ -41,7 +41,7 @@ class SearchFragment : Fragment() {
 
         val thisActivity = activity
         if (thisActivity is AppCompatActivity) {
-            thisActivity.supportActionBar?.title = "Search"
+            thisActivity.supportActionBar?.title = getString(R.string.search)
             thisActivity.supportActionBar?.setDisplayHomeAsUpEnabled(false)
         }
         setHasOptionsMenu(true)
@@ -57,7 +57,7 @@ class SearchFragment : Fragment() {
         }
 
         val time = safeArgs?.stringSavedDate
-        rootView.timeTextView.text = time ?: "Anytime"
+        rootView.timeTextView.text = time ?: getString(R.string.anytime)
 
         searchViewModel.loadSavedLocation()
         rootView.locationTextView.text = searchViewModel.savedLocation

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchTimeFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchTimeFragment.kt
@@ -105,7 +105,7 @@ class SearchTimeFragment : Fragment() {
     }
 
     private fun redirectToSearch(time: String) {
-        val args = SearchFragmentArgs.Builder(time).build().toBundle()
+        val args = SearchFragmentArgs.Builder().setStringSavedDate(time).build().toBundle()
         val navOptions = NavOptions.Builder().setPopUpTo(R.id.eventsFragment, false).build()
         Navigation.findNavController(rootView).navigate(R.id.searchFragment, args, navOptions)
     }

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -39,6 +39,7 @@
         <argument
             android:name="@string/saved_date"
             app:argType="string"
+            android:defaultValue="@null"
             app:nullable="true"/>
     </fragment>
     <fragment


### PR DESCRIPTION
Fixes: #1383

Changes: 

- A default value of 'null' has been assigned to the argument 'saved_date'.
- This resolves the crash as the SearchFragmentArgs generated files throws an IllegalArgumentException if this argument
does not exist in the bundle with which it is initialised in its 'fromBundle' method. Now a null value is passed and hence the crash
does not occur.
- Additionally 2 hardcoded strings have been replaced with their resource reference equivalents

The code in SearchFragmentArgs that was throwing the exception is : 

`if (bundle.containsKey("@string/saved_date")) {`
     `// code that inserts it in arguments, redacted for simplicity`
    `} else {`
      `throw new IllegalArgumentException("Required argument \"@string/saved_date\" is missing and` `does not have an android:defaultValue");`
    `}`

After adding the `android:defaultValue="@null"` property to the `navigation.xml` file, this IllegalArgumentException statement appears to have gone from the generated file


Screenshots for the change:

![PR 1383](https://user-images.githubusercontent.com/22665789/54880143-c548ee80-4e67-11e9-87c3-be778284a913.gif)
