### PR TITLE
feat: improve layout of SearchTimeFragment

### DIFF
--- a/app/src/main/res/layout/fragment_search_time.xml
+++ b/app/src/main/res/layout/fragment_search_time.xml
@@ -3,9 +3,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_marginTop="@dimen/layout_margin_medium"
-    android:layout_marginLeft="@dimen/layout_margin_medium"
-    android:layout_marginRight="@dimen/layout_margin_medium"
+    android:background="@android:color/white"
+    android:layout_marginTop="@dimen/layout_margin_large"
+    android:layout_marginLeft="@dimen/layout_margin_large"
+    android:layout_marginRight="@dimen/layout_margin_large"
     android:orientation="vertical"
     tools:context="org.fossasia.openevent.general.search.SearchTimeFragment">
 
@@ -14,7 +15,8 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/layout_margin_extra_large"
         android:text="@string/what_time"
-        android:textColor="@color/light_grey"
+        android:layout_gravity="center_horizontal"
+        android:textColor="@color/black"
         android:textSize="@dimen/text_size_extra_large"
         android:textStyle="bold" />
 
@@ -32,54 +34,72 @@
                 android:id="@+id/anytimeTextView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/layout_margin_extra_large"
+                android:paddingTop="@dimen/layout_margin_large"
+                android:paddingBottom="@dimen/layout_margin_large"
+                android:gravity="center_vertical"
                 android:text="@string/anytime"
-                android:textColor="@color/light_grey"
+                android:background="?attr/selectableItemBackground"
+                android:textColor="@color/black"
                 android:textSize="@dimen/text_size_expanded_title" />
 
             <CheckedTextView
                 android:id="@+id/todayTextView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/layout_margin_extra_large"
+                android:paddingTop="@dimen/layout_margin_large"
+                android:paddingBottom="@dimen/layout_margin_large"
+                android:gravity="center_vertical"
                 android:text="@string/today"
-                android:textColor="@color/light_grey"
+                android:background="?attr/selectableItemBackground"
+                android:textColor="@color/black"
                 android:textSize="@dimen/text_size_expanded_title" />
 
             <CheckedTextView
                 android:id="@+id/tomorrowTextView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/layout_margin_extra_large"
+                android:paddingTop="@dimen/layout_margin_large"
+                android:paddingBottom="@dimen/layout_margin_large"
+                android:gravity="center_vertical"
                 android:text="@string/tomorrow"
-                android:textColor="@color/light_grey"
+                android:background="?attr/selectableItemBackground"
+                android:textColor="@color/black"
                 android:textSize="@dimen/text_size_expanded_title" />
 
             <CheckedTextView
                 android:id="@+id/thisWeekendTextView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/layout_margin_extra_large"
+                android:paddingTop="@dimen/layout_margin_large"
+                android:paddingBottom="@dimen/layout_margin_large"
+                android:gravity="center_vertical"
                 android:text="@string/weekend"
-                android:textColor="@color/light_grey"
+                android:background="?attr/selectableItemBackground"
+                android:textColor="@color/black"
                 android:textSize="@dimen/text_size_expanded_title" />
 
             <CheckedTextView
                 android:id="@+id/nextMonthTextView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/layout_margin_extra_large"
+                android:paddingTop="@dimen/layout_margin_large"
+                android:paddingBottom="@dimen/layout_margin_large"
+                android:gravity="center_vertical"
                 android:text="@string/month"
-                android:textColor="@color/light_grey"
+                android:background="?attr/selectableItemBackground"
+                android:textColor="@color/black"
                 android:textSize="@dimen/text_size_expanded_title" />
 
             <CheckedTextView
                 android:id="@+id/timeTextView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/layout_margin_extra_large"
+                android:paddingTop="@dimen/layout_margin_large"
+                android:paddingBottom="@dimen/layout_margin_large"
+                android:gravity="center_vertical"
                 android:text="@string/pick_date"
-                android:textColor="@color/light_grey"
+                android:background="?attr/selectableItemBackground"
+                android:textColor="@color/black"
                 android:textSize="@dimen/text_size_expanded_title" />
         </LinearLayout>
     </ScrollView>


### PR DESCRIPTION
Fixes: #1396

Changes:
Paddings have been increased, text color changed to black, layout background set to white so that the fade out animation
looks better, ripple effect added to CheckedTextView and some other changes


Screenshots for the change:
Old Layout:
<img src = "https://user-images.githubusercontent.com/22665789/54914823-e5d28080-4f1b-11e9-8687-ae7dd06aabb3.jpeg" width ="270" height = "570"/>

New Layout:

![PR 1999](https://user-images.githubusercontent.com/22665789/54914790-d05d5680-4f1b-11e9-9908-abb2c4bde810.gif)
