### PR TITLE
fix: Set default image for similar event card

### DIFF
--- a/app/src/main/res/layout/item_card_similar_events.xml
+++ b/app/src/main/res/layout/item_card_similar_events.xml
@@ -26,7 +26,7 @@
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            tools:srcCompat="@drawable/header" />
+            android:src="@drawable/header" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/shareFab"


### PR DESCRIPTION
Summary Change: Set default image for similar events card
Fixes #1438

Screenshots for the change:
Before                                                                             
<img src="https://i.ibb.co/rM8q86p/55505692-1243859889095828-7195179499183407104-n.png" width="300">                      
After         
<img src="https://i.ibb.co/7n0xGFj/56242571-1074388959425590-1636261825425178624-n.png" width="300">
