### PR TITLE
fix: Maintainence dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,11 +12,11 @@ def STRIPE_API_TOKEN = System.getenv('STRIPE_API_TOKEN') ?: "YOUR_API_KEY"
 def MAPBOX_KEY = System.getenv('MAPBOX_KEY') ?: "pk.eyJ1IjoiYW5nbWFzMSIsImEiOiJjanNqZDd0N2YxN2Q5NDNuNTBiaGt6eHZqIn0.BCrxjW6rP_OuOuGtbhVEQg"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion versions.compileSdk
     defaultConfig {
         applicationId "com.eventyay.attendee"
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion versions.minSdk
+        targetSdkVersion versions.targetSdk
         versionCode 3
         versionName "0.0.3a"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -88,98 +88,91 @@ repositories {
 }
 
 dependencies {
-    def lifecycle_version = "2.1.0-alpha03"
-    def koin_version = "1.0.2"
-    def roomVersion = "2.1.0-alpha06"
-    def ktx_version = "1.0.0"
-    def ktx2_version = "2.0.0"
-    def nav_version = "2.1.0-alpha01"
-    def anko_version = "0.10.8"
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'androidx.appcompat:appcompat:1.1.0-alpha03'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha3'
-    implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.recyclerview:recyclerview:1.1.0-alpha03'
-    implementation 'com.google.android.material:material:1.1.0-alpha05'
-    implementation "androidx.browser:browser:1.0.0"
-    implementation 'androidx.exifinterface:exifinterface:1.0.0'
-    implementation "androidx.lifecycle:lifecycle-extensions:${lifecycle_version}"
-    implementation "androidx.lifecycle:lifecycle-common-java8:${lifecycle_version}"
-    implementation "androidx.lifecycle:lifecycle-reactivestreams:${lifecycle_version}"
-    implementation "androidx.room:room-runtime:${roomVersion}"
-    implementation "androidx.room:room-rxjava2:${roomVersion}"
-    kapt "androidx.room:room-compiler:${roomVersion}"
-    testImplementation "androidx.room:room-testing:${roomVersion}"
-    implementation 'androidx.preference:preference:1.1.0-alpha01'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation libraries.multidex
+    implementation libraries.appcompat
+    implementation libraries.constraintLayout
+    implementation libraries.cardView
+    implementation libraries.recyclerView
+    implementation libraries.material
+    implementation libraries.browser
+    implementation libraries.exifinterface
+    implementation libraries.lifecycle_extensions
+    implementation libraries.lifecycle_common
+    implementation libraries.lifecycle_reactive
+    implementation libraries.room_runtime
+    implementation libraries.room_rxjava2
+    kapt libraries.room_compiler
+    testImplementation libraries.room_testing
+    implementation libraries.preference
+    implementation libraries.kotlin_stdlib
 
     // KTX
-    implementation "androidx.core:core-ktx:$ktx_version"
-    implementation "androidx.fragment:fragment-ktx:$ktx_version"
-    implementation "androidx.collection:collection-ktx:$ktx_version"
-    implementation "androidx.lifecycle:lifecycle-reactivestreams-ktx:$ktx2_version"
+    implementation libraries.core_ktx
+    implementation libraries.fragment_ktx
+    implementation libraries.fragment_ktx
+    implementation libraries.lifecycle_reactive_ktx
 
     // Koin
-    implementation "org.koin:koin-android:$koin_version"
-    implementation "org.koin:koin-androidx-scope:$koin_version"
-    implementation "org.koin:koin-androidx-viewmodel:$koin_version"
+    implementation libraries.koin_android
+    implementation libraries.koin_androidx_scope
+    implementation libraries.koin_androidx_viewmodel
 
     // Location Play Service
-    playStoreImplementation 'com.google.android.gms:play-services-location:16.0.0'
+    playStoreImplementation libraries.playServicesLocation
 
     //Smart Auth Play Service
-    playStoreImplementation 'com.google.android.gms:play-services-auth:16.0.1'
+    playStoreImplementation libraries.playServicesAuth
 
     // Timber
-    implementation 'com.jakewharton.timber:timber:4.7.1'
-    implementation 'com.jakewharton.threetenabp:threetenabp:1.2.0'
+    implementation libraries.timber
+    implementation libraries.threetenabp
 
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.8"
-    implementation 'com.github.jasminb:jsonapi-converter:0.9'
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.14.0'
-    implementation 'com.squareup.retrofit2:retrofit:2.5.0'
-    implementation 'com.squareup.retrofit2:converter-jackson:2.5.0'
+    implementation libraries.jackson_module_kt
+    implementation libraries.jsonapi_converter
+    implementation libraries.logging_interceptor
+    implementation libraries.retrofit2
+    implementation libraries.converter_jackson
 
     // Cards Shimmer Animation
-    implementation 'com.facebook.shimmer:shimmer:0.4.0'
+    implementation libraries.facebook_shimmer
 
     // RxJava
-    implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.8'
-    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.4.0'
+    implementation libraries.rxandroid
+    implementation libraries.rxjava
+    implementation libraries.rxjava2_adapter
 
     // Picasso
-    implementation 'com.squareup.picasso:picasso:2.71828'
+    implementation libraries.picasso
 
     // Stripe
-    implementation 'com.stripe:stripe-android:8.5.0'
+    implementation libraries.stripe
 
     // QR Code
-    implementation 'com.journeyapps:zxing-android-embedded:3.6.0'
+    implementation libraries.qrCode
 
     //Navigation
-    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version" // For Kotlin use navigation-fragment-ktx
-    implementation "androidx.navigation:navigation-ui-ktx:$nav_version" // For Kotlin use navigation-ui-ktx
+    implementation libraries.nav_fragment_ktx         // For Kotlin use navigation-fragment-ktx
+    implementation libraries.nav_ui_ktx // For Kotlin use navigation-ui-ktx
 
     //Anko
-    implementation "org.jetbrains.anko:anko-commons:$anko_version"
+    implementation libraries.anko_commons
 
     // Stetho
-    debugImplementation 'com.facebook.stetho:stetho:1.5.1'
-    debugImplementation 'com.facebook.stetho:stetho-okhttp3:1.5.1'
-    releaseImplementation 'com.github.iamareebjamal:stetho-noop:1.2.1'
-    testImplementation 'com.github.iamareebjamal:stetho-noop:1.2.1'
+    debugImplementation libraries.stetho
+    debugImplementation libraries.stetho_okhttp3
+    releaseImplementation libraries.stetho_noop
+    testImplementation libraries.stetho_noop
 
     //Mapbox SDK plugins
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-places-v7:0.7.0'
+    implementation libraries.mapboxSdk
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation "io.mockk:mockk:1.9.3"
-    testImplementation 'org.threeten:threetenbp:1.3.8'
-    testImplementation "org.koin:koin-test:$koin_version"
-    testImplementation 'androidx.arch.core:core-testing:2.0.1'
-    androidTestImplementation 'androidx.test:runner:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    testImplementation libraries.junit
+    testImplementation libraries.mockk
+    testImplementation libraries.threetenbp
+    testImplementation libraries.koin_test
+    testImplementation libraries.arch_core_test
+    androidTestImplementation libraries.runner_test
+    androidTestImplementation libraries.espresso
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.21'
+    apply from: rootProject.file('dependencies.gradle')
 
     repositories {
         google()
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath 'android.arch.navigation:navigation-safe-args-gradle-plugin:1.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,0 +1,162 @@
+ext {
+    versions = [
+            //For Project configuration
+            java                : JavaVersion.VERSION_1_8,
+            minSdk              : 16,
+            compileSdk          : 28,
+            targetSdk           : 28,
+            buildTools          : '28.0.3',
+
+            // For app
+            kotlin              : '1.3.21',
+
+            koin                : '1.0.2',
+
+            ktx                 : '1.0.0',
+            ktx2                : '2.0.0',
+
+            anko                : '0.10.8',
+
+            multiDex            : '2.0.1',
+
+            appCompat           : '1.1.0-alpha03',
+
+            recyclerView        : '1.1.0-alpha03',
+
+            constraintLayout    : '2.0.0-alpha3',
+
+            cardView            : '1.0.0',
+
+            material            : '1.1.0-alpha05',
+
+            browser             : '1.0.0',
+
+            exifinterface       : '1.0.0',
+
+            preference          : '1.1.0-alpha01',
+
+            //Architecture Components
+            lifecycle           : '2.1.0-alpha03',
+            navigation          : '2.1.0-alpha01',
+            room                : '2.1.0-alpha06',
+
+            //Playservices
+            playServicesAuth    : '16.0.1',
+            playServicesLocation: '16.0.0',
+
+            timber              : '4.7.1',
+            threetenabp         : '1.2.0',
+            threetenbp          : '1.3.8',
+
+            jackson_module_kt   : '2.9.8',
+            jsonapi_converter   : '0.9',
+
+            okhttp3             : '3.14.0',
+            retrofit2           : '2.5.0',
+
+            facebook_shimmer    : '0.4.0',
+
+            //RX
+            rxjava              : '2.2.8',
+            rxandroid           : '2.1.1',
+            rxjava2_adapter     : '2.4.0',
+
+            picasso             : '2.71828',
+
+            stripe              : '8.5.0',
+
+            qrCode              : '3.6.0',
+
+            stetho              : '1.5.1',
+            stetho_noop         : '1.2.1',
+
+            mapboxSdk           : '0.7.0',
+
+            junit               : '4.12',
+
+            mockk               : '1.9.3',
+
+            arch_core_test      : '2.0.1',
+
+            runner_test         : '1.1.1',
+
+            espesso             : '3.1.1'
+    ]
+    libraries = [
+            kotlin_stdlib          : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}",
+            multidex               : "androidx.multidex:multidex:${versions.multiDex}",
+            appcompat              : "androidx.appcompat:appcompat:${versions.appCompat}",
+            recyclerView           : "androidx.recyclerview:recyclerview:${versions.recyclerView}",
+            material               : "com.google.android.material:material:${versions.material}",
+            browser                : "androidx.browser:browser:${versions.browser}",
+            exifinterface          : "androidx.exifinterface:exifinterface:${versions.exifinterface}",
+            cardView               : "androidx.cardview:cardview:${versions.cardView}",
+            constraintLayout       : "androidx.constraintlayout:constraintlayout:${versions.constraintLayout}",
+
+            lifecycle_extensions   : "androidx.lifecycle:lifecycle-extensions:${versions.lifecycle}",
+            lifecycle_common       : "androidx.lifecycle:lifecycle-common-java8:${versions.lifecycle}",
+            lifecycle_reactive     : "androidx.lifecycle:lifecycle-reactivestreams:${versions.lifecycle}",
+
+            room_runtime           : "androidx.room:room-runtime:${versions.room}",
+            room_rxjava2           : "androidx.room:room-rxjava2:${versions.room}",
+            room_compiler          : "androidx.room:room-compiler:${versions.room}",
+            room_testing           : "androidx.room:room-testing:${versions.room}",
+
+            preference             : "androidx.preference:preference:${versions.preference}",
+
+            core_ktx               : "androidx.core:core-ktx:${versions.ktx}",
+            fragment_ktx           : "androidx.fragment:fragment-ktx:${versions.ktx}",
+            collection_ktx         : "androidx.collection:collection-ktx:${versions.ktx}",
+            lifecycle_reactive_ktx : "androidx.lifecycle:lifecycle-reactivestreams-ktx:${versions.ktx2}",
+
+            koin_android           : "org.koin:koin-android:${versions.koin}",
+            koin_androidx_scope    : "org.koin:koin-androidx-scope:${versions.koin}",
+            koin_androidx_viewmodel: "org.koin:koin-androidx-viewmodel:${versions.koin}",
+            koin_test              : "org.koin:koin-test:${versions.koin}",
+
+            playServicesLocation   : "com.google.android.gms:play-services-location:${versions.playServicesLocation}",
+            playServicesAuth       : "com.google.android.gms:play-services-auth:${versions.playServicesAuth}",
+
+            timber                 : "com.jakewharton.timber:timber:${versions.timber}",
+
+            threetenabp            : "com.jakewharton.threetenabp:threetenabp:${versions.threetenabp}",
+            threetenbp             : "org.threeten:threetenbp:${versions.threetenbp}",
+
+            jackson_module_kt      : "com.fasterxml.jackson.module:jackson-module-kotlin:${versions.jackson_module_kt}",
+            jsonapi_converter      : "com.github.jasminb:jsonapi-converter:${versions.jsonapi_converter}",
+
+            logging_interceptor    : "com.squareup.okhttp3:logging-interceptor:${versions.okhttp3}",
+
+            retrofit2              : "com.squareup.retrofit2:retrofit:${versions.retrofit2}",
+            converter_jackson      : "com.squareup.retrofit2:converter-jackson:${versions.retrofit2}",
+
+            facebook_shimmer       : "com.facebook.shimmer:shimmer:${versions.facebook_shimmer}",
+
+            rxandroid              : "io.reactivex.rxjava2:rxandroid:${versions.rxandroid}",
+            rxjava                 : "io.reactivex.rxjava2:rxjava:${versions.rxjava}",
+            rxjava2_adapter        : "com.squareup.retrofit2:adapter-rxjava2:${versions.rxjava2_adapter}",
+
+            picasso                : "com.squareup.picasso:picasso:${versions.picasso}",
+
+            stripe                 : "com.stripe:stripe-android:${versions.stripe}",
+
+            qrCode                 : "com.journeyapps:zxing-android-embedded:${versions.qrCode}",
+
+            nav_fragment_ktx       : "androidx.navigation:navigation-fragment-ktx:${versions.navigation}",
+            nav_ui_ktx             : "androidx.navigation:navigation-ui-ktx:${versions.navigation}",
+
+            anko_commons           : "org.jetbrains.anko:anko-commons:${versions.anko}",
+
+            stetho                 : "com.facebook.stetho:stetho:${versions.stetho}",
+            stetho_okhttp3         : "com.facebook.stetho:stetho-okhttp3:${versions.stetho}",
+            stetho_noop            : "com.github.iamareebjamal:stetho-noop:${versions.stetho_noop}",
+
+            mapboxSdk              : "com.mapbox.mapboxsdk:mapbox-android-plugin-places-v7:${versions.mapboxSdk}",
+
+            junit                  : "junit:junit:${versions.junit}",
+            mockk                  : "io.mockk:mockk:${versions.mockk}",
+            arch_core_test         : "androidx.arch.core:core-testing:${versions.arch_core_test}",
+            runner_test            : "androidx.test:runner:${versions.runner_test}",
+            espresso               : "androidx.test.espresso:espresso-core:${versions.espesso}"
+    ]
+}


### PR DESCRIPTION
Fixes #1410 

Changes: 
- make separate **dependencies.gradle** file containing `versions` and `libraries`. To make it single source of dependencies for easy maintenance  and easy refering of libraries used
- `build.gradle (app and project level)` files use `dependencies.gradle` file for libraries.