### PR TITLE
fix: misaligned terms conditions textview

### DIFF
--- a/app/src/main/res/layout/fragment_attendee.xml
+++ b/app/src/main/res/layout/fragment_attendee.xml
@@ -448,11 +448,11 @@
                     <CheckBox
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:gravity="center"
+                        android:layout_gravity="center_vertical"
                         android:id="@+id/acceptCheckbox"/>
                     <TextView
                         android:id="@+id/accept"
+                        android:layout_gravity="center_vertical"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content" />
                 </LinearLayout>


### PR DESCRIPTION
Fixes: #1458. 

Changes:
 - Sets the layout_gravity to center_vertical of checkbox and textview in fragment_attendee.xml
 - Removes following properties for Checkbox `layout_gravity="center"` and `gravity="center"` as `layout_gravity="center_vertical"` achieves what is required.
 
Screenshots for the change:

![pr 1459](https://user-images.githubusercontent.com/22665789/55167500-20941d00-5197-11e9-9869-764dc6f86cfa.jpeg)
