### PR TITLE
fix: Changed Button to Material Button in Login/Signup Page

### DIFF
--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -73,9 +73,9 @@
                         android:drawableStart="@drawable/ic_lock_black" />
                 </com.google.android.material.textfield.TextInputLayout>
 
-                <Button
+                <com.google.android.material.button.MaterialButton
                     android:theme="@style/AccentButton"
-                    style="@style/Widget.AppCompat.Button.Colored"
+                    style="@style/Widget.MaterialComponents.Button"
                     android:id="@+id/loginButton"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_signup.xml
+++ b/app/src/main/res/layout/fragment_signup.xml
@@ -116,9 +116,9 @@
                 android:imeOptions="actionDone"/>
         </com.google.android.material.textfield.TextInputLayout>
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:theme="@style/AccentButton"
-            style="@style/Widget.AppCompat.Button.Colored"
+            style="@style/Widget.MaterialComponents.Button"
             android:id="@+id/signUpButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -26,7 +26,7 @@
         <item name="android:windowBackground">@drawable/background_splash</item>
     </style>
 
-    <style name="AccentButton" parent="ThemeOverlay.MaterialComponents.Dark">
+    <style name="AccentButton" parent="AppTheme.MaterialButton">
         <item name="colorButtonNormal">@color/colorPrimary</item>
         <item name="colorAccent">@color/colorPrimary</item>
         <item name="android:textColor">@android:color/white</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -28,7 +28,8 @@
 
     <style name="AccentButton" parent="AppTheme.MaterialButton">
         <item name="colorButtonNormal">@color/colorPrimary</item>
-        <item name="colorAccent">@color/colorPrimary</item>
+        <item name="colorPrimary">@color/colorAccent</item>
+        <item name="colorOnPrimary">@android:color/white</item>
         <item name="android:textColor">@android:color/white</item>
         <item name="android:padding">@dimen/padding_medium</item>
         <item name="android:enabled">false</item>


### PR DESCRIPTION
Fixes #1465 

Changes: Currently the Buttons in Login/Signup Page looks colored.
But it should appear enabled only when proper email and password is entered.
Changing Button to Material Button and applying it's styles seems to do the job.

Screenshots for the change:
Newer Look:

Before Typing :
![Screenshot_20190329-031303](https://user-images.githubusercontent.com/43093724/55195692-62db4f80-51d3-11e9-93ee-a5465fa8adc3.png)

After Typing:
![Screenshot_20190329-031317](https://user-images.githubusercontent.com/43093724/55195700-6a025d80-51d3-11e9-9514-0faf63005061.png)
