### PR TITLE
fix: empty field signup crash

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/SignUpFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/SignUpFragment.kt
@@ -111,7 +111,9 @@ class SignUpFragment : Fragment() {
         rootView.lastNameText.setOnEditorActionListener { v, actionId, event ->
             when (actionId) {
                 EditorInfo.IME_ACTION_DONE -> {
-                    rootView.signUpButton.performClick()
+                    if (validateRequiredFieldsEmpty()) {
+                        rootView.signUpButton.performClick()
+                    }
                     Utils.hideSoftKeyboard(context, rootView)
                     true
                 }
@@ -196,7 +198,15 @@ class SignUpFragment : Fragment() {
 
         rootView.confirmPasswords.addTextChangedListener(object : TextWatcher {
             override fun afterTextChanged(p0: Editable?) {
-                if (confirmPasswords.text.toString().equals(passwordSignUp.text.toString())) {
+
+                /* to make PasswordToggle visible again, if made invisible
+                   after empty field error
+                 */
+                if (!textInputLayoutConfirmPassword.isEndIconVisible) {
+                    textInputLayoutConfirmPassword.isEndIconVisible = true
+                }
+
+                if (confirmPasswords.text.toString() == passwordSignUp.text.toString()) {
                     textInputLayoutConfirmPassword.error = null
                     textInputLayoutConfirmPassword.isErrorEnabled = false
                 } else {
@@ -214,13 +224,21 @@ class SignUpFragment : Fragment() {
 
         rootView.passwordSignUp.addTextChangedListener(object : TextWatcher {
             override fun afterTextChanged(p0: Editable?) {
+
+                /* to make PasswordToggle visible again, if made invisible
+                   after empty field error
+                */
+                if (!textInputLayoutPassword.isEndIconVisible) {
+                    textInputLayoutPassword.isEndIconVisible = true
+                }
+
                 if (passwordSignUp.text.toString().length >= 6 || passwordSignUp.text.toString().isEmpty()) {
                     textInputLayoutPassword.error = null
                     textInputLayoutPassword.isErrorEnabled = false
                 } else {
                     textInputLayoutPassword.error = getString(R.string.invalid_password_message)
                 }
-                if (confirmPasswords.text.toString().equals(passwordSignUp.text.toString())) {
+                if (confirmPasswords.text.toString() == passwordSignUp.text.toString()) {
                     textInputLayoutConfirmPassword.error = null
                     textInputLayoutConfirmPassword.isErrorEnabled = false
                 } else {
@@ -242,6 +260,29 @@ class SignUpFragment : Fragment() {
     private fun redirectToMain() {
         findNavController(rootView).popBackStack()
         Snackbar.make(rootView, R.string.logged_in_automatically, Snackbar.LENGTH_SHORT).show()
+    }
+
+    private fun validateRequiredFieldsEmpty(): Boolean {
+
+        var status = true
+
+        if (usernameSignUp.text.isNullOrEmpty()) {
+            usernameSignUp.error = getString(R.string.empty_email_message)
+            status = false
+        }
+        if (passwordSignUp.text.isNullOrEmpty()) {
+            passwordSignUp.error = getString(R.string.empty_password_message)
+            // make PasswordToggle invisible
+            textInputLayoutPassword.isEndIconVisible = false
+            status = false
+        }
+        if (confirmPasswords.text.isNullOrEmpty()) {
+            confirmPasswords.error = getString(R.string.empty_confirm_password_message)
+            // make PasswordToggle invisible
+            textInputLayoutConfirmPassword.isEndIconVisible = false
+            status = false
+        }
+        return status
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -221,6 +221,9 @@
     <string name="invalid_email_message">Your email address is invalid!</string>
     <string name="invalid_confirm_password_message">Your password and confirmation password do not match!</string>
     <string name="invalid_password_message">Password too short!</string>
+    <string name="empty_email_message">Email address cannot be empty</string>
+    <string name="empty_password_message">Password cannot be empty</string>
+    <string name="empty_confirm_password_message">Please confirm your password</string>
     <string name="accept_terms_and_conditions">Please accept the terms and conditions!</string>
 
     <!--social link fragment-->


### PR DESCRIPTION
Fixes #1454 

Changes: 
- add check for required fields for empty (email, password, confirm password) before perform signup() ( **to prevent crash**)
- providing informed message to in required fields if fields were empty (for UX)
- change `equals()` to `==` for better readability

Screenshots for the change:
<img src="https://user-images.githubusercontent.com/24780524/55274341-5a7f3380-52fd-11e9-97ae-b769793fe11c.gif" width=360>
