### PR TITLE
fix: multiple app crashes by reverting #1443

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/common/RecyclerViewCallbacks.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/common/RecyclerViewCallbacks.kt
@@ -1,6 +1,5 @@
 package org.fossasia.openevent.general.common
 
-import android.widget.ImageView
 import org.fossasia.openevent.general.event.Event
 
 /**
@@ -11,10 +10,8 @@ interface EventClickListener {
      * The function to be invoked when an event item is clicked
      *
      * @param eventID The ID of the clicked event
-     * @param sharedImage The view for shared element transition
-
      */
-    fun onClick(eventID: Long, sharedImage: ImageView)
+    fun onClick(eventID: Long)
 }
 
 /**

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -19,8 +19,6 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.Navigation.findNavController
 import androidx.navigation.fragment.navArgs
-import androidx.transition.TransitionInflater
-import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
 import kotlinx.android.synthetic.main.content_event.aboutEventContainer
 import kotlinx.android.synthetic.main.content_event.locationContainer
@@ -63,7 +61,6 @@ import org.fossasia.openevent.general.utils.nullToEmpty
 import org.fossasia.openevent.general.utils.stripHtml
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import timber.log.Timber
-import java.lang.Exception
 import java.util.Currency
 
 const val EVENT_ID = "eventId"
@@ -87,9 +84,27 @@ class EventDetailsFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        postponeEnterTransition()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            sharedElementEnterTransition = TransitionInflater.from(context).inflateTransition(android.R.transition.move)
+        eventViewModel.event
+            .nonNull()
+            .observe(this, Observer {
+                loadEvent(it)
+                eventShare = it
+                title = eventShare.name
+
+                if (eventShare.favorite) {
+                    setFavoriteIcon(R.drawable.ic_baseline_favorite_white)
+                }
+
+                if (runOnce) {
+                    loadSocialLinksFragment()
+                    loadSimilarEventsFragment()
+                }
+                runOnce = false
+
+                Timber.d("Fetched events of id %d", safeArgs.eventId)
+                showEventErrorScreen(false)
+                setHasOptionsMenu(true)
+            })
     }
 
     override fun onCreateView(
@@ -136,52 +151,6 @@ class EventDetailsFragment : Fragment() {
         }
 
         return rootView
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        eventViewModel.event
-            .nonNull()
-            .observe(this, Observer {
-                loadEvent(it)
-                eventShare = it
-                title = eventShare.name
-
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-                    rootView.logo.transitionName = safeArgs.eventId.toString()
-                // Set Cover Image
-                it.originalImageUrl?.let {
-                    Picasso.get()
-                        .load(it)
-                        .placeholder(R.drawable.header)
-                        .into(rootView.logo, object : Callback {
-                            override fun onSuccess() {
-                                startPostponedEnterTransition()
-                            }
-
-                            override fun onError(e: Exception?) {
-                                startPostponedEnterTransition()
-                            }
-                        })
-                } ?: run {
-                    startPostponedEnterTransition()
-                }
-
-                if (eventShare.favorite) {
-                    setFavoriteIcon(R.drawable.ic_baseline_favorite_white)
-                }
-
-                if (runOnce) {
-                    loadSocialLinksFragment()
-                    loadSimilarEventsFragment()
-                }
-                runOnce = false
-
-                Timber.d("Fetched events of id %d", safeArgs.eventId)
-                showEventErrorScreen(false)
-                setHasOptionsMenu(true)
-            })
     }
 
     private fun loadEvent(event: Event) {
@@ -241,7 +210,7 @@ class EventDetailsFragment : Fragment() {
 
         // Event Description Section
         if (!event.description.isNullOrEmpty()) {
-            setTextField(rootView.eventDescription, event.description.stripHtml())
+            setTextField(rootView.eventDescription, event.description?.stripHtml())
 
             rootView.eventDescription.post {
                 if (rootView.eventDescription.lineCount > LINE_COUNT) {
@@ -275,9 +244,9 @@ class EventDetailsFragment : Fragment() {
             rootView.eventLocationLinearLayout.setOnClickListener(mapClickListener)
 
             Picasso.get()
-                .load(eventViewModel.loadMap(event))
-                .placeholder(R.drawable.ic_map_black)
-                .into(rootView.imageMap)
+                    .load(eventViewModel.loadMap(event))
+                    .placeholder(R.drawable.ic_map_black)
+                    .into(rootView.imageMap)
         }
 
         // Date and Time section

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventViewHolder.kt
@@ -1,7 +1,6 @@
 package org.fossasia.openevent.general.event
 
 import android.view.View
-import androidx.core.view.ViewCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.squareup.picasso.Picasso
 import kotlinx.android.extensions.LayoutContainer
@@ -65,10 +64,9 @@ class EventViewHolder(override val containerView: View) : RecyclerView.ViewHolde
                 .placeholder(R.drawable.header)
                 .into(containerView.eventImage)
         }
-        ViewCompat.setTransitionName(containerView.eventImage, event.id.toString())
 
         containerView.setOnClickListener {
-            eventClickListener?.onClick(event.id, containerView.eventImage)
+            eventClickListener?.onClick(event.id)
                 ?: Timber.e("Event Click listener on ${this::class.java.canonicalName} is null")
         }
 

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -6,14 +6,12 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.navigation.Navigation.findNavController
-import androidx.navigation.fragment.FragmentNavigatorExtras
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.content_no_internet.view.noInternetCard
 import kotlinx.android.synthetic.main.content_no_internet.view.retry
@@ -84,7 +82,7 @@ class EventsFragment : Fragment(), ScrollToTop {
         savedInstanceState: Bundle?
     ): View? {
         rootView = inflater.inflate(R.layout.fragment_events, container, false)
-        postponeEnterTransition()
+
         if (preference.getString(SAVED_LOCATION).isNullOrEmpty()) {
             findNavController(requireActivity(), R.id.frameContainer).navigate(R.id.welcomeFragment)
         }
@@ -102,11 +100,6 @@ class EventsFragment : Fragment(), ScrollToTop {
 
         rootView.eventsRecycler.adapter = eventsListAdapter
         rootView.eventsRecycler.isNestedScrollingEnabled = false
-        rootView.eventsRecycler.viewTreeObserver
-            .addOnPreDrawListener {
-                startPostponedEnterTransition()
-                true
-            }
 
         eventsViewModel.showShimmerEvents
             .nonNull()
@@ -167,21 +160,13 @@ class EventsFragment : Fragment(), ScrollToTop {
         super.onViewCreated(view, savedInstanceState)
 
         val eventClickListener: EventClickListener = object : EventClickListener {
-            override fun onClick(eventID: Long, sharedImage: ImageView) {
-                val extras =
-                    FragmentNavigatorExtras(
-                        sharedImage to eventID.toString()
-                    )
-                EventDetailsFragmentArgs.Builder()
-                    .setEventId(eventID)
-                    .build()
-                    .toBundle()
-                    .also { bundle ->
-                        findNavController(view).navigate(R.id.eventDetailsFragment,
-                            bundle,
-                            getAnimFade(),
-                            extras)
-                    }
+            override fun onClick(eventID: Long) { EventDetailsFragmentArgs.Builder()
+                .setEventId(eventID)
+                .build()
+                .toBundle()
+                .also { bundle ->
+                    findNavController(view).navigate(R.id.eventDetailsFragment, bundle, getAnimFade())
+                }
             }
         }
 

--- a/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsFragment.kt
@@ -5,12 +5,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.Navigation.findNavController
-import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.snackbar.Snackbar
@@ -60,8 +58,6 @@ class SimilarEventsFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         rootView = inflater.inflate(R.layout.fragment_similar_events, container, false)
-
-        postponeEnterTransition()
         similarEventsViewModel.similarLocationEvents
             .nonNull()
             .observe(viewLifecycleOwner, Observer {
@@ -104,20 +100,14 @@ class SimilarEventsFragment : Fragment() {
         similarEventsListAdapter = get(scope = getOrCreateScope(Scopes.SIMILAR_EVENTS_FRAGMENT.toString()))
 
         val eventClickListener: EventClickListener = object : EventClickListener {
-            override fun onClick(eventID: Long, sharedImage: ImageView) {
-                val extras =
-                    FragmentNavigatorExtras(
-                        sharedImage to eventID.toString()
-                    )
+            override fun onClick(eventID: Long) {
                 EventDetailsFragmentArgs.Builder()
                     .setEventId(eventID)
                     .build()
                     .toBundle()
                     .also { bundle ->
-                        findNavController(view).navigate(R.id.eventDetailsFragment,
-                            bundle,
-                            getAnimSlide(),
-                            extras)
+                        findNavController(view).navigate(R.id.eventDetailsFragment, bundle,
+                            getAnimSlide())
                     }
             }
         }
@@ -154,12 +144,6 @@ class SimilarEventsFragment : Fragment() {
 
         view.similarEventsRecycler.adapter = similarEventsListAdapter
         view.similarEventsRecycler.isNestedScrollingEnabled = false
-        postponeEnterTransition()
-        view.similarEventsRecycler.viewTreeObserver
-            .addOnPreDrawListener {
-                startPostponedEnterTransition()
-                true
-            }
     }
 
     private fun handleVisibility(similarEvents: List<Event>) {

--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
@@ -5,16 +5,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.NavOptions
-import androidx.navigation.Navigation
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.navigation.Navigation.findNavController
-import androidx.navigation.fragment.FragmentNavigatorExtras
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.fragment_favorite.noLikedText
 import kotlinx.android.synthetic.main.fragment_favorite.favoriteCoordinatorLayout
@@ -65,15 +62,9 @@ class FavoriteFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         rootView = inflater.inflate(R.layout.fragment_favorite, container, false)
-        postponeEnterTransition()
         rootView.favoriteEventsRecycler.layoutManager = LinearLayoutManager(activity)
         rootView.favoriteEventsRecycler.adapter = favoriteEventsRecyclerAdapter
         rootView.favoriteEventsRecycler.isNestedScrollingEnabled = false
-        rootView.favoriteEventsRecycler.viewTreeObserver
-            .addOnPreDrawListener {
-                startPostponedEnterTransition()
-                true
-            }
 
         val thisActivity = activity
         if (thisActivity is AppCompatActivity) {
@@ -134,21 +125,13 @@ class FavoriteFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         val eventClickListener: EventClickListener = object : EventClickListener {
-            override fun onClick(eventID: Long, sharedImage: ImageView) {
-                val extras =
-                    FragmentNavigatorExtras(
-                        sharedImage to eventID.toString()
-                    )
-                EventDetailsFragmentArgs.Builder()
-                    .setEventId(eventID)
-                    .build()
-                    .toBundle()
-                    .also { bundle ->
-                        Navigation.findNavController(view).navigate(R.id.eventDetailsFragment,
-                            bundle,
-                            getAnimFade(),
-                            extras)
-                    }
+            override fun onClick(eventID: Long) { EventDetailsFragmentArgs.Builder()
+                .setEventId(eventID)
+                .build()
+                .toBundle()
+                .also { bundle ->
+                    findNavController(view).navigate(R.id.eventDetailsFragment, bundle, getAnimFade())
+                }
             }
         }
 

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
@@ -6,13 +6,11 @@ import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.Navigation
-import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.snackbar.Snackbar
@@ -55,7 +53,7 @@ class SearchResultsFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         rootView = inflater.inflate(R.layout.fragment_search_results, container, false)
-        postponeEnterTransition()
+
         val thisActivity = activity
         if (thisActivity is AppCompatActivity) {
             thisActivity.supportActionBar?.title = getString(R.string.search_results)
@@ -67,11 +65,6 @@ class SearchResultsFragment : Fragment() {
 
         rootView.eventsRecycler.adapter = favoriteEventsRecyclerAdapter
         rootView.eventsRecycler.isNestedScrollingEnabled = false
-        rootView.eventsRecycler.viewTreeObserver
-            .addOnPreDrawListener {
-                startPostponedEnterTransition()
-                true
-            }
 
         searchViewModel.events
             .nonNull()
@@ -114,21 +107,13 @@ class SearchResultsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val eventClickListener: EventClickListener = object : EventClickListener {
-            override fun onClick(eventID: Long, sharedImage: ImageView) {
-                val extras =
-                    FragmentNavigatorExtras(
-                        sharedImage to eventID.toString()
-                    )
-                EventDetailsFragmentArgs.Builder()
-                    .setEventId(eventID)
-                    .build()
-                    .toBundle()
-                    .also { bundle ->
-                        Navigation.findNavController(view).navigate(R.id.eventDetailsFragment,
-                            bundle,
-                            getAnimFade(),
-                            extras)
-                    }
+            override fun onClick(eventID: Long) { EventDetailsFragmentArgs.Builder()
+                .setEventId(eventID)
+                .build()
+                .toBundle()
+                .also { bundle ->
+                    Navigation.findNavController(view).navigate(R.id.eventDetailsFragment, bundle, getAnimFade())
+                }
             }
         }
 

--- a/app/src/main/res/layout/content_event.xml
+++ b/app/src/main/res/layout/content_event.xml
@@ -284,7 +284,6 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/layout_margin_large"
             android:orientation="vertical"
-            android:descendantFocusability="blocksDescendants"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Fixes: #1475

Changes:
This reverts commit f2b9ae17f1072cbe6270dc3669fec7c7aca9aaea (PR #1443) which was causing multiple crashes including

- Crash on clicking event in EventsFragment after navigating from some other fragment
- EventsFragment being created and displayed briefly on selecting FavoriteFragment before displaying the intended fragment (i.e. FavoriteFragment)
- EventsFragment being created twice on selecting it from navigation
- Crash on searching for events in SearchFragment
- App hangs and sometimes crashes in FavoriteFragment on selecting a favorite event

Screenshots for the change:
Crashes before reverting:

![crashes](https://user-images.githubusercontent.com/22665789/55277123-c45e0400-5322-11e9-8349-59b8db6b5685.gif)


After reverting:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/22665789/55276966-c4f59b00-5320-11e9-8e9a-ce9dc27192a6.gif)

Also
Fixes: #1480
Fixes: #1481