### PR TITLE
feat: Sort tickets and grey out old tickets.

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventUtils.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventUtils.kt
@@ -55,10 +55,10 @@ object EventUtils {
     fun loadMapUrl(event: Event) = "geo:<${event.latitude}>,<${event.longitude}>" +
         "?q=<${event.latitude}>,<${event.longitude}>"
 
-    fun getEventDateTime(dateString: String, timeZone: String): ZonedDateTime {
+    fun getEventDateTime(dateString: String, timeZone: String?): ZonedDateTime {
         try {
             return when (PreferenceManager.getDefaultSharedPreferences(OpenEventGeneral.appContext)
-                .getBoolean("useEventTimeZone", false)) {
+                .getBoolean("useEventTimeZone", false) && !timeZone.isNullOrBlank()) {
 
                 true -> ZonedDateTime.parse(dateString)
                     .toOffsetDateTime()
@@ -74,7 +74,7 @@ object EventUtils {
         }
     }
 
-    fun getTimeInMilliSeconds(dateString: String, timeZone: String): Long {
+    fun getTimeInMilliSeconds(dateString: String, timeZone: String?): Long {
         return getEventDateTime(dateString, timeZone).toInstant().toEpochMilli()
     }
 

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersRecyclerAdapter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersRecyclerAdapter.kt
@@ -9,6 +9,7 @@ import org.fossasia.openevent.general.event.Event
 class OrdersRecyclerAdapter : RecyclerView.Adapter<OrdersViewHolder>() {
 
     private val eventAndOrderIdentifier = ArrayList<Pair<Event, String>>()
+    private val showExpired = false
     private var clickListener: OrderClickListener? = null
     var attendeesNumber = listOf<Int>()
 
@@ -16,7 +17,7 @@ class OrdersRecyclerAdapter : RecyclerView.Adapter<OrdersViewHolder>() {
         clickListener = listener
     }
 
-    fun addAllPairs(list: List<Pair<Event, String>>) {
+    fun addAllPairs(list: List<Pair<Event, String>>, showExpired: Boolean) {
         if (eventAndOrderIdentifier.isNotEmpty())
             this.eventAndOrderIdentifier.clear()
         eventAndOrderIdentifier.addAll(list)
@@ -32,7 +33,7 @@ class OrdersRecyclerAdapter : RecyclerView.Adapter<OrdersViewHolder>() {
             holder.bind(eventAndOrderIdentifier[position].first,
                 clickListener,
                 eventAndOrderIdentifier[position].second,
-                it)
+                it, showExpired)
         }
     }
 

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
@@ -21,6 +21,7 @@ import kotlinx.android.synthetic.main.fragment_orders_under_user.view.ordersNest
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.ScrollToTop
 import org.fossasia.openevent.general.auth.LoginFragmentArgs
+import org.fossasia.openevent.general.event.EventUtils
 import org.fossasia.openevent.general.utils.Utils
 import org.fossasia.openevent.general.utils.Utils.getAnimFade
 import org.fossasia.openevent.general.utils.extensions.nonNull
@@ -109,7 +110,10 @@ class OrdersUnderUserFragment : Fragment(), ScrollToTop {
             ordersUnderUserVM.eventAndOrderIdentifier
                 .nonNull()
                 .observe(viewLifecycleOwner, Observer {
-                    ordersRecyclerAdapter.addAllPairs(it)
+                    val list = it.sortedByDescending {
+                        EventUtils.getTimeInMilliSeconds(it.first.startsAt, null)
+                    }
+                    ordersRecyclerAdapter.addAllPairs(list)
                     ordersRecyclerAdapter.notifyDataSetChanged()
                     Timber.d("Fetched events of size %s", ordersRecyclerAdapter.itemCount)
                 })

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
@@ -64,7 +64,7 @@ class OrdersUnderUserFragment : Fragment(), ScrollToTop {
                     thisActivity.supportActionBar?.title = "Past Tickets"
                     thisActivity.supportActionBar?.setDisplayHomeAsUpEnabled(true)
                     setHasOptionsMenu(true)
-                    context?.let { navAnimGone(activity?.navigation, it) }
+                    navAnimGone(activity?.navigation, requireContext())
                 }
                 false -> {
                     thisActivity.supportActionBar?.title = "Tickets"

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
@@ -82,8 +82,7 @@ class OrdersUnderUserFragment : Fragment(), ScrollToTop {
         rootView.ordersRecycler.layoutManager = linearLayoutManager
 
         if (ordersUnderUserVM.isLoggedIn()) {
-            ordersRecyclerAdapter.addAllPairs(emptyList(), safeArgs.showExpired)
-            ordersUnderUserVM.ordersUnderUser(safeArgs.showExpired)
+            if (ordersRecyclerAdapter.itemCount == 0) ordersUnderUserVM.ordersUnderUser(safeArgs.showExpired)
             if (safeArgs.showExpired) rootView.expireFilter.isVisible = false
 
             val recyclerViewClickListener = object : OrdersRecyclerAdapter.OrderClickListener {

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
@@ -14,7 +14,9 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.navigation.Navigation.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.snackbar.Snackbar
+import kotlinx.android.synthetic.main.activity_main.navigation
 import kotlinx.android.synthetic.main.content_no_tickets.findMyTickets
+import kotlinx.android.synthetic.main.content_no_tickets.noTicketMessage
 import kotlinx.android.synthetic.main.fragment_orders_under_user.noTicketsScreen
 import kotlinx.android.synthetic.main.fragment_orders_under_user.view.ordersUnderUserCoordinatorLayout
 import kotlinx.android.synthetic.main.fragment_orders_under_user.view.ordersRecycler
@@ -28,6 +30,7 @@ import org.fossasia.openevent.general.event.EventUtils
 import org.fossasia.openevent.general.utils.Utils
 import org.fossasia.openevent.general.utils.Utils.getAnimFade
 import org.fossasia.openevent.general.utils.Utils.getAnimSlide
+import org.fossasia.openevent.general.utils.Utils.navAnimGone
 import org.fossasia.openevent.general.utils.extensions.nonNull
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import timber.log.Timber
@@ -61,6 +64,7 @@ class OrdersUnderUserFragment : Fragment(), ScrollToTop {
                     thisActivity.supportActionBar?.title = "Past Tickets"
                     thisActivity.supportActionBar?.setDisplayHomeAsUpEnabled(true)
                     setHasOptionsMenu(true)
+                    context?.let { navAnimGone(activity?.navigation, it) }
                 }
                 false -> {
                     thisActivity.supportActionBar?.title = "Tickets"
@@ -150,8 +154,13 @@ class OrdersUnderUserFragment : Fragment(), ScrollToTop {
 
     private fun showNoTicketsScreen(show: Boolean) {
         noTicketsScreen.isVisible = show
-        findMyTickets.setOnClickListener {
-            Utils.openUrl(requireContext(), resources.getString(R.string.ticket_issues_url))
+        if (safeArgs.showExpired) {
+            findMyTickets.isVisible = false
+            noTicketMessage.text = getString(R.string.no_past_tickets)
+        } else {
+            findMyTickets.setOnClickListener {
+                Utils.openUrl(requireContext(), resources.getString(R.string.ticket_issues_url))
+            }
         }
     }
 

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserViewModel.kt
@@ -94,8 +94,10 @@ class OrdersUnderUserViewModel(
                 }
                 finalList = eventAndIdentifier
                 when (showExpired) {
-                    false -> finalList = finalList.filter { EventUtils.getTimeInMilliSeconds(it.first.endsAt, null) > System.currentTimeMillis() }
-                    true -> finalList = finalList.filter { EventUtils.getTimeInMilliSeconds(it.first.endsAt, null) < System.currentTimeMillis() }
+                    false -> finalList = finalList.filter {
+                        EventUtils.getTimeInMilliSeconds(it.first.endsAt, null) > System.currentTimeMillis() }
+                    true -> finalList = finalList.filter {
+                        EventUtils.getTimeInMilliSeconds(it.first.endsAt, null) < System.currentTimeMillis() }
                 }
                 if (finalList.isEmpty()) mutableNoTickets.value = true
                 mutableEventAndOrderIdentifier.value = finalList

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersViewHolder.kt
@@ -16,12 +16,12 @@ class OrdersViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         event: Event,
         clickListener: OrdersRecyclerAdapter.OrderClickListener?,
         orderIdentifier: String?,
-        attendeesNumber: Int
+        attendeesNumber: Int,
+        showExpired: Boolean
     ) {
         val formattedDateTime = EventUtils.getEventDateTime(event.startsAt, event.timezone)
         val formattedTime = EventUtils.getFormattedTime(formattedDateTime)
         val timezone = EventUtils.getFormattedTimeZone(formattedDateTime)
-        val formattedEndDateTime = EventUtils.getTimeInMilliSeconds(event.endsAt, null)
 
         itemView.eventName.text = event.name
         itemView.time.text = "Starts at $formattedTime $timezone"
@@ -44,7 +44,7 @@ class OrdersViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
                     .placeholder(R.drawable.header)
                     .into(itemView.eventImage)
         }
-        if (System.currentTimeMillis() > formattedEndDateTime) {
+        if (!showExpired) {
             itemView.alpha = 0.5F
             val matrix = ColorMatrix()
             matrix.setSaturation(0F)

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersViewHolder.kt
@@ -45,7 +45,6 @@ class OrdersViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
                     .into(itemView.eventImage)
         }
         if (!showExpired) {
-            itemView.alpha = 0.5F
             val matrix = ColorMatrix()
             matrix.setSaturation(0F)
             itemView.eventImage.colorFilter = ColorMatrixColorFilter(matrix)

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersViewHolder.kt
@@ -1,5 +1,7 @@
 package org.fossasia.openevent.general.order
 
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
 import androidx.recyclerview.widget.RecyclerView
 import android.view.View
 import com.squareup.picasso.Picasso
@@ -19,6 +21,7 @@ class OrdersViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val formattedDateTime = EventUtils.getEventDateTime(event.startsAt, event.timezone)
         val formattedTime = EventUtils.getFormattedTime(formattedDateTime)
         val timezone = EventUtils.getFormattedTimeZone(formattedDateTime)
+        val formattedEndDateTime = EventUtils.getTimeInMilliSeconds(event.endsAt, null)
 
         itemView.eventName.text = event.name
         itemView.time.text = "Starts at $formattedTime $timezone"
@@ -40,6 +43,12 @@ class OrdersViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
                     .load(it)
                     .placeholder(R.drawable.header)
                     .into(itemView.eventImage)
+        }
+        if (System.currentTimeMillis() > formattedEndDateTime) {
+            itemView.alpha = 0.5F
+            val matrix = ColorMatrix()
+            matrix.setSaturation(0F)
+            itemView.eventImage.colorFilter = ColorMatrixColorFilter(matrix)
         }
     }
 }

--- a/app/src/main/res/layout/content_no_tickets.xml
+++ b/app/src/main/res/layout/content_no_tickets.xml
@@ -1,59 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_height="wrap_content"
     android:layout_width="match_parent"
-    android:layout_margin="@dimen/layout_margin_large"
-    app:cardCornerRadius="@dimen/card_corner_radius"
-    android:elevation="@dimen/card_elevation">
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:layout_margin="@dimen/layout_margin_large">
+    android:layout_height="wrap_content"
+    android:layout_margin="@dimen/layout_margin_extra_large"
+    android:orientation="vertical">
 
-        <RelativeLayout
+    <RelativeLayout
+        android:layout_width="@dimen/item_image_view_large"
+        android:layout_height="@dimen/item_image_view_large"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="@dimen/layout_margin_large">
+
+        <ImageView
             android:layout_width="@dimen/item_image_view_large"
             android:layout_height="@dimen/item_image_view_large"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginTop="@dimen/layout_margin_large">
+            android:layout_centerInParent="true"
+            android:scaleType="centerCrop"
+            app:srcCompat="@drawable/round_shape" />
 
-            <ImageView
-                android:layout_width="@dimen/item_image_view_large"
-                android:layout_height="@dimen/item_image_view_large"
-                android:layout_centerInParent="true"
-                android:scaleType="centerCrop"
-                app:srcCompat="@drawable/round_shape" />
+        <ImageView
+            android:id="@+id/ticketImageView"
+            android:layout_width="@dimen/item_image_view"
+            android:layout_height="@dimen/item_image_view"
+            android:layout_centerInParent="true"
+            android:scaleType="centerCrop"
+            app:srcCompat="@drawable/ic_baseline_ticket"
+            app:tint="@color/colorPrimary"/>
 
-            <ImageView
-                android:id="@+id/ticketImageView"
-                android:layout_width="@dimen/item_image_view"
-                android:layout_height="@dimen/item_image_view"
-                android:layout_centerInParent="true"
-                android:scaleType="centerCrop"
-                app:srcCompat="@drawable/ic_baseline_ticket"
-                app:tint="@color/colorPrimary"/>
+    </RelativeLayout>
 
-        </RelativeLayout>
+    <TextView
+        android:id="@+id/noTicketMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="@dimen/layout_margin_extra_large"
+        android:text="@string/no_ticket_message"
+        android:textSize="@dimen/text_size_medium" />
 
-        <TextView
-            android:id="@+id/noTicketMessage"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginTop="@dimen/layout_margin_extra_large"
-            android:text="@string/no_ticket_message"
-            android:textSize="@dimen/text_size_medium" />
+    <TextView
+        android:id="@+id/findMyTickets"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="@dimen/layout_margin_large"
+        android:text="@string/find_my_tickets"
+        android:textColor="@color/colorPrimary"
+        android:textSize="@dimen/text_size_large" />
 
-        <TextView
-            android:id="@+id/findMyTickets"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginTop="@dimen/layout_margin_large"
-            android:text="@string/find_my_tickets"
-            android:textColor="@color/colorPrimary"
-            android:textSize="@dimen/text_size_large" />
-
-    </LinearLayout>
-</androidx.cardview.widget.CardView>
+</LinearLayout>

--- a/app/src/main/res/layout/content_no_tickets.xml
+++ b/app/src/main/res/layout/content_no_tickets.xml
@@ -1,51 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="@dimen/layout_margin_extra_large"
-    android:orientation="vertical">
+    android:layout_width="match_parent"
+    android:layout_margin="@dimen/layout_margin_large"
+    app:cardCornerRadius="@dimen/card_corner_radius"
+    android:elevation="@dimen/card_elevation">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_margin="@dimen/layout_margin_large">
 
-    <RelativeLayout
-        android:layout_width="@dimen/item_image_view_large"
-        android:layout_height="@dimen/item_image_view_large"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginTop="@dimen/layout_margin_large">
-
-        <ImageView
+        <RelativeLayout
             android:layout_width="@dimen/item_image_view_large"
             android:layout_height="@dimen/item_image_view_large"
-            android:layout_centerInParent="true"
-            android:scaleType="centerCrop"
-            app:srcCompat="@drawable/round_shape" />
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="@dimen/layout_margin_large">
 
-        <ImageView
-            android:id="@+id/ticketImageView"
-            android:layout_width="@dimen/item_image_view"
-            android:layout_height="@dimen/item_image_view"
-            android:layout_centerInParent="true"
-            android:scaleType="centerCrop"
-            app:srcCompat="@drawable/ic_baseline_ticket"
-            app:tint="@color/colorPrimary"/>
+            <ImageView
+                android:layout_width="@dimen/item_image_view_large"
+                android:layout_height="@dimen/item_image_view_large"
+                android:layout_centerInParent="true"
+                android:scaleType="centerCrop"
+                app:srcCompat="@drawable/round_shape" />
 
-    </RelativeLayout>
+            <ImageView
+                android:id="@+id/ticketImageView"
+                android:layout_width="@dimen/item_image_view"
+                android:layout_height="@dimen/item_image_view"
+                android:layout_centerInParent="true"
+                android:scaleType="centerCrop"
+                app:srcCompat="@drawable/ic_baseline_ticket"
+                app:tint="@color/colorPrimary"/>
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginTop="@dimen/layout_margin_extra_large"
-        android:text="@string/no_ticket_message"
-        android:textSize="@dimen/text_size_medium" />
+        </RelativeLayout>
 
-    <TextView
-        android:id="@+id/findMyTickets"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginTop="@dimen/layout_margin_large"
-        android:text="@string/find_my_tickets"
-        android:textColor="@color/colorPrimary"
-        android:textSize="@dimen/text_size_large" />
+        <TextView
+            android:id="@+id/noTicketMessage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="@dimen/layout_margin_extra_large"
+            android:text="@string/no_ticket_message"
+            android:textSize="@dimen/text_size_medium" />
 
-</LinearLayout>
+        <TextView
+            android:id="@+id/findMyTickets"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="@dimen/layout_margin_large"
+            android:text="@string/find_my_tickets"
+            android:textColor="@color/colorPrimary"
+            android:textSize="@dimen/text_size_large" />
+
+    </LinearLayout>
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/fragment_orders_under_user.xml
+++ b/app/src/main/res/layout/fragment_orders_under_user.xml
@@ -1,18 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/ordersUnderUserCoordinatorLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <TextView
+        android:id="@+id/expireFilter"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textColor="@color/black"
+        android:textSize="18sp"
+        android:background="@drawable/filled_border"
+        android:padding="@dimen/padding_medium"
+        android:text="Upcoming >"
+        app:layout_constraintTop_toTopOf="parent"/>
+
     <androidx.core.widget.NestedScrollView
         android:id="@+id/ordersNestedScrollView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/layout_margin_medium"
         android:layout_marginBottom="@dimen/layout_margin_medium"
         android:orientation="vertical"
+        app:layout_constraintTop_toBottomOf="@id/expireFilter"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <LinearLayout
@@ -40,6 +52,7 @@
         android:id="@+id/shimmerSearch"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/expireFilter"
         android:visibility="gone">
 
         <LinearLayout
@@ -59,4 +72,4 @@
         </LinearLayout>
     </com.facebook.shimmer.ShimmerFrameLayout>
 
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_orders_under_user.xml
+++ b/app/src/main/res/layout/fragment_orders_under_user.xml
@@ -12,9 +12,12 @@
         android:layout_height="wrap_content"
         android:textColor="@color/black"
         android:textSize="18sp"
+        android:gravity="right"
         android:background="@drawable/filled_border"
-        android:padding="@dimen/padding_medium"
-        android:text="Upcoming >"
+        android:paddingTop="@dimen/padding_medium"
+        android:paddingBottom="@dimen/padding_medium"
+        android:paddingRight="@dimen/padding_large"
+        android:text="Past >"
         app:layout_constraintTop_toTopOf="parent"/>
 
     <androidx.core.widget.NestedScrollView

--- a/app/src/main/res/layout/fragment_orders_under_user.xml
+++ b/app/src/main/res/layout/fragment_orders_under_user.xml
@@ -11,13 +11,13 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textColor="@color/black"
-        android:textSize="18sp"
+        android:textSize="@dimen/text_size_larger"
         android:gravity="right"
         android:background="@drawable/filled_border"
         android:paddingTop="@dimen/padding_medium"
         android:paddingBottom="@dimen/padding_medium"
         android:paddingRight="@dimen/padding_large"
-        android:text="Past >"
+        android:text="@string/past"
         app:layout_constraintTop_toTopOf="parent"/>
 
     <androidx.core.widget.NestedScrollView

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -101,7 +101,13 @@
         android:id="@+id/orderUnderUserFragment"
         android:name="org.fossasia.openevent.general.order.OrdersUnderUserFragment"
         android:label="OrdersUnderUserFragment"
-        tools:layout="@layout/fragment_orders_under_user" />
+        tools:layout="@layout/fragment_orders_under_user">
+
+        <argument
+            android:name="showExpired"
+            app:argType="boolean"
+            android:defaultValue="false"/>
+    </fragment>
     <fragment
         android:id="@+id/orderDetailsFragment"
         android:name="org.fossasia.openevent.general.order.OrderDetailsFragment"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -7,6 +7,7 @@
     <dimen name="text_size_expanded_title_large">27sp</dimen>
     <dimen name="text_size_extra_large">32sp</dimen>
     <dimen name="text_size_large">16sp</dimen>
+    <dimen name="text_size_larger">18sp</dimen>
     <dimen name="text_size_medium">14sp</dimen>
     <dimen name="text_size_small">12sp</dimen>
     <dimen name="text_size_very_large">42sp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,7 @@
     <string name="view_ticket">View</string>
     <string name="no_ticket_message">Not seeing your tickets? Learn more about how to find them.</string>
     <string name="no_past_tickets">No past tickets.</string>
+    <string name="past">Past ></string>
     <string name="find_my_tickets">Find my tickets</string>
     <string name="no_tickets_available">No tickets available!</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,7 @@
     <string name="ok">ok</string>
     <string name="view_ticket">View</string>
     <string name="no_ticket_message">Not seeing your tickets? Learn more about how to find them.</string>
+    <string name="no_past_tickets">No past tickets.</string>
     <string name="find_my_tickets">Find my tickets</string>
     <string name="no_tickets_available">No tickets available!</string>
 


### PR DESCRIPTION
Fixes #1478 

Changes: sorted tickets so that event with earliest start date time appears first. Greyed out pictures of events on tickets which have ended and set alpha to 0.5 for ended events.

Screenshots for the change:
![Screenshot_2019-03-30-19-44-06-657_com eventyay attendee](https://user-images.githubusercontent.com/37517284/55277431-279d6580-5326-11e9-8f99-90260ca670dd.png)
