### PR TITLE
fix: app crash on going back from similar fragment'

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsFragment.kt
@@ -27,6 +27,7 @@ import org.fossasia.openevent.general.event.EventUtils
 import org.fossasia.openevent.general.event.EventsListAdapter
 import org.fossasia.openevent.general.common.FavoriteFabClickListener
 import org.fossasia.openevent.general.common.ShareFabClickListener
+import org.fossasia.openevent.general.event.EventLayoutType
 import org.fossasia.openevent.general.utils.Utils.getAnimSlide
 import org.fossasia.openevent.general.utils.extensions.nonNull
 import org.koin.android.ext.android.get
@@ -97,7 +98,7 @@ class SimilarEventsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        similarEventsListAdapter = get(scope = getOrCreateScope(Scopes.SIMILAR_EVENTS_FRAGMENT.toString()))
+        similarEventsListAdapter = EventsListAdapter(EventLayoutType.SIMILAR_EVENTS, get())
 
         val eventClickListener: EventClickListener = object : EventClickListener {
             override fun onClick(eventID: Long) {
@@ -170,7 +171,6 @@ class SimilarEventsFragment : Fragment() {
 
         handleVisibility(similarEvents)
         Timber.d("Fetched Similar events of size %s", similarEvents.size)
-        similarEvents.shuffle()
         similarEventsListAdapter.submitList(similarEvents)
         similarEventsListAdapter.notifyDataSetChanged()
     }

--- a/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsViewModel.kt
@@ -59,7 +59,7 @@ class SimilarEventsViewModel(private val eventService: EventService) : ViewModel
             }.subscribe({
                 mutableSimilarLocationEvents.value = it.filter { it.id != eventId }
             }, {
-                Timber.e(it, "Error fetching simialr events")
+                Timber.e(it, "Error fetching similar events")
                 mutableError.value = "Error fetching similar events"
             })
         )


### PR DESCRIPTION
Fixes: #1474

Changes:

- On selecting a similar event from the EventDetailsFragment, a newEventDetailsFragment is created for the selected event.
- However using Koin DI, the same adapter object was being used.
- This resulted in app crashes on going back from the new event.
- This commit fixes the issue by instantiating the SimilarEventsListAdapter using its constructor and not KOIN DI

Additional Changes

- Removed shuffling of list of Similar events so that the fragment returns to the original order on pressing back
- Corrected a typo in the word 'similar' in `SimilarEventsViewModel`

Screenshots for the change:

![prsimilarfragmentscrash](https://user-images.githubusercontent.com/22665789/55291762-4a9c4800-5400-11e9-99d8-9c0e90fde5bf.gif)

