### PR TITLE
feat: Add no internet view on TicketsFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
@@ -16,6 +16,8 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.navigation.Navigation.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.snackbar.Snackbar
+import kotlinx.android.synthetic.main.content_no_internet.view.retry
+import kotlinx.android.synthetic.main.content_no_internet.view.noInternetCard
 import kotlinx.android.synthetic.main.fragment_tickets.ticketsCoordinatorLayout
 import kotlinx.android.synthetic.main.fragment_tickets.view.eventName
 import kotlinx.android.synthetic.main.fragment_tickets.view.organizerName
@@ -32,6 +34,7 @@ import org.fossasia.openevent.general.event.Event
 import org.fossasia.openevent.general.event.EventUtils
 import org.fossasia.openevent.general.utils.Utils.getAnimFade
 import org.fossasia.openevent.general.utils.Utils.getAnimSlide
+import org.fossasia.openevent.general.utils.Utils.isNetworkConnected
 import org.fossasia.openevent.general.utils.extensions.nonNull
 import org.fossasia.openevent.general.utils.nullToEmpty
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -120,8 +123,11 @@ class TicketsFragment : Fragment() {
                 Snackbar.make(ticketsCoordinatorLayout, it, Snackbar.LENGTH_LONG).show()
             })
 
-        ticketsViewModel.loadEvent(safeArgs.eventId)
-        ticketsViewModel.loadTickets(safeArgs.eventId)
+        rootView.retry.setOnClickListener {
+            loadTickets()
+        }
+
+        loadTickets()
 
         return rootView
     }
@@ -193,5 +199,23 @@ class TicketsFragment : Fragment() {
                 .setPositiveButton(resources.getString(R.string.ok)) { dialog, _ -> dialog.cancel() }
         val alert = builder.create()
         alert.show()
+    }
+
+    private fun loadTickets() {
+        if (!isNetworkConnected(context) && ticketsViewModel.tickets.value.isNullOrEmpty())
+            showNoInternetScreen(true)
+        else {
+            showNoInternetScreen(false)
+            ticketsViewModel.loadEvent(safeArgs.eventId)
+            ticketsViewModel.loadTickets(safeArgs.eventId)
+        }
+    }
+
+    private fun showNoInternetScreen(show: Boolean) {
+        rootView.noInternetCard.isVisible = show
+        rootView.ticketTableHeader.isVisible = !show
+        rootView.ticketsRecycler.isVisible = !show
+        rootView.progressBarTicket.isVisible = !show
+        rootView.register.isVisible = !show
     }
 }

--- a/app/src/main/res/layout/fragment_tickets.xml
+++ b/app/src/main/res/layout/fragment_tickets.xml
@@ -132,6 +132,7 @@
                 android:layout_marginTop="@dimen/layout_margin_large"
                 android:layout_marginBottom="@dimen/layout_margin_large"
                 android:text="@string/register" />
+            <include layout="@layout/content_no_internet" />
         </LinearLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
Detail:
Add no internet card on Ticket Fragment and show it when there is no internet and no tickets retained in view model

Fixes: #1491

Screenshots for the change:
<img src="https://i.ibb.co/G5sHg4h/ezgif-4-9feb51280a25.gif" width="300">            <img src="https://i.ibb.co/3r3GPM7/ezgif-4-9866abe6915e.gif" width="300">