### PR TITLE
fix: incorrect image displayed for event in EventsFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventViewHolder.kt
@@ -43,6 +43,7 @@ class EventViewHolder(override val containerView: View) : RecyclerView.ViewHolde
         event: Event,
         dateFormat: String
     ) {
+        containerView.eventImage.setImageResource(R.drawable.header)
         containerView.eventName.text = event.name
         containerView.locationName.text = event.locationName
 


### PR DESCRIPTION
Fixes: #1476

Changes:
On binding the EventViewHolder, the image resource is first set to the placeholder image.
This prevents an incorrect image to be displayed i.e. an image which was loaded for the previously loaded event
before this viewholder got recycled

Screenshots for the change:

![PRfor1476](https://user-images.githubusercontent.com/22665789/55309079-4ca2ed00-547a-11e9-93f7-88b40a68d9dc.gif)
