### PR TITLE
feat: display multiple columns of events in landscape and tablets

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -10,7 +10,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
-import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.GridLayoutManager
 import androidx.navigation.Navigation.findNavController
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.content_no_internet.view.noInternetCard
@@ -96,7 +96,8 @@ class EventsFragment : Fragment(), ScrollToTop {
 
         rootView.progressBar.isIndeterminate = true
 
-        rootView.eventsRecycler.layoutManager = LinearLayoutManager(activity)
+        rootView.eventsRecycler.layoutManager =
+            GridLayoutManager(activity, resources.getInteger(R.integer.events_column_count))
 
         rootView.eventsRecycler.adapter = eventsListAdapter
         rootView.eventsRecycler.isNestedScrollingEnabled = false

--- a/app/src/main/res/values-land/integers.xml
+++ b/app/src/main/res/values-land/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="events_column_count">2</integer>
+</resources>

--- a/app/src/main/res/values-sw600dp-land/integers.xml
+++ b/app/src/main/res/values-sw600dp-land/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="events_column_count">4</integer>
+</resources>

--- a/app/src/main/res/values-sw600dp/dimens.xml
+++ b/app/src/main/res/values-sw600dp/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="layout_margin_medium">16dp</dimen>
+</resources>

--- a/app/src/main/res/values-sw600dp/integers.xml
+++ b/app/src/main/res/values-sw600dp/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="events_column_count">3</integer>
+</resources>

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="events_column_count">1</integer>
+</resources>


### PR DESCRIPTION
Fixes: #1476

Changes:

- Displays multiple columns of events in EventsFragment by using GridLayoutManager instead of LinearLayoutManager
- The column count for events has been specified in newly created integers resources file for different source sets:
'landscape', 'smallest width 600 dp' and 'smallest width 600 dp landscape'
- Dimensions file for tablets created to increase size of a margin dimension


Screenshots for the change:

Previous Layout:

![newissue](https://user-images.githubusercontent.com/22665789/55312796-f470e880-5483-11e9-9dd7-160bddc97769.gif)

New Layout: 

Mobile landscape
![Newpr](https://user-images.githubusercontent.com/22665789/55312810-faff6000-5483-11e9-9fad-ecbc1b29d2de.gif)

Tablet Portrait

![column pr tab 3](https://user-images.githubusercontent.com/22665789/55312829-06eb2200-5484-11e9-8597-ce2834992969.jpg)

Tablet Landscape:

![column pr tab 4](https://user-images.githubusercontent.com/22665789/55312847-0c486c80-5484-11e9-9518-0218dc0c7091.jpg)


