### PR TITLE
fix: event title being cut off in EventDetailsFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -35,8 +35,8 @@ import kotlinx.android.synthetic.main.content_event.view.eventOrganiserName
 import kotlinx.android.synthetic.main.content_event.view.eventTimingLinearLayout
 import kotlinx.android.synthetic.main.content_event.view.imageMap
 import kotlinx.android.synthetic.main.content_event.view.locationUnderMap
-import kotlinx.android.synthetic.main.content_event.view.logo
-import kotlinx.android.synthetic.main.content_event.view.logoIcon
+import kotlinx.android.synthetic.main.content_event.view.eventImage
+import kotlinx.android.synthetic.main.content_event.view.organizerLogoIcon
 import kotlinx.android.synthetic.main.content_event.view.nestedContentEventScroll
 import kotlinx.android.synthetic.main.content_event.view.organizerName
 import kotlinx.android.synthetic.main.content_event.view.refundPolicy
@@ -139,7 +139,7 @@ class EventDetailsFragment : Fragment() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             rootView.nestedContentEventScroll.setOnScrollChangeListener { _, _, scrollY, _, _ ->
                 if (thisActivity is AppCompatActivity) {
-                    if (scrollY > rootView.eventName.height + rootView.logo.height)
+                    if (scrollY > rootView.eventName.height + rootView.eventImage.height)
                         /*Toolbar title set to name of Event if scrolled more than
                         combined height of eventImage and eventName views*/
                         thisActivity.supportActionBar?.title = title
@@ -171,7 +171,7 @@ class EventDetailsFragment : Fragment() {
                     .load(event.logoUrl)
                     .placeholder(requireDrawable(requireContext(), R.drawable.ic_person_black))
                     .transform(CircleTransform())
-                    .into(rootView.logoIcon)
+                    .into(rootView.organizerLogoIcon)
 
             val organizerDescriptionListener = View.OnClickListener {
                 if (rootView.seeMoreOrganizer.text == getString(R.string.see_more)) {
@@ -271,7 +271,7 @@ class EventDetailsFragment : Fragment() {
             Picasso.get()
                     .load(it)
                     .placeholder(R.drawable.header)
-                    .into(rootView.logo)
+                    .into(rootView.eventImage)
         }
 
         // Add event to Calendar

--- a/app/src/main/res/layout/content_event.xml
+++ b/app/src/main/res/layout/content_event.xml
@@ -14,7 +14,7 @@
 
 
         <ImageView
-            android:id="@+id/logo"
+            android:id="@+id/eventImage"
             android:layout_width="@dimen/layout_margin_none"
             android:layout_height="@dimen/layout_margin_none"
             android:scaleType="centerCrop"
@@ -27,29 +27,30 @@
 
         <TextView
             android:id="@+id/eventName"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/layout_margin_large"
             android:layout_marginLeft="@dimen/layout_margin_large"
+            android:layout_marginRight="@dimen/layout_margin_large"
             android:layout_marginTop="@dimen/layout_margin_large"
             android:fontFamily="sans-serif-light"
             android:textColor="@color/dark_grey"
             android:textSize="@dimen/text_size_extra_large"
-            app:layout_constraintStart_toStartOf="@+id/logo"
-            app:layout_constraintTop_toBottomOf="@+id/logo"
+            app:layout_constraintStart_toStartOf="@+id/eventImage"
+            app:layout_constraintTop_toBottomOf="@+id/eventImage"
+            app:layout_constraintEnd_toEndOf="@+id/eventImage"
             tools:text="Open Source Meetup" />
 
         <TextView
             android:id="@+id/eventOrganiserName"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/layout_margin_moderate"
             android:fontFamily="sans-serif-thin"
-            android:text="TextView"
             android:textColor="@color/dark_grey"
             android:textStyle="bold"
             app:layout_constraintStart_toStartOf="@+id/eventName"
             app:layout_constraintTop_toBottomOf="@+id/eventName"
+            app:layout_constraintEnd_toEndOf="@+id/eventName"
             tools:text="by FOSSASIA"
             android:visibility="gone" />
 
@@ -128,7 +129,7 @@
         </LinearLayout>
 
         <LinearLayout
-            android:id="@+id/linearLayout"
+            android:id="@+id/refundPolicyLinearLayout"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/layout_margin_large"
@@ -179,7 +180,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/linearLayout"
+            app:layout_constraintTop_toBottomOf="@+id/refundPolicyLinearLayout"
             tools:visibility="visible">
 
             <View
@@ -316,10 +317,11 @@
                 android:orientation="horizontal">
 
                 <ImageView
-                    android:id="@+id/logoIcon"
+                    android:id="@+id/organizerLogoIcon"
                     android:layout_width="@dimen/logo_icon_width"
                     android:layout_height="@dimen/logo_icon_height"
                     android:layout_marginRight="@dimen/layout_margin_large"
+                    android:layout_marginEnd="@dimen/layout_margin_large"
                     android:layout_gravity="center_horizontal"
                     android:layout_marginBottom="@dimen/layout_margin_small"
                     android:scaleType="centerCrop"
@@ -365,6 +367,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:paddingLeft="@dimen/padding_large"
+                android:paddingRight="@dimen/padding_large"
                 android:paddingTop="@dimen/padding_small" />
         </LinearLayout>
 


### PR DESCRIPTION
Fixes: #1499

Changes:
- Add right margins and change other attributes according to constraint layout to correct the issue of text being cut off

Additional changes:
- Refactored a few layout view identifiers to remove ambiguity

Screenshots for the change:


<img src = "https://user-images.githubusercontent.com/22665789/55322196-4a03c000-5499-11e9-8853-086d6399b381.jpeg" width = '320' height = '676'/>


<img src = "https://user-images.githubusercontent.com/22665789/55322192-46703900-5499-11e9-86f2-d479d28c6be8.jpeg" width = '320' height = '676'/>

