### PR TITLE
fix: Stop shuffle on like and share

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsFragment.kt
@@ -171,6 +171,7 @@ class SimilarEventsFragment : Fragment() {
 
         handleVisibility(similarEvents)
         Timber.d("Fetched Similar events of size %s", similarEvents.size)
+        if (similarEventsListAdapter.currentList.size != similarEvents.size) similarEvents.shuffle()
         similarEventsListAdapter.submitList(similarEvents)
         similarEventsListAdapter.notifyDataSetChanged()
     }


### PR DESCRIPTION
Fixes #1486 

Changes: Made items not shuffle on adding to favorites and sharing.

Screenshots for the change:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/37517284/55324816-d2d22a00-54a0-11e9-8e96-64c4b801cee6.gif)
