### PR TITLE
feat: add external event url menu option in EventDetailsFragment

### DIFF
--- a/app/src/main/res/menu/event_details.xml
+++ b/app/src/main/res/menu/event_details.xml
@@ -8,6 +8,9 @@
         <item
             android:id="@+id/report_event"
             android:title="@string/report_event" />
+        <item
+            android:id="@+id/open_external_event_url"
+            android:title="@string/open_external_event_url"/>
     </group>
     <item
         android:id="@+id/event_share"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <!--event details-->
     <string name="event_card_date">Event Date :</string>
     <string name="report_event">Report Event</string>
+    <string name="open_external_event_url">Open External Event URL</string>
     <string name="about">About</string>
     <string name="see_more">See more</string>
     <string name="see_less">See less</string>


### PR DESCRIPTION
Fixes: #1505

Changes:

- Added a menu option to EventDetailsFragment to navigate to the external event url for the event
- If the external URL is null, then the menu option is disabled

Screenshots for the change:

![prfor1505](https://user-images.githubusercontent.com/22665789/55380441-d23ba100-553d-11e9-810b-d7f9561d5c7c.gif)

Additional details:
- The option has been titled 'Open External Event URL' to maintain consistency with the eventyay frontend e.g. check the option on the right side at https://eventyay.com/e/a1fcaa21/coc/

- Instead of removing the menu item if the URL is null, I have chosen to disable the option because removing the item requires calling `invalidateOptionsMenu()` which will force the menu options to be prepared once again. This resets the favorite icon status also hence the favorite icon will have to be set again. Hence to avoid this complexity I have simply disabled it. If suggested, I can use this approach to remove the option altogether when the URL is null

EDIT: Updated GIF after now hiding option when URL is null
Will squash commits once this gets approved

![prfor1505new](https://user-images.githubusercontent.com/22665789/55383445-d1a70880-5545-11e9-9bdf-923edc9b5f75.gif)
