### PR TITLE
fix: capitalised words in EditProfileFragment

### DIFF
--- a/app/src/main/res/layout/fragment_edit_profile.xml
+++ b/app/src/main/res/layout/fragment_edit_profile.xml
@@ -59,7 +59,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/first_name"
-                    android:inputType="textPersonName" />
+                    android:inputType="textPersonName|textCapWords" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <com.google.android.material.textfield.TextInputLayout
@@ -74,7 +74,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/last_name"
-                    android:inputType="textPersonName" />
+                    android:inputType="textPersonName|textCapWords" />
             </com.google.android.material.textfield.TextInputLayout>
 
         </LinearLayout>


### PR DESCRIPTION
Fixes #1511

Changes: [Add here what changes were made in this issue and if possible provide links.]
Capitalises words in EditTexts for names in the `EditProfileFragment`

Screenshots for the change:

![prfor1511](https://user-images.githubusercontent.com/22665789/55388500-0ec4c800-5551-11e9-9534-4ff39e954b78.gif)
