### PR TITLE
fix: set secondary color to editprofile buttons 

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
@@ -22,7 +22,7 @@ import androidx.lifecycle.Observer
 import com.google.android.material.snackbar.Snackbar
 import com.squareup.picasso.Picasso
 import kotlinx.android.synthetic.main.fragment_edit_profile.view.editProfileCoordinatorLayout
-import kotlinx.android.synthetic.main.fragment_edit_profile.view.buttonUpdate
+import kotlinx.android.synthetic.main.fragment_edit_profile.view.updateButton
 import kotlinx.android.synthetic.main.fragment_edit_profile.view.firstName
 import kotlinx.android.synthetic.main.fragment_edit_profile.view.lastName
 import kotlinx.android.synthetic.main.fragment_edit_profile.view.profilePhoto
@@ -105,7 +105,7 @@ class EditProfileFragment : Fragment() {
         permissionGranted = (ContextCompat.checkSelfPermission(requireContext(),
             Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED)
 
-        rootView.buttonUpdate.setOnClickListener {
+        rootView.updateButton.setOnClickListener {
             hideSoftKeyboard(context, rootView)
             editProfileViewModel.updateProfile(encodedImage, rootView.firstName.text.toString(),
                 rootView.lastName.text.toString())

--- a/app/src/main/res/layout/fragment_edit_profile.xml
+++ b/app/src/main/res/layout/fragment_edit_profile.xml
@@ -24,7 +24,7 @@
                 app:layout_constraintRight_toRightOf="parent"
                 android:layout_gravity="center_horizontal"
                 android:padding="@dimen/padding_large"
-                android:contentDescription="Profile Photo"
+                android:contentDescription="@string/profile_photo"
                 app:srcCompat="@drawable/ic_account_circle_grey" />
 
                 <com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -32,7 +32,6 @@
                     android:layout_width="@dimen/fab_width"
                     android:layout_height="@dimen/fab_height"
                     app:fabCustomSize="@dimen/fab_height"
-                    app:backgroundTint="@color/colorPrimary"
                     android:layout_margin="@dimen/layout_margin_medium"
                     app:layout_constraintRight_toRightOf="@id/profilePhoto"
                     app:layout_constraintBottom_toBottomOf="@id/profilePhoto"
@@ -79,12 +78,11 @@
 
         </LinearLayout>
 
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/buttonUpdate"
+        <Button
+            android:id="@+id/updateButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            app:backgroundTint="@color/colorPrimary"
             android:text="@string/update"
             android:textColor="@android:color/white" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="last_name_optional">Last Name (Optional)</string>
     <string name="welcome_back">Welcome back!</string>
     <string name="update">Update</string>
+    <string name="profile_photo">Profile Photo</string>
 
     <!--eventyay-->
     <string name="eventyay_logo" translatable="false">eventyay</string>


### PR DESCRIPTION
Fixes: #1532

Changes:
- Changed color of update button and profile photo FAB to secondary color by using app theme
- Refactored 'buttonUpdate' to 'updateButton' for consistency
- Moved a hardcoded string to string resources


Screenshots for the change:

![new button pr non rounded](https://user-images.githubusercontent.com/22665789/55580623-96b8f680-5738-11e9-8cf2-a66aadb48753.jpeg)
