### PR TITLE
chore: Raise minSdk to Lollipop

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.eventyay.attendee"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 5
         versionName "0.1.1"


### PR DESCRIPTION
Fixes: #1142

Changes:
- Updated minSdkVersion to 21 from 16 as OkHttp no longer supports API levels less than 21
- Removed unnecessary checks for sdk version >=21
- Removed 'left' and 'right' and replaced them with 'start' and 'end' in layout files as left/right are not needed in API 21 and start/end are recommended due to their RTL support
