### PR TITLE
fix: set chip layout position at top of SearchResultsFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
@@ -6,6 +6,9 @@ import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.core.view.children
+import android.content.res.ColorStateList
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
@@ -59,35 +62,35 @@ class SearchResultsFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         rootView = inflater.inflate(R.layout.fragment_search_results, container, false)
-        when (safeArgs.date) {
-            getString(R.string.today) -> rootView.today_chip.apply {
-                isChecked = true
-                chipBackgroundColor = resources.getColorStateList(R.color.colorPrimary)
-            }
-            getString(R.string.tomorrow) -> rootView.tomorrow_chip.apply {
-                isChecked = true
-                chipBackgroundColor = resources.getColorStateList(R.color.colorPrimary)
-            }
-            getString(R.string.weekend) -> rootView.weekend_chip.apply {
-                isChecked = true
-                chipBackgroundColor = resources.getColorStateList(R.color.colorPrimary)
-            }
-            getString(R.string.month) -> rootView.month_chip.apply {
-                isChecked = true
-                chipBackgroundColor = resources.getColorStateList(R.color.colorPrimary)
-            }
+
+        val selectedChip = when (safeArgs.date) {
+            getString(R.string.today) -> rootView.today_chip
+            getString(R.string.tomorrow) -> rootView.tomorrow_chip
+            getString(R.string.weekend) -> rootView.weekend_chip
+            getString(R.string.month) -> rootView.month_chip
+            else -> null
+        }
+        selectedChip?.apply {
+            isChecked = true
+            chipBackgroundColor = ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.colorPrimary))
         }
 
         rootView.chipGroup.setOnCheckedChangeListener { chipGroup, id ->
-            for (i in 0 until chipGroup.childCount) {
-                val chip = chipGroup.getChildAt(i) as Chip
-                if (chip.id != chipGroup.checkedChipId) {
-                    chip.chipBackgroundColor = resources.getColorStateList(R.color.grey)
-                    chip.isClickable = true
-                } else {
-                    chip.isClickable = false
-                    chip.chipBackgroundColor = resources.getColorStateList(R.color.colorPrimary)
-                    performSearch(safeArgs, chip.text.toString())
+
+            chipGroup.children.forEach { chip ->
+                if (chip is Chip) {
+                    if (chip.id != chipGroup.checkedChipId) {
+                        chip.chipBackgroundColor =
+                            ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.grey))
+                        chip.isClickable = true
+                    } else {
+                        chip.isClickable = false
+                        chip.chipBackgroundColor =
+                            ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.colorPrimary))
+                        rootView.noSearchResults.isVisible = false
+                        favoriteEventsRecyclerAdapter.submitList(null)
+                        performSearch(safeArgs, chip.text.toString())
+                    }
                 }
             }
         }
@@ -186,11 +189,11 @@ class SearchResultsFragment : Fragment() {
     }
 
     private fun showNoSearchResults(events: List<Event>) {
-        rootView.noSearchResults.visibility = if (events.isEmpty()) View.VISIBLE else View.GONE
+        rootView.noSearchResults.isVisible = events.isEmpty()
     }
 
     private fun showNoInternetError(show: Boolean) {
-        rootView.noInternetCard.visibility = if (show) View.VISIBLE else View.GONE
+        rootView.noInternetCard.isVisible = show
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/res/layout/fragment_search_results.xml
+++ b/app/src/main/res/layout/fragment_search_results.xml
@@ -40,6 +40,48 @@
             android:layout_height="match_parent"
             android:orientation="vertical">
 
+            <HorizontalScrollView
+                    android:layout_width="wrap_content"
+                    android:scrollbars="none"
+                    android:padding="@dimen/padding_medium"
+                    android:layout_height="wrap_content">
+
+                <com.google.android.material.chip.ChipGroup
+                        android:layout_width="wrap_content"
+                        android:id="@+id/chipGroup"
+                        app:singleSelection="true"
+                        android:layout_height="wrap_content">
+
+                    <com.google.android.material.chip.Chip
+                            style="@style/CustomChipChoice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:id="@+id/today_chip"
+                            android:text="@string/today" />
+
+                    <com.google.android.material.chip.Chip
+                            style="@style/CustomChipChoice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:id="@+id/tomorrow_chip"
+                            android:text="@string/tomorrow" />
+
+                    <com.google.android.material.chip.Chip
+                            style="@style/CustomChipChoice"
+                            android:layout_width="wrap_content"
+                            android:id="@+id/weekend_chip"
+                            android:layout_height="wrap_content"
+                            android:text="@string/weekend" />
+
+                    <com.google.android.material.chip.Chip
+                            style="@style/CustomChipChoice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:id="@+id/month_chip"
+                            android:text="@string/month" />
+                </com.google.android.material.chip.ChipGroup>
+            </HorizontalScrollView>
+
             <com.facebook.shimmer.ShimmerFrameLayout
                 android:id="@+id/shimmerSearch"
                 android:layout_width="match_parent"
@@ -64,49 +106,6 @@
             </com.facebook.shimmer.ShimmerFrameLayout>
 
             <include layout="@layout/content_no_internet" />
-
-            <HorizontalScrollView
-                android:layout_width="wrap_content"
-                android:scrollbars="none"
-                android:paddingLeft="@dimen/details_margin_small"
-                android:layout_height="wrap_content"
-                android:paddingStart="@dimen/details_margin_small">
-
-                <com.google.android.material.chip.ChipGroup
-                    android:layout_width="wrap_content"
-                    android:id="@+id/chipGroup"
-                    app:singleSelection="true"
-                    android:layout_height="wrap_content">
-
-                    <com.google.android.material.chip.Chip
-                        style="@style/CustomChipChoice"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:id="@+id/today_chip"
-                        android:text="@string/today" />
-
-                    <com.google.android.material.chip.Chip
-                        style="@style/CustomChipChoice"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:id="@+id/tomorrow_chip"
-                        android:text="@string/tomorrow" />
-
-                    <com.google.android.material.chip.Chip
-                        style="@style/CustomChipChoice"
-                        android:layout_width="wrap_content"
-                        android:id="@+id/weekend_chip"
-                        android:layout_height="wrap_content"
-                        android:text="@string/weekend" />
-
-                    <com.google.android.material.chip.Chip
-                        style="@style/CustomChipChoice"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:id="@+id/month_chip"
-                        android:text="@string/month" />
-                </com.google.android.material.chip.ChipGroup>
-            </HorizontalScrollView>
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/eventsRecycler"


### PR DESCRIPTION
Fixes: #1537

Changes:

- Moved chip layout at top in the vertical LinearLayout in SearchResultsFragment
- Cleaned up chip code and modified it to better suit Kotlin style
- Replaced deprecated method resources.getColorStateList with another method
- Hidden 'no results found' view and recyclerview on switching between chips

Screenshots for the change:

<img src="https://user-images.githubusercontent.com/22665789/55634877-01bc0900-57dd-11e9-8a69-c6dbdeacdbca.gif" width = '350'/>
