### PR TITLE
fix: Hide chip group when there is no internet

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
@@ -24,10 +24,11 @@ import kotlinx.android.synthetic.main.content_no_internet.view.retry
 import kotlinx.android.synthetic.main.content_no_internet.view.noInternetCard
 import kotlinx.android.synthetic.main.fragment_search_results.view.noSearchResults
 import kotlinx.android.synthetic.main.fragment_search_results.view.chipGroup
-import kotlinx.android.synthetic.main.fragment_search_results.view.today_chip
-import kotlinx.android.synthetic.main.fragment_search_results.view.tomorrow_chip
-import kotlinx.android.synthetic.main.fragment_search_results.view.weekend_chip
-import kotlinx.android.synthetic.main.fragment_search_results.view.month_chip
+import kotlinx.android.synthetic.main.fragment_search_results.view.todayChip
+import kotlinx.android.synthetic.main.fragment_search_results.view.tomorrowChip
+import kotlinx.android.synthetic.main.fragment_search_results.view.weekendChip
+import kotlinx.android.synthetic.main.fragment_search_results.view.monthChip
+import kotlinx.android.synthetic.main.fragment_search_results.view.chipGroupLayout
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.di.Scopes
 import org.fossasia.openevent.general.event.Event
@@ -64,10 +65,10 @@ class SearchResultsFragment : Fragment() {
         rootView = inflater.inflate(R.layout.fragment_search_results, container, false)
 
         val selectedChip = when (safeArgs.date) {
-            getString(R.string.today) -> rootView.today_chip
-            getString(R.string.tomorrow) -> rootView.tomorrow_chip
-            getString(R.string.weekend) -> rootView.weekend_chip
-            getString(R.string.month) -> rootView.month_chip
+            getString(R.string.today) -> rootView.todayChip
+            getString(R.string.tomorrow) -> rootView.tomorrowChip
+            getString(R.string.weekend) -> rootView.weekendChip
+            getString(R.string.month) -> rootView.monthChip
             else -> null
         }
         selectedChip?.apply {
@@ -194,6 +195,7 @@ class SearchResultsFragment : Fragment() {
 
     private fun showNoInternetError(show: Boolean) {
         rootView.noInternetCard.isVisible = show
+        rootView.chipGroupLayout.visibility = if (show) View.GONE else View.VISIBLE
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/res/layout/fragment_search_results.xml
+++ b/app/src/main/res/layout/fragment_search_results.xml
@@ -41,6 +41,7 @@
             android:orientation="vertical">
 
             <HorizontalScrollView
+                    android:id="@+id/chipGroupLayout"
                     android:layout_width="wrap_content"
                     android:scrollbars="none"
                     android:padding="@dimen/padding_medium"
@@ -56,20 +57,20 @@
                             style="@style/CustomChipChoice"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:id="@+id/today_chip"
+                            android:id="@+id/todayChip"
                             android:text="@string/today" />
 
                     <com.google.android.material.chip.Chip
                             style="@style/CustomChipChoice"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:id="@+id/tomorrow_chip"
+                            android:id="@+id/tomorrowChip"
                             android:text="@string/tomorrow" />
 
                     <com.google.android.material.chip.Chip
                             style="@style/CustomChipChoice"
                             android:layout_width="wrap_content"
-                            android:id="@+id/weekend_chip"
+                            android:id="@+id/weekendChip"
                             android:layout_height="wrap_content"
                             android:text="@string/weekend" />
 
@@ -77,7 +78,7 @@
                             style="@style/CustomChipChoice"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:id="@+id/month_chip"
+                            android:id="@+id/monthChip"
                             android:text="@string/month" />
                 </com.google.android.material.chip.ChipGroup>
             </HorizontalScrollView>


### PR DESCRIPTION
Details:
- Hide Chipgroup on displaying no internet card
- Rename id an of XML views.

Fixes #1543  

Screenshots for the change:
<img src="https://i.ibb.co/PGv3GnJ/ezgif-4-678aae65b271.gif" width="300">