### PR TITLE
fix: Make chip not clickable while fetching events

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
@@ -24,10 +24,10 @@ import kotlinx.android.synthetic.main.content_no_internet.view.retry
 import kotlinx.android.synthetic.main.content_no_internet.view.noInternetCard
 import kotlinx.android.synthetic.main.fragment_search_results.view.noSearchResults
 import kotlinx.android.synthetic.main.fragment_search_results.view.chipGroup
-import kotlinx.android.synthetic.main.fragment_search_results.view.today_chip
-import kotlinx.android.synthetic.main.fragment_search_results.view.tomorrow_chip
-import kotlinx.android.synthetic.main.fragment_search_results.view.weekend_chip
-import kotlinx.android.synthetic.main.fragment_search_results.view.month_chip
+import kotlinx.android.synthetic.main.fragment_search_results.view.todayChip
+import kotlinx.android.synthetic.main.fragment_search_results.view.tomorrowChip
+import kotlinx.android.synthetic.main.fragment_search_results.view.weekendChip
+import kotlinx.android.synthetic.main.fragment_search_results.view.monthChip
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.di.Scopes
 import org.fossasia.openevent.general.event.Event
@@ -64,10 +64,10 @@ class SearchResultsFragment : Fragment() {
         rootView = inflater.inflate(R.layout.fragment_search_results, container, false)
 
         val selectedChip = when (safeArgs.date) {
-            getString(R.string.today) -> rootView.today_chip
-            getString(R.string.tomorrow) -> rootView.tomorrow_chip
-            getString(R.string.weekend) -> rootView.weekend_chip
-            getString(R.string.month) -> rootView.month_chip
+            getString(R.string.today) -> rootView.todayChip
+            getString(R.string.tomorrow) -> rootView.tomorrowChip
+            getString(R.string.weekend) -> rootView.weekendChip
+            getString(R.string.month) -> rootView.monthChip
             else -> null
         }
         selectedChip?.apply {
@@ -131,6 +131,17 @@ class SearchResultsFragment : Fragment() {
             .nonNull()
             .observe(this, Observer {
                 Snackbar.make(rootView.searchRootLayout, it, Snackbar.LENGTH_LONG).show()
+            })
+
+        searchViewModel.chipClickable
+            .nonNull()
+            .observe(this, Observer {
+                rootView.chipGroup.children.forEach { chip ->
+                    if (chip is Chip) {
+                        chip.isClickable = it
+                        if (chip.isChecked) chip.isClickable = false
+                    }
+                }
             })
 
         rootView.retry.setOnClickListener {

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchViewModel.kt
@@ -39,6 +39,8 @@ class SearchViewModel(
     val error: LiveData<String> = mutableError
     private val mutableShowNoInternetError = MutableLiveData<Boolean>()
     val showNoInternetError: LiveData<Boolean> = mutableShowNoInternetError
+    private val mutableChipClickable = MutableLiveData<Boolean>()
+    val chipClickable: LiveData<Boolean> = mutableChipClickable
     var searchEvent: String? = null
     var savedLocation: String? = null
     private val savedNextDate = getNextDate()
@@ -56,6 +58,7 @@ class SearchViewModel(
         if (mutableEvents.value != null) {
             mutableShowShimmerResults.value = false
             mutableShowNoInternetError.value = false
+            mutableChipClickable.value = true
         }
         if (!isConnected()) return
         preference.putString(SAVED_LOCATION, location)
@@ -178,8 +181,10 @@ class SearchViewModel(
             .observeOn(AndroidSchedulers.mainThread())
             .doOnSubscribe {
                 mutableShowShimmerResults.value = true
+                mutableChipClickable.value = false
             }.doFinally {
                 mutableShowShimmerResults.value = false
+                mutableChipClickable.value = true
             }.subscribe({
                 mutableEvents.value = it
             }, {

--- a/app/src/main/res/layout/fragment_search_results.xml
+++ b/app/src/main/res/layout/fragment_search_results.xml
@@ -56,20 +56,20 @@
                             style="@style/CustomChipChoice"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:id="@+id/today_chip"
+                            android:id="@+id/todayChip"
                             android:text="@string/today" />
 
                     <com.google.android.material.chip.Chip
                             style="@style/CustomChipChoice"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:id="@+id/tomorrow_chip"
+                            android:id="@+id/tomorrowChip"
                             android:text="@string/tomorrow" />
 
                     <com.google.android.material.chip.Chip
                             style="@style/CustomChipChoice"
                             android:layout_width="wrap_content"
-                            android:id="@+id/weekend_chip"
+                            android:id="@+id/weekendChip"
                             android:layout_height="wrap_content"
                             android:text="@string/weekend" />
 
@@ -77,7 +77,7 @@
                             style="@style/CustomChipChoice"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:id="@+id/month_chip"
+                            android:id="@+id/monthChip"
                             android:text="@string/month" />
                 </com.google.android.material.chip.ChipGroup>
             </HorizontalScrollView>


### PR DESCRIPTION
Detail:
- A clickable flag inside SearchViewModel is used to check whether chip should be clickable or not.
- Change id name of chip in XML file

Fixes: #1544

Screenshots for the change:
When loading, those chips card are not clickable any more
<img src="https://i.ibb.co/Ytxc7cV/56197755-668289136956524-4691379411482574848-n.png" width="300">