### PR TITLE
fix: show ErrorSnackMessage in EventDetailsCoordinatorLayout

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -64,6 +64,7 @@ import kotlinx.android.synthetic.main.content_fetching_event_error.view.retry
 import kotlinx.android.synthetic.main.dialog_feedback.view.feedback
 import kotlinx.android.synthetic.main.dialog_feedback.view.feedbackTextInputLayout
 import kotlinx.android.synthetic.main.dialog_feedback.view.feedbackrating
+import kotlinx.android.synthetic.main.fragment_event.eventCoordinatorLayout
 import org.fossasia.openevent.general.CircleTransform
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.about.AboutEventFragmentArgs
@@ -510,6 +511,9 @@ class EventDetailsFragment : Fragment() {
         val bundle = Bundle()
         bundle.putLong(EVENT_ID, safeArgs.eventId)
         socialLinksFragemnt.arguments = bundle
+        socialLinksFragemnt.setErrorSnack {
+            eventCoordinatorLayout.longSnackbar(it)
+        }
         val transaction = childFragmentManager.beginTransaction()
         transaction.add(R.id.frameContainerSocial, socialLinksFragemnt).commit()
     }
@@ -522,6 +526,9 @@ class EventDetailsFragment : Fragment() {
         eventTopicId?.let { bundle.putLong(EVENT_TOPIC_ID, it) }
         eventLocation?.let { bundle.putString(EVENT_LOCATION, it) }
         similarEventsFragment.arguments = bundle
+        similarEventsFragment.setErrorSnack {
+            eventCoordinatorLayout.longSnackbar(it)
+        }
         childFragmentManager.beginTransaction()
             .replace(R.id.frameContainerSimilarEvents, similarEventsFragment).commit()
     }
@@ -548,7 +555,7 @@ class EventDetailsFragment : Fragment() {
         rootView.container.isVisible = !show
         rootView.eventErrorCard.isVisible = show
         val menuItemSize = menuActionBar?.size() ?: 0
-        for (i in 0..(menuItemSize - 1)) {
+        for (i in 0 until menuItemSize) {
             menuActionBar?.getItem(i)?.isVisible = !show
         }
     }

--- a/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsFragment.kt
@@ -15,7 +15,6 @@ import kotlinx.android.synthetic.main.fragment_similar_events.progressBar
 import kotlinx.android.synthetic.main.fragment_similar_events.similarEventsDivider
 import kotlinx.android.synthetic.main.fragment_similar_events.similarEventsRecycler
 import kotlinx.android.synthetic.main.fragment_similar_events.view.similarEventsRecycler
-import kotlinx.android.synthetic.main.fragment_similar_events.view.similarEventsCoordinatorLayout
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.di.Scopes
 import org.fossasia.openevent.general.event.Event
@@ -26,7 +25,6 @@ import org.fossasia.openevent.general.common.FavoriteFabClickListener
 import org.fossasia.openevent.general.event.EventLayoutType
 import org.fossasia.openevent.general.utils.Utils.getAnimSlide
 import org.fossasia.openevent.general.utils.extensions.nonNull
-import org.jetbrains.anko.design.longSnackbar
 import org.koin.android.ext.android.get
 import org.koin.androidx.scope.ext.android.bindScope
 import org.koin.androidx.scope.ext.android.getOrCreateScope
@@ -43,6 +41,7 @@ class SimilarEventsFragment : Fragment() {
     private var similarIdEvents: MutableList<Event> = mutableListOf()
     private var similarLocationEvents: MutableList<Event> = mutableListOf()
     private var similarEvents: MutableList<Event> = mutableListOf()
+    private var showErrorSnack: ((String) -> Unit)? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -79,7 +78,7 @@ class SimilarEventsFragment : Fragment() {
         similarEventsViewModel.error
             .nonNull()
             .observe(viewLifecycleOwner, Observer {
-                rootView.similarEventsCoordinatorLayout.longSnackbar(it)
+                showErrorSnack?.invoke(it)
             })
 
         similarEventsViewModel.progress
@@ -132,6 +131,14 @@ class SimilarEventsFragment : Fragment() {
         similarEventsDivider.isVisible = !similarEvents.isEmpty()
         moreLikeThis.isVisible = !similarEvents.isEmpty()
         similarEventsRecycler.isVisible = !similarEvents.isEmpty()
+    }
+
+    /*
+        function to set errorSnackMessage CallBack, to be invoked ,
+        to be invoked when snack error is generated
+     */
+    fun setErrorSnack(errorSnack: (String) -> Unit) {
+        showErrorSnack = errorSnack
     }
 
     private fun setUpAdapter() {

--- a/app/src/main/java/org/fossasia/openevent/general/social/SocialLinksFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/social/SocialLinksFragment.kt
@@ -11,15 +11,13 @@ import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import kotlinx.android.synthetic.main.fragment_social_links.eventHostDetails
 import kotlinx.android.synthetic.main.fragment_social_links.socialLinksRecycler
-import kotlinx.android.synthetic.main.fragment_social_links.socialLinksCoordinatorLayout
 import kotlinx.android.synthetic.main.fragment_social_links.view.progressBarSocial
-import kotlinx.android.synthetic.main.fragment_social_links.view.socialLinksRecycler
 import kotlinx.android.synthetic.main.fragment_social_links.view.socialLinkReload
+import kotlinx.android.synthetic.main.fragment_social_links.view.socialLinksRecycler
 import kotlinx.android.synthetic.main.fragment_social_links.view.socialNoInternet
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.event.EVENT_ID
 import org.fossasia.openevent.general.utils.extensions.nonNull
-import org.jetbrains.anko.design.longSnackbar
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import timber.log.Timber
 
@@ -29,6 +27,7 @@ class SocialLinksFragment : Fragment() {
     private lateinit var rootView: View
     private var id: Long = -1
     private lateinit var linearLayoutManager: LinearLayoutManager
+    private var showErrorSnack: ((String) -> Unit)? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -77,7 +76,7 @@ class SocialLinksFragment : Fragment() {
         socialLinksViewModel.error
             .nonNull()
             .observe(viewLifecycleOwner, Observer {
-                socialLinksCoordinatorLayout.longSnackbar(it)
+                showErrorSnack?.invoke(it)
             })
 
         socialLinksViewModel.internetError
@@ -87,6 +86,14 @@ class SocialLinksFragment : Fragment() {
             })
 
         return rootView
+    }
+
+    /*
+        function to set errorSnackMessage CallBack, to be invoked ,
+        to be invoked when snack error is generated
+     */
+    fun setErrorSnack(errorSnack: (String) -> Unit) {
+        showErrorSnack = errorSnack
     }
 
     private fun handleVisibility(socialLinks: List<SocialLink>) {


### PR DESCRIPTION
Fixes #1553 

Changes:
 Change the targetView of SnackBar to `EventDetailsCoordinatorLayout` to show the snackMessage without Scrolling

Screenshots for the change:
<img src="https://user-images.githubusercontent.com/24780524/55672144-1d92de00-58b5-11e9-9c3b-e29fd2036fba.gif" width=360>
