### PR TITLE
fix: remove html tags before isNullOrEmpty

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -203,8 +203,9 @@ class EventDetailsFragment : Fragment() {
         }
 
         // Event Description Section
-        if (!event.description.isNullOrEmpty()) {
-            setTextField(rootView.eventDescription, event.description.stripHtml())
+        val description = event.description.stripHtml()
+        if (!description.isNullOrEmpty()) {
+            setTextField(rootView.eventDescription, description)
 
             rootView.eventDescription.post {
                 if (rootView.eventDescription.lineCount > LINE_COUNT) {


### PR DESCRIPTION
Fixes #1554 

Changes: 
using `stripHtml()` to remove html tags before isNullOrEmpty

Screenshots for the change:
<img src="https://user-images.githubusercontent.com/24780524/55673925-fabff400-58cb-11e9-9a15-7658c40a54af.jpeg" width=360>