### PR TITLE
fix: Move network logic into ViewModel with Broadcast Receiver

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/connectivity/MutableConnectionLiveData.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/connectivity/MutableConnectionLiveData.kt
@@ -1,0 +1,33 @@
+package org.fossasia.openevent.general.connectivity
+
+import android.content.Intent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.IntentFilter
+import android.net.ConnectivityManager
+import androidx.lifecycle.MutableLiveData
+import org.fossasia.openevent.general.OpenEventGeneral
+import org.fossasia.openevent.general.utils.Utils
+
+class MutableConnectionLiveData : MutableLiveData<Boolean>() {
+    private val context by lazy {
+        OpenEventGeneral.appContext
+    }
+
+    private val broadcastReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            postValue(Utils.isNetworkConnected(context))
+        }
+    }
+
+    override fun onActive() {
+        super.onActive()
+        val intentFilter = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
+        context?.registerReceiver(broadcastReceiver, intentFilter)
+    }
+
+    override fun onInactive() {
+        super.onInactive()
+        context?.unregisterReceiver(broadcastReceiver)
+    }
+}

--- a/app/src/main/java/org/fossasia/openevent/general/di/Modules.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/di/Modules.kt
@@ -67,6 +67,7 @@ import org.fossasia.openevent.general.search.LocationService
 import org.fossasia.openevent.general.search.SearchTypeViewModel
 import org.fossasia.openevent.general.search.LocationServiceImpl
 import org.fossasia.openevent.general.auth.SmartAuthViewModel
+import org.fossasia.openevent.general.connectivity.MutableConnectionLiveData
 import org.fossasia.openevent.general.settings.SettingsViewModel
 import org.fossasia.openevent.general.social.SocialLink
 import org.fossasia.openevent.general.social.SocialLinkApi
@@ -143,11 +144,12 @@ val apiModule = module {
     factory { AttendeeService(get(), get(), get()) }
     factory { OrderService(get(), get(), get()) }
     factory { Resource() }
+    factory { MutableConnectionLiveData() }
 }
 
 val viewModelModule = module {
     viewModel { LoginViewModel(get(), get(), get()) }
-    viewModel { EventsViewModel(get(), get(), get()) }
+    viewModel { EventsViewModel(get(), get(), get(), get()) }
     viewModel { ProfileViewModel(get(), get()) }
     viewModel { SignUpViewModel(get(), get(), get()) }
     viewModel { EventDetailsViewModel(get(), get()) }
@@ -156,7 +158,7 @@ val viewModelModule = module {
     viewModel { SearchLocationViewModel(get(), get()) }
     viewModel { SearchTimeViewModel(get()) }
     viewModel { SearchTypeViewModel(get(), get()) }
-    viewModel { TicketsViewModel(get(), get(), get(), get()) }
+    viewModel { TicketsViewModel(get(), get(), get(), get(), get()) }
     viewModel { AboutEventViewModel(get(), get()) }
     viewModel { SocialLinksViewModel(get(), get(), get()) }
     viewModel { FavoriteEventsViewModel(get(), get()) }

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchViewModel.kt
@@ -9,7 +9,7 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.common.SingleLiveEvent
-import org.fossasia.openevent.general.data.Network
+import org.fossasia.openevent.general.connectivity.MutableConnectionLiveData
 import org.fossasia.openevent.general.data.Preference
 import org.fossasia.openevent.general.data.Resource
 import org.fossasia.openevent.general.event.Event
@@ -26,7 +26,7 @@ import timber.log.Timber
 class SearchViewModel(
     private val eventService: EventService,
     private val preference: Preference,
-    private val network: Network,
+    private val mutableConnectionLiveData: MutableConnectionLiveData,
     private val resource: Resource
 ) : ViewModel() {
 
@@ -38,8 +38,7 @@ class SearchViewModel(
     val events: LiveData<List<Event>> = mutableEvents
     private val mutableError = SingleLiveEvent<String>()
     val error: LiveData<String> = mutableError
-    private val mutableShowNoInternetError = MutableLiveData<Boolean>()
-    val showNoInternetError: LiveData<Boolean> = mutableShowNoInternetError
+    val connection: LiveData<Boolean> = mutableConnectionLiveData
     private val mutableChipClickable = MutableLiveData<Boolean>()
     val chipClickable: LiveData<Boolean> = mutableChipClickable
     var searchEvent: String? = null
@@ -79,9 +78,8 @@ class SearchViewModel(
 
     fun loadEvents(location: String, time: String, type: String) {
         if (mutableEvents.value != null) {
-            mutableShowShimmerResults.value = false
-            mutableShowNoInternetError.value = false
             mutableChipClickable.value = true
+            return
         }
         if (!isConnected()) return
         preference.putString(SAVED_LOCATION, location)
@@ -289,11 +287,10 @@ class SearchViewModel(
         )
     }
 
-    fun isConnected(): Boolean {
-        val isConnected = network.isNetworkConnected()
-        mutableShowNoInternetError.value = !isConnected
-        mutableShowShimmerResults.value = isConnected
-        return isConnected
+    fun isConnected(): Boolean = mutableConnectionLiveData.value ?: false
+
+    fun clearEvents() {
+        mutableEvents.value = null
     }
 
     override fun onCleared() {

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsViewModel.kt
@@ -9,6 +9,7 @@ import io.reactivex.schedulers.Schedulers
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.auth.AuthHolder
 import org.fossasia.openevent.general.common.SingleLiveEvent
+import org.fossasia.openevent.general.connectivity.MutableConnectionLiveData
 import org.fossasia.openevent.general.data.Resource
 import org.fossasia.openevent.general.event.Event
 import org.fossasia.openevent.general.event.EventService
@@ -18,7 +19,8 @@ class TicketsViewModel(
     private val ticketService: TicketService,
     private val eventService: EventService,
     private val authHolder: AuthHolder,
-    private val resource: Resource
+    private val resource: Resource,
+    private val mutableConnectionLiveData: MutableConnectionLiveData
 ) : ViewModel() {
 
     private val compositeDisposable = CompositeDisposable()
@@ -26,6 +28,7 @@ class TicketsViewModel(
     private val mutableProgressTickets = MutableLiveData<Boolean>()
     val progressTickets: LiveData<Boolean> = mutableProgressTickets
     val tickets = MutableLiveData<List<Ticket>>()
+    val connection: LiveData<Boolean> = mutableConnectionLiveData
     private val mutableError = SingleLiveEvent<String>()
     val error: LiveData<String> = mutableError
     private val mutableEvent = MutableLiveData<Event>()
@@ -72,6 +75,8 @@ class TicketsViewModel(
             })
         )
     }
+
+    fun isConnected(): Boolean = mutableConnectionLiveData.value ?: false
 
     fun totalTicketsEmpty(ticketIdAndQty: List<Pair<Int, Int>>): Boolean {
         return ticketIdAndQty.sumBy { it.second } == 0

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="see_maps">See maps</string>
     <string name="error_message">There was an error. Tap here to try again.</string>
     <string name="in">In</string>
+    <string name="clear_all">Clear All</string>
 
     <!--profile details-->
     <string name="user_name">Username</string>
@@ -120,6 +121,7 @@
     <string name="past">Past ></string>
     <string name="find_my_tickets">Find my tickets</string>
     <string name="no_tickets_available">No tickets available!</string>
+    <string name="ticket_details">Ticket Details</string>
 
     <!--payment details-->
     <string name="card_number">Card Number</string>


### PR DESCRIPTION
Details:
- Use broadcast receiver to detect connectivity change
- Delete Retry button in no internet card as connectivity is auto-detected and reloading will be made automatically
- Set up live data boolean for connectivity in ViewModel

Fixes: #1550 

Screenshots for the change:
<img src="https://i.ibb.co/kBhB5yH/ezgif-4-2cb1f040af19.gif" alt="ezgif-4-2cb1f040af19" border="0">

<img src="https://i.ibb.co/2gxCgYF/ezgif-4-0310143ddb09.gif" alt="ezgif-4-0310143ddb09" border="0">

<img src="https://i.ibb.co/cQgN7fc/ezgif-4-347290b89873.gif" alt="ezgif-4-347290b89873" border="0">

<img src="https://i.ibb.co/q9pPgC7/ezgif-4-b3175399b8b0.gif" alt="ezgif-4-b3175399b8b0" border="0">

<img src="https://i.ibb.co/bmnrJjH/ezgif-4-d2fe43875d8e.gif" alt="ezgif-4-d2fe43875d8e" border="0">

<img src="https://i.ibb.co/PspYGQ5/ezgif-4-fa54acdb6785.gif" alt="ezgif-4-fa54acdb6785" border="0">