### PR TITLE
fix: strip raw html evenr description before sharing

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventUtils.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventUtils.kt
@@ -12,6 +12,7 @@ import org.fossasia.openevent.general.OpenEventGeneral
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.data.Resource
 import org.fossasia.openevent.general.utils.nullToEmpty
+import org.fossasia.openevent.general.utils.stripHtml
 import org.threeten.bp.ZoneId
 import org.threeten.bp.ZonedDateTime
 import org.threeten.bp.format.DateTimeFormatter
@@ -44,8 +45,9 @@ object EventUtils {
         val endsAt = getEventDateTime(event.endsAt, event.timezone)
 
         message.append(resource.getString(R.string.event_name)).append(event.name).append("\n\n")
-        if (!description.isEmpty()) message.append(resource.getString(R.string.event_description))
-                .append(event.description.nullToEmpty()).append("\n\n")
+        if (description.stripHtml().nullToEmpty().isNotEmpty())
+            message.append(resource.getString(R.string.event_description))
+                .append(event.description.nullToEmpty().stripHtml()).append("\n\n")
         message.append(resource.getString(R.string.starts_on))
                 .append(startsAt.format(dateFormat)).append(" ")
                 .append(startsAt.format(timeFormat)).append("\n")
@@ -54,7 +56,7 @@ object EventUtils {
                 .append(endsAt.format(timeFormat)).append("\n")
         message.append(resource.getString(R.string.event_location))
                 .append(event.locationName)
-        if (!eventUrl.isEmpty()) message.append("\n")
+        if (eventUrl.isNotEmpty()) message.append("\n")
                 .append(resource.getString(R.string.event_link))
                 .append(eventUrl)
 
@@ -216,9 +218,9 @@ object EventUtils {
         val sendIntent = Intent()
         sendIntent.action = Intent.ACTION_SEND
         sendIntent.type = "text/plain"
-        sendIntent.putExtra(Intent.EXTRA_TEXT, EventUtils.getSharableInfo(event))
+        sendIntent.putExtra(Intent.EXTRA_TEXT, getSharableInfo(event))
         eventImage.tag?.let {
-            val bmpUri = EventUtils.getLocalBitmapUri(eventImage)
+            val bmpUri = getLocalBitmapUri(eventImage)
             if (bmpUri != null) {
                 sendIntent.type = "image/*"
                 sendIntent.putExtra(Intent.EXTRA_STREAM, bmpUri)


### PR DESCRIPTION
Fixes #1602 

Changes:
- stripHtml() to remove Html tags before putting text in intent
- remove redundant qualifiers
- !value.isEmpty() -> value.isNotEmpty()

Screenshots for the change:
<img src="https://user-images.githubusercontent.com/24780524/56112218-fd7bb280-5f77-11e9-9781-f4fcca68769a.png" width=360>
