### PR TITLE
fix: Remove empty space.

### DIFF
--- a/app/src/main/res/layout/content_event.xml
+++ b/app/src/main/res/layout/content_event.xml
@@ -413,7 +413,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/similarEventsContainer"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Fixes #1630

Changes: Removed empty space between organizer and speaker containers.

Screenshots for the change:
![image](https://user-images.githubusercontent.com/37517284/56411634-05509500-629f-11e9-8a5d-18f0b2c1700e.png)
