### PR TITLE
chore: Move flask filter logic from ViewModels to Services

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeService.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeService.kt
@@ -27,12 +27,13 @@ class AttendeeService(
         return attendeeApi.deleteAttendee(id)
     }
 
-    fun getCustomFormsForAttendees(id: Long, filter: String): Single<List<CustomForm>> {
+    fun getCustomFormsForAttendees(id: Long): Single<List<CustomForm>> {
         val formsSingle = attendeeDao.getCustomFormsForId(id)
         return formsSingle.flatMap {
             if (it.isNotEmpty())
                 formsSingle
-            else
+            else {
+                val filter = "[{\"name\":\"form\",\"op\":\"eq\",\"val\":\"order\"}]"
                 attendeeApi.getCustomFormsForAttendees(id, filter)
                         .map {
                             attendeeDao.insertCustomForms(it)
@@ -40,6 +41,7 @@ class AttendeeService(
                         .flatMap {
                             formsSingle
                         }
+            }
         }
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeViewModel.kt
@@ -311,8 +311,7 @@ class AttendeeViewModel(
     }
 
     fun getCustomFormsForAttendees(eventId: Long) {
-        val filter = "[{\"name\":\"form\",\"op\":\"eq\",\"val\":\"order\"}]"
-        compositeDisposable.add(attendeeService.getCustomFormsForAttendees(eventId, filter)
+        compositeDisposable.add(attendeeService.getCustomFormsForAttendees(eventId)
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .doOnSubscribe {

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
@@ -42,24 +42,25 @@ class EventsViewModel(
 
     fun loadLocationEvents() {
         val query = "[{\"name\":\"location-name\",\"op\":\"ilike\",\"val\":\"%${mutableSavedLocation.value}%\"}]"
-
-        compositeDisposable.add(eventService.getEventsByLocation(query)
-            .subscribeOn(Schedulers.io())
-            .observeOn(AndroidSchedulers.mainThread())
-            .doOnSubscribe {
-                mutableShowShimmerEvents.value = true
-            }
-            .doFinally {
-                mutableProgress.value = false
-                mutableShowShimmerEvents.value = false
-                lastSearch = mutableSavedLocation.value ?: ""
-            }.subscribe({
-                mutableEvents.value = it
-            }, {
-                Timber.e(it, "Error fetching events")
-                mutableError.value = resource.getString(R.string.error_fetching_events_message)
-            })
-        )
+        if (lastSearch != savedLocation.value) {
+            compositeDisposable.add(eventService.getEventsByLocation(query)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .doOnSubscribe {
+                    mutableShowShimmerEvents.value = true
+                }
+                .doFinally {
+                    mutableProgress.value = false
+                    mutableShowShimmerEvents.value = false
+                    lastSearch = mutableSavedLocation.value ?: ""
+                }.subscribe({
+                    mutableEvents.value = it
+                }, {
+                    Timber.e(it, "Error fetching events")
+                    mutableError.value = resource.getString(R.string.error_fetching_events_message)
+                })
+            )
+        }
     }
 
     fun isConnected(): Boolean = mutableConnectionLiveData.value ?: false


### PR DESCRIPTION
Fixes #1344

Changes: Earlier, ViewModels were building flask filter queries themselves and passing them to Services.

This was not good because this leaked the data retrieval logic into the ViewModels. Only the Services should be concerned with data retrieval and they should abstract out that logic.

This change moves the logic into Services where it belongs.
