### PR TITLE
fix query,use jacksonObjectMapper and view holder crash

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventService.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventService.kt
@@ -79,7 +79,7 @@ class EventService(
         return eventDao.getFavoriteEvents()
     }
 
-    fun getEventsByLocation(locationName: String): Single<List<Event>> {
+    fun getEventsByLocation(locationName: String?): Single<List<Event>> {
         val query = "[{\"name\":\"location-name\",\"op\":\"ilike\",\"val\":\"%$locationName%\"}]"
         return eventApi.searchEvents("name", query).flatMap { apiList ->
             val eventIds = apiList.map { it.id }.toList()

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventViewHolder.kt
@@ -61,17 +61,16 @@ class EventViewHolder(override val containerView: View) : RecyclerView.ViewHolde
 
         setFabBackground(event.favorite)
 
-        event.eventType.let {
-            if (it != null)
-                addchips(it.name)
-        }
-        event.eventTopic.let {
-            if (it != null)
-                addchips(it.name)
-        }
-        event.eventSubTopic.let {
-            if (it != null)
-                addchips(it.name)
+        if (containerView.chipTags != null) {
+                event.eventType?.let {
+                    addchips(it.name)
+                }
+                event.eventTopic?.let {
+                    addchips(it.name)
+                }
+                event.eventSubTopic?.let {
+                    addchips(it.name)
+                }
         }
 
         event.originalImageUrl?.let { url ->

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
@@ -41,9 +41,8 @@ class EventsViewModel(
     }
 
     fun loadLocationEvents() {
-        val query = "[{\"name\":\"location-name\",\"op\":\"ilike\",\"val\":\"%${mutableSavedLocation.value}%\"}]"
         if (lastSearch != savedLocation.value) {
-            compositeDisposable.add(eventService.getEventsByLocation(query)
+            compositeDisposable.add(eventService.getEventsByLocation(mutableSavedLocation.value)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .doOnSubscribe {

--- a/app/src/main/java/org/fossasia/openevent/general/event/subtopic/EventSubTopicConverter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/subtopic/EventSubTopicConverter.kt
@@ -2,12 +2,13 @@ package org.fossasia.openevent.general.event.subtopic
 
 import androidx.room.TypeConverter
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 
 class EventSubTopicConverter {
 
     @TypeConverter
     fun toEventSubTopic(json: String): EventSubTopic? {
-        return ObjectMapper().readerFor(EventSubTopic::class.java).readValue<EventSubTopic>(json)
+        return jacksonObjectMapper().readerFor(EventSubTopic::class.java).readValue<EventSubTopic>(json)
     }
 
     @TypeConverter

--- a/app/src/main/java/org/fossasia/openevent/general/event/topic/EventTopicConverter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/topic/EventTopicConverter.kt
@@ -2,11 +2,12 @@ package org.fossasia.openevent.general.event.topic
 
 import androidx.room.TypeConverter
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 
 class EventTopicConverter {
     @TypeConverter
     fun toEventTopic(json: String): EventTopic? {
-        return ObjectMapper().readerFor(EventTopic::class.java).readValue<EventTopic>(json)
+        return jacksonObjectMapper().readerFor(EventTopic::class.java).readValue<EventTopic>(json)
     }
 
         @TypeConverter

--- a/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsViewModel.kt
@@ -48,9 +48,8 @@ class SimilarEventsViewModel(private val eventService: EventService, private val
     }
 
     fun loadSimilarLocationEvents(location: String) {
-        val query = "[{\"name\":\"location-name\",\"op\":\"ilike\",\"val\":\"%$location%\"}]"
 
-        compositeDisposable.add(eventService.getEventsByLocation(query)
+        compositeDisposable.add(eventService.getEventsByLocation(location)
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .doOnSubscribe {

--- a/app/src/main/java/org/fossasia/openevent/general/event/types/EventTypeConverter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/types/EventTypeConverter.kt
@@ -2,11 +2,12 @@ package org.fossasia.openevent.general.event.types
 
 import androidx.room.TypeConverter
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 
 class EventTypeConverter {
     @TypeConverter
     fun toEventType(json: String): EventType? {
-        return ObjectMapper().readerFor(EventType::class.java).readValue<EventType>(json)
+        return jacksonObjectMapper().readerFor(EventType::class.java).readValue<EventType>(json)
     }
 
     @TypeConverter


### PR DESCRIPTION
Fixes #1637 

Changes: Use jacksonObjectMapper instead of ObjectMapper(),Do not add chip view in favourtie view items,nested query fix for location events

Screenshots for the change: