### PR TITLE
refactor: Use Kotlin only safe args plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'androidx.navigation.safeargs'
+apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 def STRIPE_API_TOKEN = System.getenv('STRIPE_API_TOKEN') ?: "YOUR_API_KEY"
 def MAPBOX_KEY = System.getenv('MAPBOX_KEY') ?: "pk.eyJ1IjoiYW5nbWFzMSIsImEiOiJjanNqZDd0N2YxN2Q5NDNuNTBiaGt6eHZqIn0.BCrxjW6rP_OuOuGtbhVEQg"

--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
@@ -555,9 +555,7 @@ class AttendeeFragment : Fragment() {
 
     private fun openOrderCompletedFragment() {
         attendeeViewModel.paymentCompleted.value = false
-        OrderCompletedFragmentArgs.Builder()
-            .setEventId(safeArgs.eventId)
-            .build()
+        OrderCompletedFragmentArgs(safeArgs.eventId)
             .toBundle()
             .also { bundle ->
                 findNavController(rootView).navigate(R.id.orderCompletedFragment, bundle, getAnimFade())

--- a/app/src/main/java/org/fossasia/openevent/general/auth/ProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/ProfileFragment.kt
@@ -42,9 +42,7 @@ class ProfileFragment : Fragment() {
     private var emailSettings: String? = null
 
     private fun redirectToLogin() {
-        LoginFragmentArgs.Builder()
-            .setSnackbarMessage(getString(R.string.log_in_first))
-            .build()
+        LoginFragmentArgs(getString(R.string.log_in_first))
             .toBundle()
             .also { bundle ->
                 findNavController(rootView).navigate(R.id.loginFragment, bundle, getAnimFade())
@@ -104,9 +102,7 @@ class ProfileFragment : Fragment() {
         rootView.manageEventsLL.setOnClickListener { startOrgaApp("com.eventyay.organizer") }
 
         rootView.settingsLL.setOnClickListener {
-
-            SettingsFragmentArgs.Builder(emailSettings)
-                .build()
+            SettingsFragmentArgs(emailSettings)
                 .toBundle()
                 .also { bundle ->
                     findNavController(rootView).navigate(R.id.settingsFragment, bundle, getAnimFade())

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -125,7 +125,7 @@ class EventDetailsFragment : Fragment() {
                 }
                 runOnce = false
 
-                Timber.d("Fetched events of id %d", safeArgs.eventId)
+                Timber.d("Fetched events of id ${safeArgs.eventId}")
                 showEventErrorScreen(false)
                 setHasOptionsMenu(true)
             })
@@ -176,9 +176,8 @@ class EventDetailsFragment : Fragment() {
         }
 
         val speakerClickListener: SpeakerClickListener = object : SpeakerClickListener {
-            override fun onClick(speakerId: Long) { SpeakerFragmentArgs.Builder()
-                .setSpeakerId(speakerId)
-                .build()
+            override fun onClick(speakerId: Long) {
+                SpeakerFragmentArgs(speakerId)
                 .toBundle()
                 .also { bundle ->
                     findNavController(rootView).navigate(R.id.speakerFragment, bundle, getAnimSlide())
@@ -264,9 +263,7 @@ class EventDetailsFragment : Fragment() {
         currency = Currency.getInstance(event.paymentCurrency ?: "USD").symbol
         // About event on-click
         val aboutEventOnClickListener = View.OnClickListener {
-            AboutEventFragmentArgs.Builder()
-                .setEventId(safeArgs.eventId)
-                .build()
+            AboutEventFragmentArgs(safeArgs.eventId)
                 .toBundle()
                 .also { bundle ->
                     findNavController(rootView).navigate(R.id.aboutEventFragment, bundle, getAnimSlide())
@@ -382,9 +379,7 @@ class EventDetailsFragment : Fragment() {
                 return true
             }
             R.id.open_faqs -> {
-                EventFAQFragmentArgs.Builder()
-                    .setEventId(safeArgs.eventId)
-                    .build()
+                EventFAQFragmentArgs(safeArgs.eventId)
                     .toBundle()
                     .also { bundle ->
                         findNavController(rootView).navigate(R.id.eventFAQFragment, bundle, getAnimSlide())
@@ -443,10 +438,7 @@ class EventDetailsFragment : Fragment() {
     }
 
     private fun loadTicketFragment() {
-        TicketsFragmentArgs.Builder()
-            .setEventId(safeArgs.eventId)
-            .setCurrency(currency)
-            .build()
+        TicketsFragmentArgs(safeArgs.eventId, currency)
             .toBundle()
             .also { bundle ->
                 findNavController(rootView).navigate(R.id.ticketsFragment, bundle, getAnimSlide())
@@ -511,9 +503,7 @@ class EventDetailsFragment : Fragment() {
     }
 
     private fun redirectToLogin() {
-        LoginFragmentArgs.Builder()
-            .setSnackbarMessage(getString(R.string.log_in_first))
-            .build()
+        LoginFragmentArgs(getString(R.string.log_in_first))
             .toBundle()
             .also { bundle ->
                 findNavController(rootView).navigate(R.id.loginFragment, bundle, Utils.getAnimFade())

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -166,9 +166,8 @@ class EventsFragment : Fragment(), ScrollToTop {
         super.onViewCreated(view, savedInstanceState)
 
         val eventClickListener: EventClickListener = object : EventClickListener {
-            override fun onClick(eventID: Long) { EventDetailsFragmentArgs.Builder()
-                .setEventId(eventID)
-                .build()
+            override fun onClick(eventID: Long) {
+                EventDetailsFragmentArgs(eventID)
                 .toBundle()
                 .also { bundle ->
                     findNavController(view).navigate(R.id.eventDetailsFragment, bundle, getAnimFade())
@@ -198,12 +197,12 @@ class EventsFragment : Fragment(), ScrollToTop {
     }
 
     private fun openSearch(hashTag: String) {
-        SearchResultsFragmentArgs.Builder()
-            .setQuery("")
-            .setLocation(Preference().getString(SAVED_LOCATION).toString())
-            .setDate(getString(R.string.anytime))
-            .setType(hashTag)
-            .build()
+        SearchResultsFragmentArgs(
+            query = "",
+            location = Preference().getString(SAVED_LOCATION).toString(),
+            date = getString(R.string.anytime),
+            type = hashTag
+        )
             .toBundle()
             .also { bundle ->
                 findNavController(rootView).navigate(R.id.searchResultsFragment, bundle, getAnimSlide())

--- a/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/topic/SimilarEventsFragment.kt
@@ -98,9 +98,7 @@ class SimilarEventsFragment : Fragment() {
 
         val eventClickListener: EventClickListener = object : EventClickListener {
             override fun onClick(eventID: Long) {
-                EventDetailsFragmentArgs.Builder()
-                    .setEventId(eventID)
-                    .build()
+                EventDetailsFragmentArgs(eventID)
                     .toBundle()
                     .also { bundle ->
                         findNavController(view).navigate(R.id.eventDetailsFragment, bundle,

--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
@@ -118,9 +118,8 @@ class FavoriteFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         val eventClickListener: EventClickListener = object : EventClickListener {
-            override fun onClick(eventID: Long) { EventDetailsFragmentArgs.Builder()
-                .setEventId(eventID)
-                .build()
+            override fun onClick(eventID: Long) {
+                EventDetailsFragmentArgs(eventID)
                 .toBundle()
                 .also { bundle ->
                     findNavController(view).navigate(R.id.eventDetailsFragment, bundle, getAnimFade())
@@ -151,11 +150,7 @@ class FavoriteFragment : Fragment() {
     }
 
     private fun openSearchResult(time: String) {
-        SearchResultsFragmentArgs.Builder()
-            .setQuery("")
-            .setLocation(Preference().getString(SAVED_LOCATION).toString())
-            .setDate(time)
-            .build()
+        SearchResultsFragmentArgs(query = "", location = Preference().getString(SAVED_LOCATION).toString(), date = time)
             .toBundle()
             .also { bundle ->
                 findNavController(rootView).navigate(R.id.searchResultsFragment, bundle, Utils.getAnimSlide())

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsFragment.kt
@@ -73,9 +73,7 @@ class OrderDetailsFragment : Fragment() {
 
         val eventDetailsListener = object : OrderDetailsRecyclerAdapter.EventDetailsListener {
             override fun onClick(eventID: Long) {
-                EventDetailsFragmentArgs.Builder()
-                    .setEventId(eventID)
-                    .build()
+                EventDetailsFragmentArgs(eventID)
                     .toBundle()
                     .also { bundle ->
                         findNavController(rootView).navigate(R.id.eventDetailsFragment, bundle, getAnimFade())

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
@@ -81,10 +81,7 @@ class OrdersUnderUserFragment : Fragment(), ScrollToTop {
 
             val recyclerViewClickListener = object : OrdersRecyclerAdapter.OrderClickListener {
                 override fun onClick(eventID: Long, orderIdentifier: String) {
-                    OrderDetailsFragmentArgs.Builder()
-                        .setEventId(eventID)
-                        .setOrders(orderIdentifier)
-                        .build()
+                    OrderDetailsFragmentArgs(eventID, orderIdentifier)
                         .toBundle()
                         .also { bundle ->
                             findNavController(rootView).navigate(R.id.orderDetailsFragment, bundle, getAnimFade())
@@ -93,9 +90,7 @@ class OrdersUnderUserFragment : Fragment(), ScrollToTop {
             }
 
             rootView.expireFilter.setOnClickListener {
-                OrdersUnderUserFragmentArgs.Builder()
-                    .setShowExpired(true)
-                    .build()
+                OrdersUnderUserFragmentArgs(showExpired = true)
                     .toBundle()
                     .also { bundle ->
                         findNavController(rootView).navigate(R.id.orderUnderUserFragment, bundle, getAnimSlide())
@@ -156,9 +151,7 @@ class OrdersUnderUserFragment : Fragment(), ScrollToTop {
     }
 
     private fun redirectToLogin() {
-        LoginFragmentArgs.Builder()
-            .setSnackbarMessage(getString(R.string.log_in_first))
-            .build()
+        LoginFragmentArgs(getString(R.string.log_in_first))
             .toBundle()
             .also { bundle ->
                 findNavController(rootView).navigate(R.id.loginFragment, bundle, getAnimFade())

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchFilterFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchFilterFragment.kt
@@ -62,13 +62,13 @@ class SearchFilterFragment : Fragment() {
                 setBackIndicator()
                 val navigator = Navigation.findNavController(rootView)
                 navigator.popBackStack(R.id.searchResultsFragment, true)
-                SearchFilterFragmentArgs.Builder()
-                    .setDate(safeArgs.date)
-                    .setFreeEvents(isFreeStuffChecked)
-                    .setLocation(safeArgs.location)
-                    .setType(safeArgs.type)
-                    .setQuery(safeArgs.query)
-                    .build()
+                SearchFilterFragmentArgs(
+                    date = safeArgs.date,
+                    freeEvents = isFreeStuffChecked,
+                    location = safeArgs.location,
+                    type = safeArgs.type,
+                    query = safeArgs.query
+                )
                     .toBundle()
                     .also {
                         navigator.navigate(R.id.searchResultsFragment, it, getAnimFade())

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchFragment.kt
@@ -45,9 +45,7 @@ class SearchFragment : Fragment() {
         setHasOptionsMenu(true)
 
         rootView.timeTextView.setOnClickListener {
-            SearchTimeFragmentArgs.Builder()
-                .setTime(rootView.timeTextView.text.toString())
-                .build()
+            SearchTimeFragmentArgs(rootView.timeTextView.text.toString())
                 .toBundle()
                 .also { bundle ->
                     Navigation.findNavController(rootView).navigate(R.id.searchTimeFragment, bundle, getAnimSlide())
@@ -76,9 +74,7 @@ class SearchFragment : Fragment() {
         rootView.locationTextView.text = searchViewModel.savedLocation
 
         rootView.locationTextView.setOnClickListener {
-            SearchLocationFragmentArgs.Builder()
-                .setFromSearchFragment(true)
-                .build()
+            SearchLocationFragmentArgs(fromSearchFragment = true)
                 .toBundle()
                 .also { bundle ->
                     Navigation.findNavController(rootView).navigate(R.id.searchLocationFragment, bundle, getAnimSlide())
@@ -86,9 +82,7 @@ class SearchFragment : Fragment() {
         }
 
         rootView.eventTypeTextView.setOnClickListener {
-            SearchTypeFragmentArgs.Builder()
-                .setType(rootView.eventTypeTextView.text.toString())
-                .build()
+            SearchLocationFragmentArgs(fromSearchFragment = true)
                 .toBundle()
                 .also { bundle ->
                     Navigation.findNavController(rootView).navigate(R.id.searchTypeFragment, bundle, getAnimSlide())
@@ -121,12 +115,12 @@ class SearchFragment : Fragment() {
         searchItem.actionView = searchView
         val queryListener = object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String): Boolean {
-                SearchResultsFragmentArgs.Builder()
-                    .setQuery(query)
-                    .setLocation(rootView.locationTextView.text.toString().nullToEmpty())
-                    .setDate((searchViewModel.savedTime ?: getString(R.string.anytime)).nullToEmpty())
-                    .setType((searchViewModel.savedType ?: getString(R.string.anything)).nullToEmpty())
-                    .build()
+                SearchResultsFragmentArgs(
+                    query = query,
+                    location = rootView.locationTextView.text.toString().nullToEmpty(),
+                    date = (searchViewModel.savedTime ?: getString(R.string.anytime)).nullToEmpty(),
+                    type = (searchViewModel.savedType ?: getString(R.string.anything)).nullToEmpty()
+                )
                     .toBundle()
                     .also { bundle ->
                         findNavController(rootView).navigate(R.id.searchResultsFragment, bundle, getAnimSlide())

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
@@ -194,9 +194,7 @@ class SearchResultsFragment : Fragment(), CompoundButton.OnCheckedChangeListener
         super.onViewCreated(view, savedInstanceState)
         val eventClickListener: EventClickListener = object : EventClickListener {
             override fun onClick(eventID: Long) {
-                EventDetailsFragmentArgs.Builder()
-                    .setEventId(eventID)
-                    .build()
+                EventDetailsFragmentArgs(eventID)
                     .toBundle()
                     .also { bundle ->
                         Navigation.findNavController(view).navigate(R.id.eventDetailsFragment, bundle, getAnimFade())
@@ -244,13 +242,13 @@ class SearchResultsFragment : Fragment(), CompoundButton.OnCheckedChangeListener
                 true
             }
             R.id.filter -> {
-                SearchFilterFragmentArgs.Builder()
-                    .setDate(safeArgs.date)
-                    .setFreeEvents(safeArgs.freeEvents)
-                    .setLocation(safeArgs.location)
-                    .setType(safeArgs.type)
-                    .setQuery(safeArgs.query)
-                    .build()
+                SearchFilterFragmentArgs(
+                    date = safeArgs.date,
+                    freeEvents = safeArgs.freeEvents,
+                    location = safeArgs.location,
+                    type = safeArgs.type,
+                    query = safeArgs.query
+                )
                     .toBundle()
                     .also {
                         Navigation.findNavController(rootView).navigate(R.id.searchFilterFragment, it, getAnimFade())

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
@@ -148,10 +148,7 @@ class TicketsFragment : Fragment() {
 
         val wrappedTicketAndQty = TicketIdAndQtyWrapper(ticketIdAndQty)
 
-        AttendeeFragmentArgs.Builder()
-            .setTicketIdAndQty(wrappedTicketAndQty)
-            .setEventId(safeArgs.eventId)
-            .build()
+        AttendeeFragmentArgs(eventId = safeArgs.eventId, ticketIdAndQty = wrappedTicketAndQty)
             .toBundle()
             .also { bundle ->
                 findNavController(rootView).navigate(R.id.attendeeFragment, bundle, getAnimSlide())
@@ -159,9 +156,7 @@ class TicketsFragment : Fragment() {
     }
 
     private fun redirectToLogin() {
-        LoginFragmentArgs.Builder()
-            .setSnackbarMessage(getString(R.string.log_in_first))
-            .build()
+        LoginFragmentArgs(getString(R.string.log_in_first))
             .toBundle()
             .also { bundle ->
                 findNavController(rootView).navigate(R.id.loginFragment, bundle, getAnimFade())

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -50,7 +50,7 @@
         tools:layout="@layout/fragment_search_location">
 
         <argument
-            android:name="FromSearchFragment"
+            android:name="fromSearchFragment"
             app:argType="boolean"
             android:defaultValue="false"/>
     </fragment>


### PR DESCRIPTION
Uses the kotlin version of the safe args plugin to
get rid of the builder pattern when creating the arguments object
for a destination.

Fixes #1612. 
Changes: Migrates the project to use the kotlin safe args plugin