### PR TITLE
fix: Make chip not checkable and search possible

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
@@ -150,7 +150,10 @@ class FavoriteFragment : Fragment() {
     }
 
     private fun openSearchResult(time: String) {
-        SearchResultsFragmentArgs(query = "", location = Preference().getString(SAVED_LOCATION).toString(), date = time)
+        SearchResultsFragmentArgs(query = "",
+            location = Preference().getString(SAVED_LOCATION).toString(),
+            type = getString(R.string.anything),
+            date = time)
             .toBundle()
             .also { bundle ->
                 findNavController(rootView).navigate(R.id.searchResultsFragment, bundle, Utils.getAnimSlide())

--- a/app/src/main/res/layout/fragment_favorite.xml
+++ b/app/src/main/res/layout/fragment_favorite.xml
@@ -41,18 +41,21 @@
                    android:layout_width="wrap_content"
                    android:layout_height="wrap_content"
                    android:text="@string/today"
+                   android:checkable="false"
                    android:id="@+id/todayChip"/>
 
                <com.google.android.material.chip.Chip
                    android:layout_width="wrap_content"
                    android:layout_height="wrap_content"
                    android:text="@string/tomorrow"
+                   android:checkable="false"
                    android:id="@+id/tomorrowChip"/>
 
                <com.google.android.material.chip.Chip
                    android:layout_width="wrap_content"
                    android:layout_height="wrap_content"
                    android:text="@string/weekend"
+                   android:checkable="false"
                    android:id="@+id/weekendChip"/>
 
                <com.google.android.material.chip.Chip
@@ -60,6 +63,7 @@
                    android:layout_height="wrap_content"
                    android:text="@string/month"
                    android:textSize="@dimen/text_size_small"
+                   android:checkable="false"
                    android:id="@+id/monthChip"/>
            </com.google.android.material.chip.ChipGroup>
 


### PR DESCRIPTION
Detail:
- In FavoriteFragment, make chips not clickable
- Make search possible by adding search type

Fixes: #1655

Screenshots for the change:
<img src="https://i.imgur.com/aohvY97.gif">