### PR TITLE
fix: Enable reloading when pulling in EventsFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -151,6 +151,7 @@ class EventsFragment : Fragment(), ScrollToTop {
         rootView.swiperefresh.setOnRefreshListener {
             showNoInternetScreen(!eventsViewModel.isConnected())
             eventsViewModel.clearEvents()
+            eventsViewModel.clearLastSearch()
             if (!eventsViewModel.isConnected()) {
                 rootView.swiperefresh.isRefreshing = false
             } else {

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
@@ -59,6 +59,8 @@ class EventsViewModel(
                     mutableError.value = resource.getString(R.string.error_fetching_events_message)
                 })
             )
+        } else {
+            mutableProgress.value = false
         }
     }
 
@@ -66,6 +68,10 @@ class EventsViewModel(
 
     fun clearEvents() {
         mutableEvents.value = null
+    }
+
+    fun clearLastSearch() {
+        lastSearch = ""
     }
 
     fun loadEvents() {


### PR DESCRIPTION
Details:
- Clear last search variable so that events are fetched again in EventsViewModel

Fixes #1657

Screenshots for the change:
<img src="https://i.imgur.com/5i1c0Y3.gif">