### PR TITLE
fix: Repeating HashTags

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventViewHolder.kt
@@ -63,6 +63,7 @@ class EventViewHolder(override val containerView: View) : RecyclerView.ViewHolde
         setFabBackground(event.favorite)
 
         if (containerView.chipTags != null) {
+            containerView.chipTags.removeAllViews()
             event.eventType?.let {
                 addChips(it.name)
             }


### PR DESCRIPTION
Fixes #1653 

Changes: 
- calling `chipGroup.removeAllView/()` before adding chips

Screenshots for the change:
<img src="https://user-images.githubusercontent.com/24780524/56632241-782e8700-6676-11e9-8051-e49eeb181e12.gif" width=360> 
