### PR TITLE
fix: Prevent making a lot of fragment on backstack when filtering search result

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchFilterFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchFilterFragment.kt
@@ -60,6 +60,8 @@ class SearchFilterFragment : Fragment() {
             }
             R.id.filter_set -> {
                 setBackIndicator()
+                val navigator = Navigation.findNavController(rootView)
+                navigator.popBackStack(R.id.searchResultsFragment, true)
                 SearchFilterFragmentArgs.Builder()
                     .setDate(safeArgs.date)
                     .setFreeEvents(isFreeStuffChecked)
@@ -69,8 +71,7 @@ class SearchFilterFragment : Fragment() {
                     .build()
                     .toBundle()
                     .also {
-                        Navigation.findNavController(rootView)
-                            .navigate(R.id.searchResultsFragment, it, getAnimFade())
+                        navigator.navigate(R.id.searchResultsFragment, it, getAnimFade())
                     }
                 true
             }


### PR DESCRIPTION
Prevent making a lot of fragment on the back stack when filtering the search result

Details:
Pop the fragment back to SearchResult and then start making a new search again with filter included

Fixes: #1658 

Screenshots for the change:
<img src="https://i.ibb.co/Cm38Nx5/ezgif-2-f28aa249f74e.gif" alt="ezgif-2-f28aa249f74e" border="0">