### PR TITLE
fix: Make search button possible

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchLocationFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchLocationFragment.kt
@@ -147,7 +147,7 @@ class SearchLocationFragment : Fragment() {
         val subject = PublishSubject.create<String>()
         rootView.locationSearchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String): Boolean {
-                handleDisplayPlaceSuggestions(query, subject)
+                savePlaceAndRedirectToMain(query)
                 return false
             }
 


### PR DESCRIPTION
Detail:
There was a discussion between me and @theLimitBreaker on the use of search button. Currently, it is used to make the request for autosuggestion, which I find not really useful because from my experience: when I'm having a good internet connection, then the autosuggestion appear really well but if the connection is poor, then I'm blocked in that fragment and I cannot navigate to other fragment and use the app right the start

In my opinion, the search button is the indication for searching, so it should not confuse users with a different meaning, even with good intention.

Fixes: #1673