### PR TITLE
feat: Add shared element transition

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/common/RecyclerViewCallbacks.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/common/RecyclerViewCallbacks.kt
@@ -10,8 +10,9 @@ interface EventClickListener {
      * The function to be invoked when an event item is clicked
      *
      * @param eventID The ID of the clicked event
+     * @param itemPosition The position of event object in the adapter
      */
-    fun onClick(eventID: Long)
+    fun onClick(eventID: Long, itemPosition: Int)
 }
 
 /**

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventViewHolder.kt
@@ -45,10 +45,12 @@ class EventViewHolder(override val containerView: View) : RecyclerView.ViewHolde
      */
     fun bind(
         event: Event,
-        dateFormat: String
+        dateFormat: String,
+        itemPosition: Int
     ) {
         containerView.eventName.text = event.name
         containerView.locationName.text = event.locationName
+        containerView.eventImage.transitionName = "cardItemEventImage$itemPosition"
 
         val startsAt = EventUtils.getEventDateTime(event.startsAt, event.timezone)
         val endsAt = EventUtils.getEventDateTime(event.endsAt, event.timezone)
@@ -91,7 +93,7 @@ class EventViewHolder(override val containerView: View) : RecyclerView.ViewHolde
         }
 
         containerView.setOnClickListener {
-            eventClickListener?.onClick(event.id)
+            eventClickListener?.onClick(event.id, itemPosition)
                 ?: Timber.e("Event Click listener on ${this::class.java.canonicalName} is null")
         }
 

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsListAdapter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsListAdapter.kt
@@ -46,7 +46,7 @@ class EventsListAdapter(
     override fun onBindViewHolder(holder: EventViewHolder, position: Int) {
         val event = getItem(position)
         holder.apply {
-            bind(event, EVENT_DATE_FORMAT)
+            bind(event, EVENT_DATE_FORMAT, position)
             eventClickListener = onEventClick
             favFabClickListener = onFavFabClick
             hashTagClickListAdapter = onHashtagClick

--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteEventsRecyclerAdapter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteEventsRecyclerAdapter.kt
@@ -43,7 +43,7 @@ class FavoriteEventsRecyclerAdapter(
     override fun onBindViewHolder(holder: EventViewHolder, position: Int) {
         val event = getItem(position)
         holder.apply {
-            bind(event, FAVORITE_EVENT_DATE_FORMAT)
+            bind(event, FAVORITE_EVENT_DATE_FORMAT, position)
             eventClickListener = onEventClick
             favFabClickListener = onFavFabClick
         }

--- a/app/src/main/java/org/fossasia/openevent/general/utils/DataBindingAdapters.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/utils/DataBindingAdapters.kt
@@ -6,7 +6,6 @@ import android.widget.TextView
 import androidx.databinding.BindingAdapter
 import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
-import org.fossasia.openevent.general.CircleTransform
 import org.fossasia.openevent.general.R
 import timber.log.Timber
 
@@ -40,13 +39,4 @@ fun setAvatarUrl(imageView: ImageView, url: String?) {
                 Timber.e(e)
             }
         })
-}
-
-@BindingAdapter("headerUrl")
-fun setOriginalImageUrl(imageView: ImageView, url: String?) {
-    Picasso.get()
-        .load(url)
-        .placeholder(R.drawable.header)
-        .transform(CircleTransform())
-        .into(imageView)
 }

--- a/app/src/main/res/layout/content_event.xml
+++ b/app/src/main/res/layout/content_event.xml
@@ -27,7 +27,7 @@
                 android:layout_width="@dimen/layout_margin_none"
                 android:layout_height="@dimen/layout_margin_none"
                 android:scaleType="centerCrop"
-                app:headerUrl="@{event.originalImageUrl}"
+                android:transitionName="eventDetailImage"
                 app:layout_constraintDimensionRatio="2"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.5"

--- a/app/src/main/res/menu/search.xml
+++ b/app/src/main/res/menu/search.xml
@@ -6,6 +6,6 @@
             android:icon="@drawable/ic_search_grey"
             android:title="@string/search"
             app:iconTint="@android:color/white"
-            app:actionViewClass="android.widget.SearchView"
+            app:actionViewClass="androidx.appcompat.widget.SearchView"
             app:showAsAction="always|collapseActionView" />
 </menu>


### PR DESCRIPTION
Fixes: #1686

- Add shared element transition between event detail and event list.
- Remove unused Scope file.

Screenshots for the change:
<img src="https://i.ibb.co/KhVBndp/ezgif-2-5e8abfb58111.gif" alt="ezgif-2-5e8abfb58111" border="0">  <img src="https://i.ibb.co/7G58Y3k/ezgif-2-069709e4221f.gif" alt="ezgif-2-069709e4221f" border="0">  <img src="https://i.ibb.co/K0SmJ8n/ezgif-2-c012b715d128.gif" alt="ezgif-2-c012b715d128" border="0">