### PR TITLE
fix: Change the QR value based on server

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsViewHolder.kt
@@ -87,9 +87,10 @@ class OrderDetailsViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
         }
 
         itemView.name.text = "${attendee.firstname} ${attendee.lastname}"
-        itemView.orderIdentifier.text = orderIdentifier
+        val ticketIdentifier = "$orderIdentifier-${attendee.id}"
+        itemView.orderIdentifier.text = ticketIdentifier
+        val bitmap = qrCode.generateQrBitmap(ticketIdentifier, 200, 200)
 
-        val bitmap = qrCode.generateQrBitmap(orderIdentifier, 200, 200)
         if (bitmap != null) {
             itemView.qrCodeView.setImageBitmap(bitmap)
         } else {


### PR DESCRIPTION
Change the QR code based on server.
I have tested so that even though the QR image mobile app is not the same as the QR image in the pdf file, the value given after scanning is still the same.

Fixes: #1706