### PR TITLE
fix: Retain chip state on screen rotation in SearchResultFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
@@ -60,8 +60,8 @@ class SearchResultsFragment : Fragment(), CompoundButton.OnCheckedChangeListener
         bindScope(getOrCreateScope(Scopes.SEARCH_RESULTS_FRAGMENT.toString()))
 
         days = resources.getStringArray(R.array.days)
-        eventDate = safeArgs.date
-        eventType = safeArgs.type
+        eventDate = searchViewModel.savedTime ?: safeArgs.date
+        eventType = searchViewModel.savedType ?: safeArgs.type
 
         searchViewModel.loadEventTypes()
         searchViewModel.eventTypes
@@ -74,7 +74,7 @@ class SearchResultsFragment : Fragment(), CompoundButton.OnCheckedChangeListener
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         rootView = inflater.inflate(R.layout.fragment_search_results, container, false)
 
-        setChips(safeArgs.date, safeArgs.type)
+        setChips( eventDate, eventType)
         setToolbar(activity, getString(R.string.search_results))
         setHasOptionsMenu(true)
 
@@ -217,6 +217,7 @@ class SearchResultsFragment : Fragment(), CompoundButton.OnCheckedChangeListener
         val date = eventDate
         val freeEvents = safeArgs.freeEvents
         val sortBy = safeArgs.sort
+        searchViewModel.setChipNotClickable()
         searchViewModel.searchEvent = query
         searchViewModel.loadEvents(location, date, type, freeEvents, sortBy)
     }
@@ -258,7 +259,9 @@ class SearchResultsFragment : Fragment(), CompoundButton.OnCheckedChangeListener
 
     override fun onCheckedChanged(buttonView: CompoundButton?, isChecked: Boolean) {
         if (isChecked) {
-            if (buttonView?.text == "Clear All") {
+            if (buttonView?.text == getString(R.string.clear_all)) {
+                searchViewModel.savedTime = null
+                searchViewModel.savedType = null
                 eventDate = getString(R.string.anytime)
                 eventType = getString(R.string.anything)
                 rootView.noSearchResults.isVisible = false
@@ -271,6 +274,7 @@ class SearchResultsFragment : Fragment(), CompoundButton.OnCheckedChangeListener
             }
             days.forEach {
                 if (it == buttonView?.text) {
+                    searchViewModel.savedTime = it
                     eventDate = it
                     setChips(date = it)
                     rootView.noSearchResults.isVisible = false
@@ -283,6 +287,7 @@ class SearchResultsFragment : Fragment(), CompoundButton.OnCheckedChangeListener
             }
             eventTypesList?.forEach {
                 if (it.name == buttonView?.text) {
+                    searchViewModel.savedType = it.name
                     eventType = it.name
                     setChips(type = it.name)
                     rootView.noSearchResults.isVisible = false

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchViewModel.kt
@@ -74,6 +74,10 @@ class SearchViewModel(
         savedTime = preference.getString(SAVED_TIME)
     }
 
+    fun setChipNotClickable() {
+        mutableChipClickable.value = false
+    }
+
     fun loadEvents(location: String, time: String, type: String, freeEvents: Boolean, sortBy: String) {
         if (mutableEvents.value != null) {
             mutableChipClickable.value = true


### PR DESCRIPTION
Details:
- Save chip state inside ViewModel and retain its check state in onCreateView()

Fixes: #1598

Screenshots for the change:
<img src="https://i.ibb.co/6mdMtt1/ezgif-4-c3dd5e3d130a.gif" alt="ezgif-4-c3dd5e3d130a" border="0">