### PR TITLE
fix: Reset default value for order

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeViewModel.kt
@@ -246,11 +246,11 @@ class AttendeeViewModel(
 
     private fun createOrder() {
         val attendeeList = attendees.map { AttendeeId(it.id) }.toList()
-        var amount = totalAmount.value
+        var amount: Float = totalAmount.value ?: 0F
         var paymentMode: String? = paymentOption.toLowerCase()
-        if (amount == null || amount <= 0) {
+        if (amount <= 0) {
             paymentMode = resource.getString(R.string.free)
-            amount = null
+            amount = 0F
         }
         val eventId = event.value?.id
         if (eventId != null) {

--- a/app/src/main/java/org/fossasia/openevent/general/order/Order.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/Order.kt
@@ -31,7 +31,7 @@ data class Order(
     val paymentMode: String? = null,
     val country: String? = null,
     val status: String? = null,
-    val amount: Float? = null,
+    val amount: Float = 0F,
     val identifier: String? = null,
     val orderNotes: String? = null,
     val completedAt: String? = null,


### PR DESCRIPTION
Detail:
- Set default value of the order to 0 instead of null. This helps to book for free events.

Fixes: #1621, #1728 

Even though the null amount problem is editted in the server with [#5869](https://github.com/fossasia/open-event-server/pull/5869), current Android app still get HTTP 422 UNPROCESSABLE ENTITY so I made this PR.