### PR TITLE
fix: Retain ticket locally when logged in

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/OpenEventDatabase.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/OpenEventDatabase.kt
@@ -40,7 +40,7 @@ import org.fossasia.openevent.general.ticket.TicketIdConverter
 
 @Database(entities = [Event::class, User::class, SocialLink::class, Ticket::class, Attendee::class,
     EventTopic::class, Order::class, CustomForm::class, Speaker::class, SpeakerWithEvent::class, Sponsor::class,
-    SponsorWithEvent::class, Session::class], version = 5)
+    SponsorWithEvent::class, Session::class], version = 6)
 @TypeConverters(EventIdConverter::class, EventTopicConverter::class, EventTypeConverter::class,
     EventSubTopicConverter::class, TicketIdConverter::class, MicroLocationConverter::class,
     AttendeeIdConverter::class, ListAttendeeIdConverter::class, SessionTypeConverter::class)

--- a/app/src/main/java/org/fossasia/openevent/general/attendees/Attendee.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/Attendee.kt
@@ -39,6 +39,7 @@ data class Attendee(
     @ColumnInfo(index = true)
     @Relationship("event")
     var event: EventId? = null,
+    @ColumnInfo(index = true)
     @Relationship("ticket")
     var ticket: TicketId? = null
 )

--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeDao.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeDao.kt
@@ -19,11 +19,14 @@ interface AttendeeDao {
     fun insertCustomForms(customForms: List<CustomForm>)
 
     @Query("DELETE FROM Attendee")
-    fun deleteAll()
+    fun deleteAllAttendees()
 
     @Query("SELECT * from Attendee WHERE id in (:ids)")
     fun getAttendeesWithIds(ids: List<Long>): Single<List<Attendee>>
 
     @Query("SELECT * from CustomForm WHERE event = :eventId")
     fun getCustomFormsForId(eventId: Long): Single<List<CustomForm>>
+
+    @Query("SELECT * FROM Attendee")
+    fun getAllAttendees(): Single<List<Attendee>>
 }

--- a/app/src/main/java/org/fossasia/openevent/general/attendees/ListAttendeeIdConverter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/ListAttendeeIdConverter.kt
@@ -3,6 +3,7 @@ package org.fossasia.openevent.general.attendees
 import androidx.room.TypeConverter
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 
 class ListAttendeeIdConverter {
 
@@ -14,7 +15,7 @@ class ListAttendeeIdConverter {
 
     @TypeConverter
     fun toListAttendeeId(attendeeList: String): List<AttendeeId> {
-        val objectMapper = ObjectMapper()
+        val objectMapper = jacksonObjectMapper()
         val mapType = object : TypeReference<List<AttendeeId>>() {}
         return objectMapper.readValue(attendeeList, mapType)
     }

--- a/app/src/main/java/org/fossasia/openevent/general/auth/AuthService.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/AuthService.kt
@@ -2,18 +2,22 @@ package org.fossasia.openevent.general.auth
 
 import io.reactivex.Completable
 import io.reactivex.Single
+import org.fossasia.openevent.general.attendees.AttendeeDao
 import org.fossasia.openevent.general.auth.change.ChangeRequestToken
 import org.fossasia.openevent.general.auth.change.ChangeRequestTokenResponse
 import org.fossasia.openevent.general.auth.change.Password
 import org.fossasia.openevent.general.auth.forgot.Email
 import org.fossasia.openevent.general.auth.forgot.RequestToken
 import org.fossasia.openevent.general.auth.forgot.RequestTokenResponse
+import org.fossasia.openevent.general.order.OrderDao
 import timber.log.Timber
 
 class AuthService(
     private val authApi: AuthApi,
     private val authHolder: AuthHolder,
-    private val userDao: UserDao
+    private val userDao: UserDao,
+    private val orderDao: OrderDao,
+    private val attendeeDao: AttendeeDao
 ) {
     fun login(username: String, password: String): Single<LoginResponse> {
         if (username.isEmpty() || password.isEmpty())
@@ -55,6 +59,8 @@ class AuthService(
         return Completable.fromAction {
             authHolder.token = null
             userDao.deleteUser(authHolder.getId())
+            orderDao.deleteAllOrders()
+            attendeeDao.deleteAllAttendees()
         }
     }
 

--- a/app/src/main/java/org/fossasia/openevent/general/di/Modules.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/di/Modules.kt
@@ -178,7 +178,7 @@ val apiModule = module {
     }
 
     factory { AuthHolder(get()) }
-    factory { AuthService(get(), get(), get()) }
+    factory { AuthService(get(), get(), get(), get(), get()) }
 
     factory { EventService(get(), get(), get(), get(), get(), get(), get(), get()) }
     factory { SpeakerService(get(), get(), get()) }

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDao.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDao.kt
@@ -24,6 +24,9 @@ interface EventDao {
     @Query("SELECT * from Event WHERE id = :id")
     fun getEvent(id: Long): Flowable<Event>
 
+    @Query("SELECT * FROM event WHERE id = :eventId")
+    fun getEventById(eventId: Long): Single<Event>
+
     @Query("SELECT * from Event WHERE id in (:ids)")
     fun getEventWithIds(ids: List<Long>): Single<List<Event>>
 

--- a/app/src/main/java/org/fossasia/openevent/general/order/Order.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/Order.kt
@@ -2,7 +2,6 @@ package org.fossasia.openevent.general.order
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
-import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
@@ -11,18 +10,12 @@ import com.github.jasminb.jsonapi.annotations.Id
 import com.github.jasminb.jsonapi.annotations.Relationship
 import com.github.jasminb.jsonapi.annotations.Type
 import io.reactivex.annotations.NonNull
-import org.fossasia.openevent.general.attendees.Attendee
 import org.fossasia.openevent.general.attendees.AttendeeId
-import org.fossasia.openevent.general.event.Event
 import org.fossasia.openevent.general.event.EventId
 
 @Type("order")
 @JsonNaming(PropertyNamingStrategy.KebabCaseStrategy::class)
-@Entity(foreignKeys = [
-    (ForeignKey(entity = Event::class, parentColumns = ["id"],
-        childColumns = ["event"], onDelete = ForeignKey.CASCADE)),
-    (ForeignKey(entity = Attendee::class, parentColumns = ["id"],
-        childColumns = ["attendees"], onDelete = ForeignKey.CASCADE))])
+@Entity
 data class Order(
     @Id(IntegerIdHandler::class)
     @PrimaryKey

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrderDao.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrderDao.kt
@@ -3,6 +3,8 @@ package org.fossasia.openevent.general.order
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import io.reactivex.Single
 
 @Dao
 interface OrderDao {
@@ -11,4 +13,13 @@ interface OrderDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertOrder(order: Order)
+
+    @Query("SELECT * FROM `order`")
+    fun getAllOrders(): Single<List<Order>>
+
+    @Query("DELETE FROM `order`")
+    fun deleteAllOrders()
+
+    @Query("SELECT * FROM `order` WHERE id = :orderId")
+    fun getOrderById(orderId: Long): Single<Order>
 }

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsFragment.kt
@@ -48,20 +48,18 @@ class OrderDetailsFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        ordersRecyclerAdapter.setOrderIdentifier(safeArgs.orders)
+        ordersRecyclerAdapter.setOrderIdentifier(safeArgs.orderIdentifier)
 
         orderDetailsViewModel.event
             .nonNull()
             .observe(this, Observer {
                 ordersRecyclerAdapter.setEvent(it)
-                ordersRecyclerAdapter.notifyDataSetChanged()
             })
 
         orderDetailsViewModel.attendees
             .nonNull()
             .observe(this, Observer {
                 ordersRecyclerAdapter.addAll(it)
-                ordersRecyclerAdapter.notifyDataSetChanged()
                 Timber.d("Fetched attendees of size %s", ordersRecyclerAdapter.itemCount)
             })
     }
@@ -127,7 +125,7 @@ class OrderDetailsFragment : Fragment() {
             })
 
         orderDetailsViewModel.loadEvent(safeArgs.eventId)
-        orderDetailsViewModel.loadAttendeeDetails(safeArgs.orders)
+        orderDetailsViewModel.loadAttendeeDetails(safeArgs.orderId)
 
         return rootView
     }

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsRecyclerAdapter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsRecyclerAdapter.kt
@@ -21,10 +21,12 @@ class OrderDetailsRecyclerAdapter : RecyclerView.Adapter<OrderDetailsViewHolder>
         if (attendees.isNotEmpty())
             this.attendees.clear()
         this.attendees.addAll(attendeeList)
+        notifyDataSetChanged()
     }
 
     fun setEvent(event: Event?) {
         this.event = event
+        notifyDataSetChanged()
     }
 
     fun setSeeEventListener(listener: EventDetailsListener) {

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersRecyclerAdapter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersRecyclerAdapter.kt
@@ -8,19 +8,19 @@ import org.fossasia.openevent.general.event.Event
 
 class OrdersRecyclerAdapter : RecyclerView.Adapter<OrdersViewHolder>() {
 
-    private val eventAndOrderIdentifier = ArrayList<Pair<Event, String>>()
-    private val showExpired = false
+    private val eventAndOrderIdentifier = ArrayList<Pair<Event, Order>>()
+    private var showExpired = false
     private var clickListener: OrderClickListener? = null
-    var attendeesNumber = listOf<Int>()
 
     fun setListener(listener: OrderClickListener) {
         clickListener = listener
     }
 
-    fun addAllPairs(list: List<Pair<Event, String>>, showExpired: Boolean) {
+    fun addAllPairs(list: List<Pair<Event, Order>>, showExpired: Boolean) {
         if (eventAndOrderIdentifier.isNotEmpty())
             this.eventAndOrderIdentifier.clear()
         eventAndOrderIdentifier.addAll(list)
+        this.showExpired = showExpired
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OrdersViewHolder {
@@ -29,23 +29,14 @@ class OrdersRecyclerAdapter : RecyclerView.Adapter<OrdersViewHolder>() {
     }
 
     override fun onBindViewHolder(holder: OrdersViewHolder, position: Int) {
-        attendeesNumber[position]?.let {
-            holder.bind(eventAndOrderIdentifier[position].first,
-                clickListener,
-                eventAndOrderIdentifier[position].second,
-                it, showExpired)
-        }
+        holder.bind(eventAndOrderIdentifier[position], showExpired, clickListener)
     }
 
     override fun getItemCount(): Int {
         return eventAndOrderIdentifier.size
     }
 
-    fun setAttendeeNumber(number: List<Int>) {
-        attendeesNumber = number
-    }
-
     interface OrderClickListener {
-        fun onClick(eventID: Long, orderIdentifier: String)
+        fun onClick(eventID: Long, orderIdentifier: String, orderId: Long)
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
@@ -77,9 +77,9 @@ class OrdersUnderUserFragment : Fragment(), ScrollToTop {
             if (safeArgs.showExpired) rootView.expireFilter.isVisible = false
 
             val recyclerViewClickListener = object : OrdersRecyclerAdapter.OrderClickListener {
-                override fun onClick(eventID: Long, orderIdentifier: String) {
-                        findNavController(rootView).navigate(OrdersUnderUserFragmentDirections
-                            .actionOrderUserToOrderDetails(eventID, orderIdentifier))
+                override fun onClick(eventID: Long, orderIdentifier: String, orderId: Long) {
+                    findNavController(rootView).navigate(OrdersUnderUserFragmentDirections
+                        .actionOrderUserToOrderDetails(eventID, orderIdentifier, orderId))
                 }
             }
 
@@ -109,13 +109,7 @@ class OrdersUnderUserFragment : Fragment(), ScrollToTop {
                     showNoTicketsScreen(it)
                 })
 
-            ordersUnderUserVM.attendeesNumber
-                .nonNull()
-                .observe(viewLifecycleOwner, Observer {
-                    ordersRecyclerAdapter.setAttendeeNumber(it)
-                })
-
-            ordersUnderUserVM.eventAndOrderIdentifier
+            ordersUnderUserVM.eventAndOrder
                 .nonNull()
                 .observe(viewLifecycleOwner, Observer {
                     val list = it.sortedByDescending {

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersViewHolder.kt
@@ -13,12 +13,12 @@ import org.fossasia.openevent.general.event.EventUtils
 class OrdersViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
 
     fun bind(
-        event: Event,
-        clickListener: OrdersRecyclerAdapter.OrderClickListener?,
-        orderIdentifier: String?,
-        attendeesNumber: Int,
-        showExpired: Boolean
+        eventAndOrder: Pair<Event, Order>,
+        showExpired: Boolean,
+        listener: OrdersRecyclerAdapter.OrderClickListener?
     ) {
+        val event = eventAndOrder.first
+        val order = eventAndOrder.second
         val formattedDateTime = EventUtils.getEventDateTime(event.startsAt, event.timezone)
         val formattedTime = EventUtils.getFormattedTime(formattedDateTime)
         val timezone = EventUtils.getFormattedTimeZone(formattedDateTime)
@@ -26,9 +26,10 @@ class OrdersViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         itemView.eventName.text = event.name
         itemView.time.text = "Starts at $formattedTime $timezone"
         itemView.setOnClickListener {
-            orderIdentifier?.let { it1 -> clickListener?.onClick(event.id, it1) }
+            listener?.onClick(event.id, order.identifier ?: "", order.id)
         }
 
+        val attendeesNumber = order.attendees.size
         if (attendeesNumber == 1) {
             itemView.ticketsNumber.text = "See $attendeesNumber Ticket"
         } else {
@@ -44,7 +45,7 @@ class OrdersViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
                     .placeholder(R.drawable.header)
                     .into(itemView.eventImage)
         }
-        if (!showExpired) {
+        if (showExpired) {
             val matrix = ColorMatrix()
             matrix.setSaturation(0F)
             itemView.eventImage.colorFilter = ColorMatrixColorFilter(matrix)

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketIdConverter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketIdConverter.kt
@@ -5,12 +5,14 @@ import androidx.room.TypeConverter
 class TicketIdConverter {
 
     @TypeConverter
-    fun fromTicketId(ticketId: TicketId): Long {
-        return ticketId.id
+    fun fromTicketId(ticketId: TicketId?): Long? {
+        return ticketId?.id
     }
 
     @TypeConverter
-    fun toTicketId(id: Long): TicketId {
-        return TicketId(id)
+    fun toTicketId(id: Long?): TicketId? {
+        return id?.let {
+            TicketId(id)
+        }
     }
 }

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -365,9 +365,14 @@
             android:defaultValue="-1L"/>
 
         <argument
-            android:name="orders"
+            android:name="orderIdentifier"
             app:argType="string"
-            android:defaultValue="-1"/>
+            android:defaultValue=""/>
+
+        <argument
+            android:name="orderId"
+            app:argType="long"
+            android:defaultValue="-1L"/>
     </fragment>
     <fragment
         android:id="@+id/profileFragment"


### PR DESCRIPTION
Detail:
- Retain the attendee list, order and event in the database after fetching. 
So with this PR, if there is internet connection, orders/events/attendees are fetched from the API and saved to the database, otherwise fetched from the database.

When the user logs out, all of the saved orders and attendees information will be deleted from the database.

Fixes: #1610

Screenshots for the change:
<img src="https://i.ibb.co/4WytTbT/ezgif-2-dbdc9827fe7e.gif" alt="ezgif-2-dbdc9827fe7e" border="0">