### PR TITLE
fix: Remove click listeners to remove memory leaks

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -558,6 +558,17 @@ class EventDetailsFragment : Fragment() {
         super.onPrepareOptionsMenu(menu)
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        speakersAdapter.onSpeakerClick = null
+        sponsorsAdapter.onSponsorClick = null
+        sessionsAdapter.onSessionClick = null
+        similarEventsAdapter.apply {
+            onEventClick = null
+            onFavFabClick = null
+        }
+    }
+
     private fun loadTicketFragment() {
         val currency = Currency.getInstance(eventViewModel.event.value?.paymentCurrency ?: "USD").symbol
         findNavController(rootView).navigate(EventDetailsFragmentDirections

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -202,6 +202,15 @@ class EventsFragment : Fragment(), ScrollToTop {
         }
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        eventsListAdapter.apply {
+            onEventClick = null
+            onFavFabClick = null
+            onHashtagClick = null
+        }
+    }
+
     private fun openSearch(hashTag: String) {
             findNavController(rootView).navigate(EventsFragmentDirections.actionEventsToSearchResults(
                 query = "",

--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
@@ -140,6 +140,14 @@ class FavoriteFragment : Fragment() {
         }
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        favoriteEventsRecyclerAdapter.apply {
+            onEventClick = null
+            onFavFabClick = null
+        }
+    }
+
     private fun showEmptyMessage(itemCount: Int) {
         noLikedLL.isVisible = (itemCount == 0)
     }

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsFragment.kt
@@ -149,6 +149,12 @@ class OrderDetailsFragment : Fragment() {
         }
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        ordersRecyclerAdapter.setQrImageClickListener(null)
+        ordersRecyclerAdapter.setSeeEventListener(null)
+    }
+
     private fun showEnlargedQrImage(bitmap: Bitmap) {
         val brightAttributes = activity?.window?.attributes
         orderDetailsViewModel.brightness = brightAttributes?.screenBrightness

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsRecyclerAdapter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrderDetailsRecyclerAdapter.kt
@@ -29,11 +29,11 @@ class OrderDetailsRecyclerAdapter : RecyclerView.Adapter<OrderDetailsViewHolder>
         notifyDataSetChanged()
     }
 
-    fun setSeeEventListener(listener: EventDetailsListener) {
+    fun setSeeEventListener(listener: EventDetailsListener?) {
         eventDetailsListener = listener
     }
 
-    fun setQrImageClickListener(listener: QrImageClickListener) {
+    fun setQrImageClickListener(listener: QrImageClickListener?) {
         onQrImageClicked = listener
     }
 

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersRecyclerAdapter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersRecyclerAdapter.kt
@@ -12,7 +12,7 @@ class OrdersRecyclerAdapter : RecyclerView.Adapter<OrdersViewHolder>() {
     private var showExpired = false
     private var clickListener: OrderClickListener? = null
 
-    fun setListener(listener: OrderClickListener) {
+    fun setListener(listener: OrderClickListener?) {
         clickListener = listener
     }
 

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrdersUnderUserFragment.kt
@@ -126,6 +126,11 @@ class OrdersUnderUserFragment : Fragment(), ScrollToTop {
         return rootView
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        ordersRecyclerAdapter.setListener(null)
+    }
+
     private fun showNoTicketsScreen(show: Boolean) {
         noTicketsScreen.isVisible = show
         if (safeArgs.showExpired) {

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
@@ -141,6 +141,14 @@ class SearchResultsFragment : Fragment(), CompoundButton.OnCheckedChangeListener
         return rootView
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        favoriteEventsRecyclerAdapter.apply {
+            onEventClick = null
+            onFavFabClick = null
+        }
+    }
+
     private fun setChips(date: String = eventDate, type: String = eventType) {
         if (rootView.chipGroup.childCount> 0) {
             rootView.chipGroup.removeAllViews()

--- a/app/src/main/java/org/fossasia/openevent/general/sessions/SessionFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/sessions/SessionFragment.kt
@@ -139,6 +139,11 @@ class SessionFragment : Fragment() {
         }
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        speakersAdapter.onSpeakerClick = null
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         Utils.setNewHeaderColor(activity, resources.getColor(R.color.colorPrimaryDark),

--- a/app/src/main/java/org/fossasia/openevent/general/sponsor/SponsorRecyclerAdapter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/sponsor/SponsorRecyclerAdapter.kt
@@ -9,7 +9,7 @@ const val MAXIMUM_PREVIEW_SPONSOR = 8
 
 class SponsorRecyclerAdapter : RecyclerView.Adapter<SponsorViewHolder>() {
     private val sponsorList = ArrayList<Sponsor>()
-    lateinit var onSponsorClick: SponsorClickListener
+    var onSponsorClick: SponsorClickListener? = null
 
     fun addAll(newSponsors: List<Sponsor>) {
         if (sponsorList.isNotEmpty()) sponsorList.clear()

--- a/app/src/main/java/org/fossasia/openevent/general/sponsor/SponsorViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/sponsor/SponsorViewHolder.kt
@@ -10,7 +10,7 @@ import org.fossasia.openevent.general.utils.Utils
 
 class SponsorViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
 
-    lateinit var sponsorClickListener: SponsorClickListener
+    var sponsorClickListener: SponsorClickListener? = null
 
     fun bind(
         sponsor: Sponsor,
@@ -30,7 +30,7 @@ class SponsorViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         }
 
         itemView.setOnClickListener {
-            sponsorClickListener.onClick()
+            sponsorClickListener?.onClick()
         }
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
@@ -133,6 +133,11 @@ class TicketsFragment : Fragment() {
         return rootView
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        ticketsRecyclerAdapter.setSelectListener(null)
+    }
+
     private fun checkForAuthentication() {
         if (ticketsViewModel.isLoggedIn())
             redirectToAttendee()

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsRecyclerAdapter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsRecyclerAdapter.kt
@@ -18,7 +18,7 @@ class TicketsRecyclerAdapter : RecyclerView.Adapter<TicketViewHolder>() {
         this.tickets.addAll(ticketList)
     }
 
-    fun setSelectListener(listener: TicketSelectedListener) {
+    fun setSelectListener(listener: TicketSelectedListener?) {
         selectedListener = listener
     }
 


### PR DESCRIPTION
Detail:
- The cause of the memory leak is because of the adapter of RecyclerView. If the adapter lives any longer than the RecyclerView does, the adapter is going to hold a reference to the RecyclerView which should have already gone out of memory.

Further description: https://stackoverflow.com/questions/35520946/leak-canary-recyclerview-leaking-madapter. 

To be honest, I don't completely understand the problem and the memory leak in here, but this fix does really improve the app as it is faster in my device and leak canary doesn't find any leaks. So please correct me if there is anything wrong or give me further explanations.

Fixes: #1780
