### PR TITLE
fix: liking fail in EventDetailsFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDao.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDao.kt
@@ -22,7 +22,7 @@ interface EventDao {
     fun getAllEvents(): Flowable<List<Event>>
 
     @Query("SELECT * from Event WHERE id = :id")
-    fun getEvent(id: Long): Flowable<Event>
+    fun getEvent(id: Long): Single<Event>
 
     @Query("SELECT * FROM event WHERE id = :eventId")
     fun getEventById(eventId: Long): Single<Event>

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -464,7 +464,10 @@ class EventDetailsFragment : Fragment() {
                 true
             }
             R.id.favorite_event -> {
-                eventViewModel.event.value?.let { eventViewModel.setFavorite(safeArgs.eventId, !it.favorite) }
+                eventViewModel.event.value?.let {
+                    eventViewModel.setFavorite(safeArgs.eventId, !it.favorite)
+                    setFavoriteIconFilled(!it.favorite)
+                }
                 true
             }
             R.id.event_share -> {

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsViewModel.kt
@@ -214,6 +214,10 @@ class EventDetailsViewModel(
             .withDefaultSchedulers()
             .subscribe({
                 Timber.d("Success")
+                mutableEvent.value?.let {
+                    it.favorite = favorite
+                    mutableEvent.value = it
+                }
             }, {
                 Timber.e(it, "Error")
                 mutablePopMessage.value = resource.getString(R.string.error)

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventService.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventService.kt
@@ -106,7 +106,7 @@ class EventService(
         return eventDao.getEventWithIds(eventIds)
     }
 
-    fun getEvent(id: Long): Flowable<Event> {
+    fun getEvent(id: Long): Single<Event> {
         return eventDao.getEvent(id)
     }
 


### PR DESCRIPTION
Detail:
- Change the database call for event from flowable to single object.

The main reason why clicking like behaviour is unexpected is because Flowable object keep emitting event for the ViewModel. Therefore, LiveData object about the event inside the ViewModel keeps updating constantly, and which leads to weird behavior inside this fragment.

Likes icon was updated because new event object is emitted so that we have to reset all the UI, not because we directly change the likes icon.

Fixes: #1692 