### PR TITLE
feat: Add authentication with facebook

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,8 @@ apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 def STRIPE_API_TOKEN = System.getenv('STRIPE_API_TOKEN') ?: "YOUR_API_KEY"
 def MAPBOX_KEY = System.getenv('MAPBOX_KEY') ?: "pk.eyJ1IjoiYW5nbWFzMSIsImEiOiJjanNqZDd0N2YxN2Q5NDNuNTBiaGt6eHZqIn0.BCrxjW6rP_OuOuGtbhVEQg"
+def FB_APP_ID = System.getenv('FB_APP_ID') ?: "NOT_PROVIDED"
+def FB_LOGIN_PROTOCOL = System.getenv("FB_LOGIN_PROTOCOL") ?: "NOT_PROVIDED"
 
 android {
     dataBinding {
@@ -26,7 +28,8 @@ android {
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true
         manifestPlaceholders = [
-                STRIPE_API_TOKEN: STRIPE_API_TOKEN
+                STRIPE_API_TOKEN: STRIPE_API_TOKEN,
+                FB_LOGIN_PROTOCOL: FB_LOGIN_PROTOCOL
         ]
         javaCompileOptions {
             annotationProcessorOptions {
@@ -41,10 +44,12 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             buildConfigField "String", "DEFAULT_BASE_URL", '"https://api.eventyay.com/v1/"'
             buildConfigField "String", "MAPBOX_KEY", '"'+MAPBOX_KEY+'"'
+            resValue "string", "FB_APP_ID", '"'+FB_APP_ID+'"'
         }
         debug {
             buildConfigField "String", "DEFAULT_BASE_URL", '"https://open-event-api-dev.herokuapp.com/v1/"'
             buildConfigField "String", "MAPBOX_KEY", '"'+MAPBOX_KEY+'"'
+            resValue "string", "FB_APP_ID", '"'+FB_APP_ID+'"'
         }
     }
 
@@ -186,6 +191,10 @@ dependencies {
 
     //LeakCanary
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.0-alpha-1'
+
+    //Facebook authentication
+    implementation 'com.facebook.android:facebook-login:5.0.1'
+
 
     testImplementation 'junit:junit:4.12'
     testImplementation "io.mockk:mockk:1.9.3"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,5 +36,23 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_provider"/>
         </provider>
+        <meta-data
+            android:name="com.facebook.sdk.ApplicationId"
+            android:value= "@string/FB_APP_ID" />
+
+        <activity android:name="com.facebook.FacebookActivity"
+            android:configChanges=
+                "keyboard|keyboardHidden|screenLayout|screenSize|orientation"
+            android:label="@string/app_name" />
+        <activity
+            android:name="com.facebook.CustomTabActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="${FB_LOGIN_PROTOCOL}" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/app/src/main/java/org/fossasia/openevent/general/auth/AuthFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/AuthFragment.kt
@@ -1,17 +1,20 @@
 package org.fossasia.openevent.general.auth
 
+import android.content.Intent
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.Observer
 import androidx.navigation.Navigation
 import androidx.navigation.fragment.navArgs
-import kotlinx.android.synthetic.main.fragment_auth.view.getStartedButton
-import kotlinx.android.synthetic.main.fragment_auth.view.email
-import kotlinx.android.synthetic.main.fragment_auth.view.rootLayout
+import com.facebook.CallbackManager
 import org.fossasia.openevent.general.BuildConfig
 import org.fossasia.openevent.general.PLAY_STORE_BUILD_FLAVOR
 import org.fossasia.openevent.general.R
@@ -20,16 +23,30 @@ import org.fossasia.openevent.general.utils.Utils.hideSoftKeyboard
 import org.fossasia.openevent.general.utils.Utils.show
 import org.fossasia.openevent.general.utils.Utils.progressDialog
 import org.fossasia.openevent.general.utils.extensions.nonNull
-import org.jetbrains.anko.design.longSnackbar
-import org.jetbrains.anko.design.snackbar
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import kotlinx.android.synthetic.main.dialog_password.view.textInputLayoutPassword
+import kotlinx.android.synthetic.main.dialog_password.view.textInputLayoutConfirmPassword
+import kotlinx.android.synthetic.main.dialog_password.view.password
+import kotlinx.android.synthetic.main.dialog_password.view.confirmPassword
+import kotlinx.android.synthetic.main.fragment_auth.view.*
+import org.fossasia.openevent.general.event.EVENT_DETAIL_FRAGMENT
+import org.fossasia.openevent.general.notification.NOTIFICATION_FRAGMENT
+import org.fossasia.openevent.general.order.ORDERS_FRAGMENT
+import org.fossasia.openevent.general.ticket.TICKETS_FRAGMNET
+import org.jetbrains.anko.design.longSnackbar
+import org.jetbrains.anko.design.snackbar
+
+private const val NOT_PROVIDED = "NOT_PROVIDED"
 
 class AuthFragment : Fragment() {
     private lateinit var rootView: View
     private val authViewModel by viewModel<AuthViewModel>()
     private val safeArgs: AuthFragmentArgs by navArgs()
     private val smartAuthViewModel by sharedViewModel<SmartAuthViewModel>()
+    private val callbackManager = CallbackManager.Factory.create()
+    private lateinit var signUp: SignUp
+    private var fbLogIn = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -59,14 +76,36 @@ class AuthFragment : Fragment() {
             authViewModel.checkUser(rootView.email.text.toString())
         }
 
+        if (getString(R.string.FB_APP_ID) == NOT_PROVIDED) {
+            rootView.orTextView.visibility = View.GONE
+            rootView.facebookLoginButton.visibility = View.GONE
+        }
+
+        rootView.facebookLoginButton.fragment = this
+        authViewModel.setFacebookLogin(callbackManager)
+
         authViewModel.isUserExists
             .nonNull()
             .observe(viewLifecycleOwner, Observer {
-                if (it)
-                    redirectToLogin(rootView.email.text.toString())
-                else
-                    redirectToSignUp()
+                if (fbLogIn) {
+                    if (it)
+                        redirectToLogin(
+                            email = signUp.email.toString(),
+                            snackbarMessage = getString(R.string.email_already_registered)
+                        )
+                    else
+                        showPasswordDialog(signUp)
+                } else {
+                    if (it)
+                        redirectToLogin(
+                            email = rootView.email.text.toString(),
+                            snackbarMessage = getString(R.string.login_to_continue)
+                        )
+                    else
+                        redirectToSignUp()
+                }
                 authViewModel.mutableStatus.postValue(null)
+                authViewModel.mutableFbLogin.postValue(false)
             })
 
         authViewModel.progress
@@ -87,13 +126,137 @@ class AuthFragment : Fragment() {
                 rootView.rootLayout.longSnackbar(it)
             })
 
+        authViewModel.signedUp
+            .nonNull()
+            .observe(viewLifecycleOwner, Observer {
+                rootView.snackbar(R.string.sign_up_success)
+                authViewModel.login(signUp)
+            })
+
+        authViewModel.signUp
+            .nonNull()
+            .observe(viewLifecycleOwner, Observer {
+                this.signUp = it
+            })
+
+        authViewModel.fbLogIn
+            .nonNull()
+            .observe(viewLifecycleOwner, Observer {
+                this.fbLogIn = it
+            })
+
+        authViewModel.loggedIn.observe(viewLifecycleOwner, Observer {
+            redirectToMain()
+        })
+
         return rootView
     }
 
-    private fun redirectToLogin(email: String = "") {
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        callbackManager.onActivityResult(requestCode, resultCode, data)
+    }
+
+    private fun redirectToMain() {
+        val destinationId =
+            when (safeArgs.redirectedFrom) {
+                PROFILE_FRAGMENT -> R.id.profileFragment
+                EVENT_DETAIL_FRAGMENT -> R.id.eventDetailsFragment
+                ORDERS_FRAGMENT -> R.id.orderUnderUserFragment
+                TICKETS_FRAGMNET -> R.id.ticketsFragment
+                NOTIFICATION_FRAGMENT -> R.id.notificationFragment
+                else -> R.id.eventsFragment
+            }
+        Navigation.findNavController(rootView).popBackStack(destinationId, false)
+        rootView.snackbar(R.string.logged_in_automatically)
+    }
+
+    private fun showPasswordDialog(signUp: SignUp) {
+        val layout = layoutInflater.inflate(R.layout.dialog_password, null)
+
+        val alertDialog = AlertDialog.Builder(requireContext())
+            .setTitle(getString(R.string.password))
+            .setView(layout)
+            .setCancelable(false)
+            .setPositiveButton(getString(R.string.submit)) { _, _ ->
+                Toast.makeText(context, signUp.email, Toast.LENGTH_SHORT).show()
+                signUp.password = layout.password.text.toString()
+                authViewModel.signUp(signUp)
+            }
+            .setNegativeButton(getString(R.string.cancel)) { dialog, _ ->
+                dialog.cancel()
+                rootView.snackbar(getString(R.string.sign_in_canceled))
+            }
+            .show()
+        alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = false
+
+        layout.password.addTextChangedListener(object : TextWatcher {
+            override fun afterTextChanged(p0: Editable?) {
+
+                if (!layout.textInputLayoutPassword.isEndIconVisible) {
+                    layout.textInputLayoutPassword.isEndIconVisible = true
+                }
+
+                if (layout.password.text.toString().length >= 6) {
+                    layout.textInputLayoutPassword.error = null
+                    layout.textInputLayoutPassword.isErrorEnabled = false
+                } else {
+                    layout.textInputLayoutPassword.error = getString(R.string.invalid_password_message)
+                }
+                if (layout.confirmPassword.text.toString() == layout.password.text.toString()) {
+                    layout.textInputLayoutConfirmPassword.error = null
+                    layout.textInputLayoutConfirmPassword.isErrorEnabled = false
+                } else {
+                    layout.textInputLayoutConfirmPassword.error =
+                        getString(R.string.invalid_confirm_password_message)
+                }
+                when (layout.textInputLayoutConfirmPassword.isErrorEnabled ||
+                    layout.textInputLayoutPassword.isErrorEnabled) {
+                    true -> alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = false
+                    false -> alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = true
+                }
+            }
+
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) { /*Implement here*/ }
+
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) { /*Implement here*/ }
+        })
+
+        layout.confirmPassword.addTextChangedListener(object : TextWatcher {
+            override fun afterTextChanged(p0: Editable?) {
+
+                if (!layout.textInputLayoutConfirmPassword.isEndIconVisible) {
+                    layout.textInputLayoutConfirmPassword.isEndIconVisible = true
+                }
+
+                if (layout.confirmPassword.text.toString() == layout.password.text.toString()) {
+                    layout.textInputLayoutConfirmPassword.error = null
+                    layout.textInputLayoutConfirmPassword.isErrorEnabled = false
+                } else {
+                    layout.textInputLayoutConfirmPassword.error =
+                        getString(R.string.invalid_confirm_password_message)
+                }
+                when (layout.textInputLayoutConfirmPassword.isErrorEnabled ||
+                    layout.textInputLayoutPassword.isErrorEnabled ||
+                    layout.password.text.toString().length < 6) {
+                    true -> alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = false
+                    false -> alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = true
+                }
+            }
+
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) { /*Implement here*/ }
+
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) { /*Implement here*/ }
+        })
+    }
+
+    private fun redirectToLogin(email: String = "", snackbarMessage: String = "") {
         Navigation.findNavController(rootView)
             .navigate(AuthFragmentDirections
-                .actionAuthToLogIn(email, safeArgs.redirectedFrom)
+                .actionAuthToLogIn(email = email,
+                    redirectedFrom = safeArgs.redirectedFrom,
+                    snackbarMessage = snackbarMessage
+                )
             )
     }
 

--- a/app/src/main/java/org/fossasia/openevent/general/auth/AuthViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/AuthViewModel.kt
@@ -1,8 +1,16 @@
 package org.fossasia.openevent.general.auth
 
+import android.os.Bundle
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.facebook.FacebookCallback
+import com.facebook.FacebookException
+import com.facebook.AccessToken
+import com.facebook.login.LoginManager
+import com.facebook.login.LoginResult
+import com.facebook.GraphRequest
+import com.facebook.CallbackManager
 import org.fossasia.openevent.general.R
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.plusAssign
@@ -10,6 +18,12 @@ import org.fossasia.openevent.general.data.Network
 import org.fossasia.openevent.general.data.Resource
 import org.fossasia.openevent.general.utils.extensions.withDefaultSchedulers
 import timber.log.Timber
+import org.fossasia.openevent.general.common.SingleLiveEvent
+import org.fossasia.openevent.general.utils.nullToEmpty
+
+private const val EMAIL = "email"
+private const val FIRST_NAME = "first_name"
+private const val LAST_NAME = "last_name"
 
 class AuthViewModel(
     private val authService: AuthService,
@@ -24,6 +38,14 @@ class AuthViewModel(
     val isUserExists: LiveData<Boolean> = mutableStatus
     private val mutableError = MutableLiveData<String>()
     val error: LiveData<String> = mutableError
+    private val mutableSignedUp = MutableLiveData<User>()
+    val signedUp: LiveData<User> = mutableSignedUp
+    private val mutableLoggedIn = SingleLiveEvent<Boolean>()
+    var loggedIn: LiveData<Boolean> = mutableLoggedIn
+    val mutableFbLogin = MutableLiveData<Boolean>()
+    val fbLogIn: LiveData<Boolean> = mutableFbLogin
+    val mutableSignUp = MutableLiveData<SignUp>()
+    val signUp: LiveData<SignUp> = mutableSignUp
 
     fun checkUser(email: String) {
         if (!network.isNetworkConnected()) {
@@ -43,5 +65,93 @@ class AuthViewModel(
                 mutableError.value = resource.getString(R.string.error)
                 Timber.d(it, "Failed")
             })
+    }
+
+    fun signUp(signUp: SignUp) {
+        if (!network.isNetworkConnected()) {
+            mutableError.value = resource.getString(R.string.no_internet_message)
+            return
+        }
+
+        compositeDisposable += authService.signUp(signUp)
+            .withDefaultSchedulers()
+            .doOnSubscribe {
+                mutableProgress.value = true
+            }.doFinally {
+                mutableProgress.value = false
+            }.subscribe({
+                mutableSignedUp.value = it
+                Timber.d("Success!")
+            }, {
+                when {
+                    it.toString().contains("HTTP 409") ->
+                        mutableError.value = resource.getString(R.string.sign_up_fail_email_exist_message)
+                    it.toString().contains("HTTP 422") ->
+                        mutableError.value = resource.getString(R.string.sign_up_fail_email_invalid_message)
+                    else -> mutableError.value = resource.getString(R.string.sign_up_fail_message)
+                }
+                Timber.d(it, "Failed")
+            })
+    }
+
+    fun login(signUp: SignUp) {
+        if (!network.isNetworkConnected()) {
+            mutableError.value = resource.getString(R.string.no_internet_message)
+            return
+        }
+        compositeDisposable += authService.login(signUp.email.nullToEmpty(), signUp.password.nullToEmpty())
+            .withDefaultSchedulers()
+            .doOnSubscribe {
+                mutableProgress.value = true
+            }.doFinally {
+                mutableProgress.value = false
+            }.subscribe({
+                mutableLoggedIn.value = true
+                Timber.d("Success!")
+            }, {
+                mutableError.value = resource.getString(R.string.login_automatically_fail_message)
+                Timber.d(it, "Failed")
+            })
+    }
+
+    fun setFacebookLogin(callbackManager: CallbackManager) {
+        LoginManager.getInstance().registerCallback(callbackManager,
+            object : FacebookCallback<LoginResult> {
+                override fun onSuccess(loginResult: LoginResult) {
+                    LoginManager.getInstance().logOut()
+                    fetchUserProfile(loginResult.accessToken)
+                }
+
+                override fun onCancel() {
+                    mutableError.value = "Cancelled"
+                }
+
+                override fun onError(exception: FacebookException) {
+                    mutableError.value = "Error"
+                    Timber.e(exception)
+                }
+            })
+    }
+
+    private fun fetchUserProfile(token: AccessToken?) {
+        val request = GraphRequest.newMeRequest(
+            token
+        ) { data, _ ->
+            if (!data.has(EMAIL)) {
+                mutableError.value = resource.getString(R.string.fb_email_not_registered)
+            } else {
+                mutableSignUp.value = SignUp(
+                    firstName = data.getString(FIRST_NAME),
+                    lastName = data.getString(LAST_NAME),
+                    email = data.getString(EMAIL)
+                )
+                mutableFbLogin.value = true
+                checkUser(data.getString(EMAIL))
+            }
+        }
+        val parameters = Bundle()
+        parameters.putString("fields", "$FIRST_NAME,$LAST_NAME,$EMAIL")
+        request.parameters = parameters
+        request.executeAsync()
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
@@ -62,6 +62,9 @@ class LoginFragment : Fragment() {
         if (loginViewModel.isLoggedIn())
             popBackStack()
 
+        val snackbarMessage = safeArgs.snackbarMessage
+        if (!snackbarMessage.isNullOrEmpty()) rootView.loginCoordinatorLayout.longSnackbar(snackbarMessage)
+
         rootView.loginButton.setOnClickListener {
             loginViewModel.login(email.text.toString(), password.text.toString())
             hideSoftKeyboard(context, rootView)

--- a/app/src/main/res/layout/dialog_password.xml
+++ b/app/src/main/res/layout/dialog_password.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="@dimen/padding_large">
+
+    <com.google.android.material.textfield.TextInputLayout
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+        android:id="@+id/textInputLayoutPassword"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/padding_medium"
+        android:layout_marginTop="@dimen/padding_medium"
+        app:passwordToggleEnabled="true">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/password"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:drawableLeft="@drawable/ic_lock_black"
+            android:drawablePadding="@dimen/layout_margin_moderate"
+            android:drawableStart="@drawable/ic_lock_black"
+            android:hint="@string/password"
+            android:inputType="textPassword" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+        android:id="@+id/textInputLayoutConfirmPassword"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/padding_medium"
+        android:layout_marginTop="@dimen/padding_medium"
+        app:passwordToggleEnabled="true">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/confirmPassword"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:drawableLeft="@drawable/ic_lock_black"
+            android:drawablePadding="@dimen/layout_margin_moderate"
+            android:drawableStart="@drawable/ic_lock_black"
+            android:hint="@string/confirm_password"
+            android:inputType="textPassword" />
+    </com.google.android.material.textfield.TextInputLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_auth.xml
+++ b/app/src/main/res/layout/fragment_auth.xml
@@ -56,6 +56,20 @@
             android:text="@string/get_started"
             android:textAllCaps="false"/>
 
+        <TextView
+            android:id="@+id/orTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/or"
+            android:textColor="@android:color/black"
+            android:layout_gravity="center_horizontal"/>
+
+        <com.facebook.login.widget.LoginButton
+            android:id="@+id/facebookLoginButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/layout_margin_large"/>
+
     </LinearLayout>
 
 </FrameLayout>

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -602,6 +602,12 @@
             android:name="redirectedFrom"
             app:argType="string"
             android:defaultValue="profile"/>
+        <argument
+            android:name="snackbarMessage"
+            app:argType="string"
+            app:nullable="true"
+            android:defaultValue="@null"/>
+
     </fragment>
     <fragment
         android:id="@+id/signUpFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,6 +260,9 @@
     <string name="order_not_completed">Order not completed!</string>
     <string name="removed_from_liked">Removed %1$s from liked events</string>
     <string name="undo">Undo</string>
+    <string name="email_already_registered">This email address is already registered with us. Please login to continue</string>
+    <string name="login_to_continue">Login_to_continue</string>
+    <string name="fb_email_not_registered">Email is not registered with this facebook account</string>
 
     <!--welcome fragment-->
     <string name="start_text_1">Where \ndo you \ngo out?</string>
@@ -270,6 +273,7 @@
     <string name="auth_title">Let\'s get started</string>
     <string name="auth_subtitle">Sign up or log in to see what\'s happening near you</string>
     <string name="get_started">Get Started</string>
+    <string name="or">or</string>
 
     <!--sign up fragment-->
     <string name="invalid_email_message">Your email address is invalid!</string>


### PR DESCRIPTION
Part of #1751 
- Collect user data i.e. email, first name, last name using facebook api.
- Check if the email is already registered with Eventyay.
- If yes then redirect to login and display msg about email is already registered with us.
- If not then show a password alert dialog and ask the user to provide password and sign up.
- Log in automatically and redirect to back stack
- Declear api keys as environmental variable
- Hide login button if api key is not provided
- Move logic to view model