### PR TITLE
fix: Load event detail UI immediately on EventDetailsFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -136,6 +136,12 @@ class EventDetailsFragment : Fragment() {
         setToolbar(activity)
         setHasOptionsMenu(true)
 
+        val currentEvent = eventViewModel.event.value
+        if (currentEvent != null)
+            loadEvent(currentEvent)
+        else
+            eventViewModel.loadEvent(safeArgs.eventId)
+
         rootView.feedbackRv.layoutManager = LinearLayoutManager(context)
         rootView.feedbackRv.adapter = feedbackAdapter
 
@@ -379,13 +385,6 @@ class EventDetailsFragment : Fragment() {
             .nonNull()
             .observe(this, Observer { isConnected ->
                 if (isConnected) {
-                    showEventErrorScreen(false)
-                    val currentEvent = eventViewModel.event.value
-                    if (currentEvent == null)
-                        eventViewModel.loadEvent(safeArgs.eventId)
-                    else
-                        loadEvent(currentEvent)
-
                     val currentFeedback = eventViewModel.eventFeedback.value
                     if (currentFeedback == null) {
                         eventViewModel.fetchEventFeedback(safeArgs.eventId)
@@ -435,12 +434,6 @@ class EventDetailsFragment : Fragment() {
                         rootView.socialLinkContainer.visibility =
                             if (currentSocialLinks.isEmpty()) View.GONE else View.VISIBLE
                     }
-                } else {
-                    val currentEvent = eventViewModel.event.value
-                    if (currentEvent == null)
-                        showEventErrorScreen(true)
-                    else
-                        loadEvent(currentEvent)
                 }
             })
 


### PR DESCRIPTION
Detail:
- Previously, loadEvent() only called only when there is internet connection. Now it is loaded immediately when rootView is created.
- Delete postpone on shared element transition as sometimes it takes time to load the cover image. It is better to just make the transition with the default image if the cover image is not loaded.

Fixes: #1798 #1805

@liveHarshit can you test this implementation to see if there is any problem with shared element transition with your device