### PR TITLE
fix: Fix shared element transition problems for older version

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -7,7 +7,6 @@ import android.os.Bundle
 import android.provider.CalendarContract
 import android.text.Editable
 import android.text.TextWatcher
-import android.transition.TransitionInflater
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
@@ -25,7 +24,6 @@ import androidx.navigation.Navigator
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
 import kotlinx.android.synthetic.main.content_event.view.eventDateDetailsFirst
 import kotlinx.android.synthetic.main.content_event.view.eventDateDetailsSecond
@@ -81,6 +79,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 import timber.log.Timber
 import java.util.Currency
 import org.fossasia.openevent.general.utils.Utils.setToolbar
+import org.fossasia.openevent.general.utils.extensions.setSharedElementEnterTransition
 import org.jetbrains.anko.design.longSnackbar
 import org.jetbrains.anko.design.snackbar
 
@@ -128,8 +127,7 @@ class EventDetailsFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        sharedElementEnterTransition = TransitionInflater.from(context).inflateTransition(android.R.transition.move)
-        postponeEnterTransition()
+        setSharedElementEnterTransition()
 
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_event, container, false)
         rootView = binding.root
@@ -297,15 +295,7 @@ class EventDetailsFragment : Fragment() {
         Picasso.get()
             .load(event.originalImageUrl)
             .placeholder(R.drawable.header)
-            .into(rootView.eventImage, object : Callback {
-                override fun onSuccess() {
-                    startPostponedEnterTransition()
-                }
-
-                override fun onError(e: Exception?) {
-                    startPostponedEnterTransition()
-                }
-            })
+            .into(rootView.eventImage)
 
         // Organizer Section
         if (!event.organizerName.isNullOrEmpty()) {

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -38,6 +38,8 @@ import org.fossasia.openevent.general.utils.extensions.nonNull
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import timber.log.Timber
 import org.fossasia.openevent.general.utils.Utils.setToolbar
+import org.fossasia.openevent.general.utils.extensions.setPostponeSharedElementTransition
+import org.fossasia.openevent.general.utils.extensions.setStartPostponedEnterTransition
 import org.jetbrains.anko.design.longSnackbar
 
 /**
@@ -73,7 +75,7 @@ class EventsFragment : Fragment(), ScrollToTop {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        postponeEnterTransition()
+        setPostponeSharedElementTransition()
         rootView = inflater.inflate(R.layout.fragment_events, container, false)
         setHasOptionsMenu(true)
         if (preference.getString(SAVED_LOCATION).isNullOrEmpty()) {
@@ -162,7 +164,7 @@ class EventsFragment : Fragment(), ScrollToTop {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         rootView.eventsRecycler.viewTreeObserver.addOnGlobalLayoutListener {
-            startPostponedEnterTransition()
+            setStartPostponedEnterTransition()
         }
 
         val eventClickListener: EventClickListener = object : EventClickListener {

--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
@@ -33,6 +33,8 @@ import org.fossasia.openevent.general.utils.extensions.nonNull
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import timber.log.Timber
 import org.fossasia.openevent.general.utils.Utils.setToolbar
+import org.fossasia.openevent.general.utils.extensions.setPostponeSharedElementTransition
+import org.fossasia.openevent.general.utils.extensions.setStartPostponedEnterTransition
 import org.jetbrains.anko.design.longSnackbar
 import org.jetbrains.anko.design.snackbar
 
@@ -48,14 +50,14 @@ class FavoriteFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        postponeEnterTransition()
+        setPostponeSharedElementTransition()
         rootView = inflater.inflate(R.layout.fragment_favorite, container, false)
         rootView.favoriteEventsRecycler.layoutManager = LinearLayoutManager(activity)
         rootView.favoriteEventsRecycler.adapter = favoriteEventsRecyclerAdapter
         rootView.favoriteEventsRecycler.isNestedScrollingEnabled = false
         setToolbar(activity, getString(R.string.likes), false)
         rootView.viewTreeObserver.addOnDrawListener {
-            startPostponedEnterTransition()
+            setStartPostponedEnterTransition()
         }
 
         rootView.findText.setOnClickListener {

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
@@ -43,6 +43,8 @@ import androidx.navigation.Navigator
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import kotlinx.android.synthetic.main.item_card_events.view.eventImage
 import org.fossasia.openevent.general.event.EventViewHolder
+import org.fossasia.openevent.general.utils.extensions.setPostponeSharedElementTransition
+import org.fossasia.openevent.general.utils.extensions.setStartPostponedEnterTransition
 
 class SearchResultsFragment : Fragment(), CompoundButton.OnCheckedChangeListener {
 
@@ -72,7 +74,7 @@ class SearchResultsFragment : Fragment(), CompoundButton.OnCheckedChangeListener
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         rootView = inflater.inflate(R.layout.fragment_search_results, container, false)
-        postponeEnterTransition()
+        setPostponeSharedElementTransition()
 
         setChips(eventDate, eventType)
         setToolbar(activity, getString(R.string.search_results))
@@ -83,7 +85,7 @@ class SearchResultsFragment : Fragment(), CompoundButton.OnCheckedChangeListener
         rootView.eventsRecycler.adapter = favoriteEventsRecyclerAdapter
         rootView.eventsRecycler.isNestedScrollingEnabled = false
         rootView.viewTreeObserver.addOnDrawListener {
-            startPostponedEnterTransition()
+            setStartPostponedEnterTransition()
         }
 
         searchViewModel.events

--- a/app/src/main/java/org/fossasia/openevent/general/utils/extensions/FragmentExt.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/utils/extensions/FragmentExt.kt
@@ -1,0 +1,25 @@
+package org.fossasia.openevent.general.utils.extensions
+
+import android.os.Build
+import android.transition.TransitionInflater
+import androidx.fragment.app.Fragment
+
+const val SUPPORTED_TRANSITION_VERSION = Build.VERSION_CODES.O
+
+fun Fragment.setStartPostponedEnterTransition() {
+    if (Build.VERSION.SDK_INT >= SUPPORTED_TRANSITION_VERSION) {
+        this.startPostponedEnterTransition()
+    }
+}
+
+fun Fragment.setSharedElementEnterTransition(transition: Int = android.R.transition.move) {
+    if (Build.VERSION.SDK_INT >= SUPPORTED_TRANSITION_VERSION) {
+        sharedElementEnterTransition = TransitionInflater.from(context).inflateTransition(transition)
+    }
+}
+
+fun Fragment.setPostponeSharedElementTransition() {
+    if (Build.VERSION.SDK_INT >= SUPPORTED_TRANSITION_VERSION) {
+        postponeEnterTransition()
+    }
+}


### PR DESCRIPTION
Detail:
- Only set shared element transition for API version >= 26
- Remove delay for loading image

Fixes: #1805
Fixes #1804

Discussion on #1799 