### PR TITLE
fix: Avoid app crash on login API version <= 24

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -142,7 +142,7 @@ dependencies {
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation 'com.jakewharton.threetenabp:threetenabp:1.2.0'
 
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.9"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.6"
     implementation 'com.github.jasminb:jsonapi-converter:0.9'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.14.2'
     implementation 'com.squareup.retrofit2:retrofit:2.5.0'


### PR DESCRIPTION
Details:
- This is due to a bug from jackson-module-kotlin that doesn't support Android < API 24. So dependency version is reduced from 2.9.9 to 2.9.6

Fixes: #1829

**Related**
Issue #1784 
https://github.com/FasterXML/jackson-module-kotlin/issues/218