### PR TITLE
fix: Improve AttendeeFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeViewModel.kt
@@ -95,7 +95,6 @@ class AttendeeViewModel(
     var singleTicket = false
     var monthSelectedPosition: Int = 0
     var yearSelectedPosition: Int = 0
-    var cardTypePosition: Int = 0
     var identifierList = ArrayList<String>()
     var editTextList = ArrayList<EditText>()
     var paymentCurrency: String = ""

--- a/app/src/main/java/org/fossasia/openevent/general/utils/Utils.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/utils/Utils.kt
@@ -57,10 +57,13 @@ object Utils {
         return connectivityManager?.activeNetworkInfo != null
     }
 
-    fun progressDialog(context: Context?): ProgressDialog {
+    fun progressDialog(
+        context: Context?,
+        message: String? = context?.resources?.getString(R.string.loading_message)
+    ): ProgressDialog {
         val dialog = ProgressDialog(context)
         dialog.setCancelable(false)
-        dialog.setMessage("Loading...")
+        dialog.setMessage(message)
         return dialog
     }
 

--- a/app/src/main/res/layout/fragment_attendee.xml
+++ b/app/src/main/res/layout/fragment_attendee.xml
@@ -303,6 +303,7 @@
                     tools:listitem="@layout/item_attendee" />
 
                 <RelativeLayout
+                    android:id="@+id/billingInfoCheckboxSection"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content">
                     <TextView
@@ -494,38 +495,6 @@
                         android:layout_height="wrap_content"
                         android:layout_marginBottom="@dimen/layout_margin_medium"
                         android:layout_marginTop="@dimen/layout_margin_large"
-                        android:text="@string/card_type"
-                        android:textSize="@dimen/text_size_large" />
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:background="@drawable/filled_border"
-                        android:gravity="center"
-                        android:orientation="horizontal">
-
-                        <TextView
-                            android:id="@+id/selectCard"
-                            android:layout_width="wrap_content"
-                            android:layout_height="@dimen/spinner_width"
-                            android:layout_weight="0.8"
-                            android:gravity="center"
-                            android:textSize="@dimen/text_size_large" />
-
-                        <androidx.appcompat.widget.AppCompatSpinner
-                            android:id="@+id/cardSelector"
-                            android:layout_width="@dimen/spinner_width"
-                            android:layout_height="@dimen/spinner_width"
-                            android:layout_marginLeft="@dimen/layout_margin_medium"
-                            android:spinnerMode="dialog" />
-                    </LinearLayout>
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/layout_margin_medium"
-                        android:layout_marginTop="@dimen/layout_margin_large"
                         android:text="@string/expiration_date"
                         android:textSize="@dimen/text_size_large" />
 
@@ -627,18 +596,7 @@
                         android:layout_marginEnd="@dimen/details_margin_small"
                         android:layout_marginTop="@dimen/layout_margin_large"
                         android:layout_marginBottom="@dimen/layout_margin_large"
-                        android:enabled="false"
                         android:text="@string/register"/>
-
-                    <ProgressBar
-                        android:layout_centerInParent="true"
-                        android:id="@+id/progressBarAttendee"
-                        android:layout_width="@dimen/spinner_height"
-                        android:layout_height="@dimen/spinner_width"
-                        android:elevation="@dimen/card_elevation"
-                        android:padding="@dimen/padding_small"
-                        android:visibility="gone"
-                        tools:visibility="visible"/>
                 </RelativeLayout>
 
             </LinearLayout>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -172,7 +172,6 @@
     <string name="sign_in_canceled">সিগণ ইন ক্যানসেল!</string>
     <string name="sign_up_success">সিগণ উপ সাফল্য!</string>
     <string name="cannot_fetch_location">অবস্থান আনা যাচ্ছে না!</string>
-    <string name="confirmation_dialog">আপনি কি অর্ডার কন্ফার্ম করতে চান?</string>
     <string name="order_not_completed">অর্ডার কমপ্লিট হয়নি!</string>
 
     <!--welcome fragment-->

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -150,7 +150,6 @@
     <string name="timeZone_title">Sử dụng múi giờ của sự kiện.</string>
     <string name="timeZone_summary">Múi giờ của bạn sẽ được sử dụng khi khóa lại.</string>
     <string name="hide">(giấu)</string>
-    <string name="confirmation_dialog">Bạn có chắc chắn để khẳng định trình tự?</string>
     <string name="order_not_completed">Để không hoàn thành!</string>
     <string name="country">Quốc Gia</string>
     <string name="visit_website">truy cập trang web</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -263,6 +263,7 @@
     <string name="create_attendee_success_message">Attendees created successfully!</string>
     <string name="create_attendee_fail_message">Unable to create Attendee!</string>
     <string name="fill_all_fields_message">Please fill in all the fields</string>
+    <string name="fill_required_fields_message">Please fill in all the required fields</string>
     <string name="free">free</string>
     <string name="order_success_message">Order created successfully!</string>
     <string name="order_fail_message">Unable to create Order!</string>
@@ -282,7 +283,6 @@
     <string name="sign_in_canceled">Sign In canceled!</string>
     <string name="sign_up_success">Sign Up Success!</string>
     <string name="cannot_fetch_location">Cannot fetch location!</string>
-    <string name="confirmation_dialog">Are you sure to confirm the order?</string>
     <string name="order_not_completed">Order not completed!</string>
     <string name="removed_from_liked">Removed %1$s from liked events</string>
     <string name="undo">Undo</string>
@@ -411,5 +411,7 @@
     <string name="no_speaker_profile_created_message">You haven\'t created any speaker profile</string>
     <string name="create_speaker_fail_message">Fail on creating speaker profile</string>
     <string name="update_speaker_fail_message">Fail on updating speaker profile</string>
+    <string name="loading_message">Loading...</string>
+    <string name="creating_order_message">Creating order...</string>
 
 </resources>


### PR DESCRIPTION
Details:
- Set up more logically time display of event
- Remove card type selector as it doesn't matter that much. Stripe automatically determine card type based on card number provided
- Hide billing information for free tickets
- Show pop up message for "required fields should be filled"
- Remove confirm dialog on ordering ticket (based on Eventbrite)

Fixes #1885 
