### PR TITLE
feat: Filter call for speakers event

### DIFF
--- a/app/schemas/org.fossasia.openevent.general.OpenEventDatabase/6.json
+++ b/app/schemas/org.fossasia.openevent.general.OpenEventDatabase/6.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 6,
-    "identityHash": "aa57ed3fc9eae95608d5d07698a99ae0",
+    "identityHash": "6dd7be6dcd6abac08bf30c108ac7bbc9",
     "entities": [
       {
         "tableName": "Event",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `identifier` TEXT NOT NULL, `startsAt` TEXT NOT NULL, `endsAt` TEXT NOT NULL, `timezone` TEXT NOT NULL, `privacy` TEXT NOT NULL, `paymentCountry` TEXT, `paypalEmail` TEXT, `thumbnailImageUrl` TEXT, `schedulePublishedOn` TEXT, `paymentCurrency` TEXT, `organizerDescription` TEXT, `originalImageUrl` TEXT, `onsiteDetails` TEXT, `organizerName` TEXT, `largeImageUrl` TEXT, `deletedAt` TEXT, `ticketUrl` TEXT, `locationName` TEXT, `codeOfConduct` TEXT, `state` TEXT, `searchableLocationName` TEXT, `description` TEXT, `pentabarfUrl` TEXT, `xcalUrl` TEXT, `logoUrl` TEXT, `externalEventUrl` TEXT, `iconImageUrl` TEXT, `icalUrl` TEXT, `createdAt` TEXT, `bankDetails` TEXT, `chequeDetails` TEXT, `isComplete` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `refundPolicy` TEXT, `orderExpiryTime` INTEGER NOT NULL, `canPayByStripe` INTEGER NOT NULL, `canPayByCheque` INTEGER NOT NULL, `canPayByBank` INTEGER NOT NULL, `canPayByPaypal` INTEGER NOT NULL, `canPayOnsite` INTEGER NOT NULL, `isSponsorsEnabled` INTEGER NOT NULL, `hasOrganizerInfo` INTEGER NOT NULL, `isSessionsSpeakersEnabled` INTEGER NOT NULL, `isTicketingEnabled` INTEGER NOT NULL, `isTaxEnabled` INTEGER NOT NULL, `isMapShown` INTEGER NOT NULL, `favorite` INTEGER NOT NULL, `eventTopic` TEXT, `eventType` TEXT, `eventSubTopic` TEXT, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `identifier` TEXT NOT NULL, `startsAt` TEXT NOT NULL, `endsAt` TEXT NOT NULL, `timezone` TEXT NOT NULL, `privacy` TEXT NOT NULL, `paymentCountry` TEXT, `paypalEmail` TEXT, `thumbnailImageUrl` TEXT, `schedulePublishedOn` TEXT, `paymentCurrency` TEXT, `organizerDescription` TEXT, `originalImageUrl` TEXT, `onsiteDetails` TEXT, `organizerName` TEXT, `largeImageUrl` TEXT, `deletedAt` TEXT, `ticketUrl` TEXT, `locationName` TEXT, `codeOfConduct` TEXT, `state` TEXT, `searchableLocationName` TEXT, `description` TEXT, `pentabarfUrl` TEXT, `xcalUrl` TEXT, `logoUrl` TEXT, `externalEventUrl` TEXT, `iconImageUrl` TEXT, `icalUrl` TEXT, `createdAt` TEXT, `bankDetails` TEXT, `chequeDetails` TEXT, `isComplete` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `refundPolicy` TEXT, `orderExpiryTime` INTEGER NOT NULL, `canPayByStripe` INTEGER NOT NULL, `canPayByCheque` INTEGER NOT NULL, `canPayByBank` INTEGER NOT NULL, `canPayByPaypal` INTEGER NOT NULL, `canPayOnsite` INTEGER NOT NULL, `isSponsorsEnabled` INTEGER NOT NULL, `hasOrganizerInfo` INTEGER NOT NULL, `isSessionsSpeakersEnabled` INTEGER NOT NULL, `isTicketingEnabled` INTEGER NOT NULL, `isTaxEnabled` INTEGER NOT NULL, `isMapShown` INTEGER NOT NULL, `favorite` INTEGER NOT NULL, `eventTopic` TEXT, `eventType` TEXT, `eventSubTopic` TEXT, `speakersCall` TEXT, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -325,6 +325,12 @@
             "columnName": "eventSubTopic",
             "affinity": "TEXT",
             "notNull": false
+          },
+          {
+            "fieldPath": "speakersCall",
+            "columnName": "speakersCall",
+            "affinity": "TEXT",
+            "notNull": false
           }
         ],
         "primaryKey": {
@@ -357,6 +363,14 @@
               "eventSubTopic"
             ],
             "createSql": "CREATE  INDEX `index_Event_eventSubTopic` ON `${TABLE_NAME}` (`eventSubTopic`)"
+          },
+          {
+            "name": "index_Event_speakersCall",
+            "unique": false,
+            "columnNames": [
+              "speakersCall"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_speakersCall` ON `${TABLE_NAME}` (`speakersCall`)"
           }
         ],
         "foreignKeys": []
@@ -1701,7 +1715,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'aa57ed3fc9eae95608d5d07698a99ae0')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6dd7be6dcd6abac08bf30c108ac7bbc9')"
     ]
   }
 }

--- a/app/src/main/java/org/fossasia/openevent/general/OpenEventDatabase.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/OpenEventDatabase.kt
@@ -30,6 +30,7 @@ import org.fossasia.openevent.general.sessions.sessiontype.SessionTypeConverter
 import org.fossasia.openevent.general.sessions.track.TrackConverter
 import org.fossasia.openevent.general.social.SocialLink
 import org.fossasia.openevent.general.social.SocialLinksDao
+import org.fossasia.openevent.general.speakercall.SpeakersCallConverter
 import org.fossasia.openevent.general.speakers.Speaker
 import org.fossasia.openevent.general.speakers.SpeakerDao
 import org.fossasia.openevent.general.speakers.SpeakerWithEvent
@@ -47,7 +48,8 @@ import org.fossasia.openevent.general.ticket.TicketIdConverter
     SponsorWithEvent::class, Session::class, SpeakersCall::class], version = 6)
 @TypeConverters(EventIdConverter::class, EventTopicConverter::class, EventTypeConverter::class,
     EventSubTopicConverter::class, TicketIdConverter::class, MicroLocationConverter::class, UserIdConverter::class,
-    AttendeeIdConverter::class, ListAttendeeIdConverter::class, SessionTypeConverter::class, TrackConverter::class)
+    AttendeeIdConverter::class, ListAttendeeIdConverter::class, SessionTypeConverter::class, TrackConverter::class,
+    SpeakersCallConverter::class)
 abstract class OpenEventDatabase : RoomDatabase() {
 
     abstract fun eventDao(): EventDao

--- a/app/src/main/java/org/fossasia/openevent/general/event/Event.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/Event.kt
@@ -12,6 +12,7 @@ import com.github.jasminb.jsonapi.annotations.Type
 import org.fossasia.openevent.general.event.subtopic.EventSubTopic
 import org.fossasia.openevent.general.event.topic.EventTopic
 import org.fossasia.openevent.general.event.types.EventType
+import org.fossasia.openevent.general.speakercall.SpeakersCall
 
 @Type("event")
 @JsonNaming(PropertyNamingStrategy.KebabCaseStrategy::class)
@@ -72,12 +73,15 @@ data class Event(
     var favorite: Boolean = false,
     @ColumnInfo(index = true)
     @Relationship("event-topic", resolve = true)
-    var eventTopic: EventTopic? = null,
+    val eventTopic: EventTopic? = null,
     @ColumnInfo(index = true)
     @Relationship("event-type", resolve = true)
-    var eventType: EventType? = null,
+    val eventType: EventType? = null,
     @ColumnInfo(index = true)
     @Relationship("event-sub-topic", resolve = true)
-    var eventSubTopic: EventSubTopic? = null
+    val eventSubTopic: EventSubTopic? = null,
+    @ColumnInfo(index = true)
+    @Relationship("speakers-call", resolve = true)
+    val speakersCall: SpeakersCall? = null
 
 )

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventApi.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventApi.kt
@@ -11,7 +11,7 @@ interface EventApi {
     @GET("events?include=event-topic")
     fun getEvents(): Single<List<Event>>
 
-    @GET("events?include=event-sub-topic,event-topic,event-type")
+    @GET("events?include=event-sub-topic,event-topic,event-type,speakers-call")
     fun searchEvents(@Query("sort") sort: String, @Query("filter") eventName: String): Single<List<Event>>
 
     @GET

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -545,6 +545,8 @@ class EventDetailsFragment : Fragment() {
                 menu.findItem(R.id.open_external_event_url).isVisible = false
             if (currentEvent.codeOfConduct.isNullOrBlank())
                 menu.findItem(R.id.code_of_conduct).isVisible = false
+            if (currentEvent.speakersCall == null)
+                menu.findItem(R.id.call_for_speakers).isVisible = false
             setFavoriteIconFilled(currentEvent.favorite)
         }
         super.onPrepareOptionsMenu(menu)

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventService.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventService.kt
@@ -80,8 +80,11 @@ class EventService(
     }
 
     fun getSearchEvents(eventName: String, sortBy: String): Flowable<List<Event>> {
-        return eventApi.searchEvents(sortBy, eventName).flatMapPublisher { apiList ->
-            updateFavorites(apiList)
+        return eventApi.searchEvents(sortBy, eventName).flatMapPublisher { eventsList ->
+            eventsList.forEach {
+                it.speakersCall?.let { sc -> speakersCallDao.insertSpeakerCall(sc) }
+            }
+            updateFavorites(eventsList)
         }
     }
 
@@ -97,7 +100,7 @@ class EventService(
         }
     }
 
-    fun updateFavorites(apiList: List<Event>): Flowable<List<Event>> {
+    private fun updateFavorites(apiList: List<Event>): Flowable<List<Event>> {
 
         val ids = apiList.map { it.id }.toList()
         eventTopicsDao.insertEventTopics(getEventTopicList(apiList))

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchFilterFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchFilterFragment.kt
@@ -9,9 +9,9 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.RadioButton
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Observer
 import androidx.navigation.Navigation.findNavController
 import androidx.navigation.fragment.navArgs
+import kotlinx.android.synthetic.main.fragment_search_filter.view.callForSpeakerCheckBox
 import kotlinx.android.synthetic.main.fragment_search_filter.view.dateRadioButton
 import kotlinx.android.synthetic.main.fragment_search_filter.view.freeStuffCheckBox
 import kotlinx.android.synthetic.main.fragment_search_filter.view.sessionsAndSpeakerCheckBox
@@ -22,21 +22,19 @@ import kotlinx.android.synthetic.main.fragment_search_filter.view.tvSelectDate
 import kotlinx.android.synthetic.main.fragment_search_filter.view.tvSelectLocation
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.utils.Utils.setToolbar
-import org.fossasia.openevent.general.utils.extensions.nonNull
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 const val SEARCH_FILTER_FRAGMENT = "SearchFilterFragment"
 
 class SearchFilterFragment : Fragment() {
     private lateinit var rootView: View
-    private var isFreeStuffChecked = false
     private lateinit var selectedTime: String
     private lateinit var selectedLocation: String
     private lateinit var selectedCategory: String
     private val searchViewModel by viewModel<SearchViewModel>()
     private val safeArgs: SearchFilterFragmentArgs by navArgs()
     private lateinit var sortBy: String
-    private var isSessionsAndSpeakersChecked = false
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -48,18 +46,6 @@ class SearchFilterFragment : Fragment() {
         setFilterParams()
         setFilters()
         setSortByRadioGroup()
-
-        searchViewModel.mutableFreeTickets
-            .nonNull()
-            .observe(viewLifecycleOwner, Observer {
-                isFreeStuffChecked = it
-            })
-
-        searchViewModel.mutableSessionAndSpeaker
-            .nonNull()
-            .observe(viewLifecycleOwner, Observer {
-                isSessionsAndSpeakersChecked = true
-            })
 
         return rootView
     }
@@ -95,12 +81,13 @@ class SearchFilterFragment : Fragment() {
             R.id.filter_set -> {
                 findNavController(rootView).navigate(SearchFilterFragmentDirections.actionSearchFilterToSearchResults(
                     date = selectedTime,
-                    freeEvents = isFreeStuffChecked,
+                    freeEvents = rootView.freeStuffCheckBox.isChecked,
                     location = selectedLocation,
                     type = selectedCategory,
                     query = safeArgs.query,
                     sort = sortBy,
-                    sessionsAndSpeakers = isSessionsAndSpeakersChecked
+                    sessionsAndSpeakers = rootView.sessionsAndSpeakerCheckBox.isChecked,
+                    callForSpeakers = rootView.callForSpeakerCheckBox.isChecked
                 ))
                 true
             }
@@ -147,13 +134,7 @@ class SearchFilterFragment : Fragment() {
         }
 
         rootView.freeStuffCheckBox.isChecked = safeArgs.freeEvents
-        rootView.freeStuffCheckBox.setOnCheckedChangeListener { _, isChecked ->
-            searchViewModel.mutableFreeTickets.postValue(isChecked)
-        }
-
         rootView.sessionsAndSpeakerCheckBox.isChecked = safeArgs.sessionsAndSpeakers
-        rootView.sessionsAndSpeakerCheckBox.setOnCheckedChangeListener { _, isChecked ->
-            searchViewModel.mutableSessionAndSpeaker.postValue(isChecked)
-        }
+        rootView.callForSpeakerCheckBox.isChecked = safeArgs.callForSpeakers
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
@@ -228,10 +228,11 @@ class SearchResultsFragment : Fragment(), CompoundButton.OnCheckedChangeListener
         val date = eventDate
         val freeEvents = safeArgs.freeEvents
         val sortBy = safeArgs.sort
+        val callForSpeakers = safeArgs.callForSpeakers
 
         val sessionsAndSpeakers = safeArgs.sessionsAndSpeakers
         searchViewModel.searchEvent = query
-        searchViewModel.loadEvents(location, date, type, freeEvents, sortBy, sessionsAndSpeakers)
+        searchViewModel.loadEvents(location, date, type, freeEvents, sortBy, sessionsAndSpeakers, callForSpeakers)
     }
 
     private fun showNoSearchResults(events: List<Event>) {
@@ -258,7 +259,8 @@ class SearchResultsFragment : Fragment(), CompoundButton.OnCheckedChangeListener
                     type = safeArgs.type,
                     query = safeArgs.query,
                     sort = safeArgs.sort,
-                    sessionsAndSpeakers = safeArgs.sessionsAndSpeakers))
+                    sessionsAndSpeakers = safeArgs.sessionsAndSpeakers,
+                    callForSpeakers = safeArgs.callForSpeakers))
                 true
             }
             else -> super.onOptionsItemSelected(item)

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchViewModel.kt
@@ -41,8 +41,6 @@ class SearchViewModel(
     private val mutableError = SingleLiveEvent<String>()
     val error: LiveData<String> = mutableError
     val connection: LiveData<Boolean> = mutableConnectionLiveData
-    val mutableSessionAndSpeaker = MutableLiveData<Boolean>()
-    val mutableFreeTickets = MutableLiveData<Boolean>()
     var searchEvent: String? = null
     var savedLocation: String? = null
     var savedType: String? = null
@@ -84,7 +82,8 @@ class SearchViewModel(
         type: String,
         freeEvents: Boolean,
         sortBy: String,
-        sessionsAndSpeakers: Boolean
+        sessionsAndSpeakers: Boolean,
+        callForSpeakers: Boolean
     ) {
         if (mutableEvents.value != null) {
             return
@@ -108,7 +107,7 @@ class SearchViewModel(
                |    }
             """.trimIndent()
             else ""
-        val callForSpeakersFilter = if (sessionsAndSpeakers)
+        val sessionsAndSpeakersFilter = if (sessionsAndSpeakers)
             """, {
                |       'name':'is-sessions-speakers-enabled',
                |       'op':'eq',
@@ -140,7 +139,7 @@ class SearchViewModel(
                 |       'op':'ge',
                 |       'val':'%${EventUtils.getTimeInISO8601(Date())}%'
                 |    }$freeStuffFilter
-                |    $callForSpeakersFilter]
+                |    $sessionsAndSpeakersFilter]
                 |}]""".trimMargin().replace("'", "\"")
             time == "Anytime" -> """[{
                 |   'and':[{
@@ -164,7 +163,7 @@ class SearchViewModel(
                 |       'op':'ge',
                 |       'val':'%${EventUtils.getTimeInISO8601(Date())}%'
                 |    }$freeStuffFilter
-                |    $callForSpeakersFilter]
+                |    $sessionsAndSpeakersFilter]
                 |}]""".trimMargin().replace("'", "\"")
             time == "Today" -> """[{
                 |   'and':[{
@@ -196,7 +195,7 @@ class SearchViewModel(
                 |       'op':'ge',
                 |       'val':'%${EventUtils.getTimeInISO8601(Date())}%'
                 |    }$freeStuffFilter
-                |    $callForSpeakersFilter]
+                |    $sessionsAndSpeakersFilter]
                 |}]""".trimMargin().replace("'", "\"")
             time == "Tomorrow" -> """[{
                 |   'and':[{
@@ -228,7 +227,7 @@ class SearchViewModel(
                 |       'op':'ge',
                 |       'val':'%${EventUtils.getTimeInISO8601(Date())}%'
                 |    }$freeStuffFilter
-                |    $callForSpeakersFilter]
+                |    $sessionsAndSpeakersFilter]
                 |}]""".trimMargin().replace("'", "\"")
             time == "This weekend" -> """[{
                 |   'and':[{
@@ -260,7 +259,7 @@ class SearchViewModel(
                 |       'op':'ge',
                 |       'val':'%${EventUtils.getTimeInISO8601(Date())}%'
                 |    }$freeStuffFilter
-                |    $callForSpeakersFilter]
+                |    $sessionsAndSpeakersFilter]
                 |}]""".trimMargin().replace("'", "\"")
             time == "In the next month" -> """[{
                 |   'and':[{
@@ -292,7 +291,7 @@ class SearchViewModel(
                 |       'op':'ge',
                 |       'val':'%${EventUtils.getTimeInISO8601(Date())}%'
                 |    }$freeStuffFilter
-                |    $callForSpeakersFilter]
+                |    $sessionsAndSpeakersFilter]
                 |}]""".trimMargin().replace("'", "\"")
 
             else -> """[{
@@ -325,7 +324,7 @@ class SearchViewModel(
                 |       'op':'ge',
                 |       'val':'%${EventUtils.getTimeInISO8601(Date())}%'
                 |    }$freeStuffFilter
-                |    $callForSpeakersFilter]
+                |    $sessionsAndSpeakersFilter]
                 |}]""".trimMargin().replace("'", "\"")
         }
         Timber.e(query)
@@ -338,7 +337,7 @@ class SearchViewModel(
                 stopLoaders()
             }.subscribe({
                 stopLoaders()
-                mutableEvents.value = it
+                mutableEvents.value = if (callForSpeakers) it.filter { it.speakersCall != null } else it
             }, {
                 stopLoaders()
                 Timber.e(it, "Error fetching events")

--- a/app/src/main/java/org/fossasia/openevent/general/speakercall/SpeakersCallConverter.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/speakercall/SpeakersCallConverter.kt
@@ -1,0 +1,15 @@
+package org.fossasia.openevent.general.speakercall
+
+import androidx.room.TypeConverter
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
+class SpeakersCallConverter {
+    @TypeConverter
+    fun toSpeakersCall(json: String): SpeakersCall? {
+        return jacksonObjectMapper().readerFor(SpeakersCall::class.java).readValue<SpeakersCall>(json)
+    }
+
+    @TypeConverter
+    fun toJson(speakersCall: SpeakersCall?) = ObjectMapper().writeValueAsString(speakersCall)
+}

--- a/app/src/main/res/layout/fragment_search_filter.xml
+++ b/app/src/main/res/layout/fragment_search_filter.xml
@@ -135,6 +135,17 @@
                 android:text="@string/sessions_and_speakers"
                 android:textColor="@color/light_grey"
                 android:textSize="@dimen/text_size_large" />
+
+            <CheckBox
+                android:id="@+id/callForSpeakerCheckBox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/layout_margin_large"
+                android:layoutDirection="rtl"
+                android:padding="@dimen/padding_medium"
+                android:text="@string/call_for_speakers"
+                android:textColor="@color/light_grey"
+                android:textSize="@dimen/text_size_large" />
         </LinearLayout>
 
         <LinearLayout

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -245,6 +245,11 @@
             android:name="sessionsAndSpeakers"
             app:argType="boolean"
             android:defaultValue="false"/>
+
+        <argument
+            android:name="callForSpeakers"
+            app:argType="boolean"
+            android:defaultValue="false"/>
     </fragment>
     <fragment
         android:id="@+id/speakerFragment"
@@ -801,6 +806,11 @@
 
         <argument
             android:name="sessionsAndSpeakers"
+            app:argType="boolean"
+            android:defaultValue="false"/>
+
+        <argument
+            android:name="callForSpeakers"
             app:argType="boolean"
             android:defaultValue="false"/>
     </fragment>


### PR DESCRIPTION
Details:
- Remove retaining checkbox state in ViewModel as Android automatically do it for Checkbox component
- Set up Call For Speakers filter
- Hide option menu Call For Speakers with events not containing speakers call.

Fixes: #1825

Screenshots for the change:
<img src="https://i.ibb.co/xGpYQZ2/ezgif-2-5933bbf30de4.gif" alt="ezgif-2-5933bbf30de4" border="0">