### PR TITLE
fix: Avoid crash on OrderCompleted

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/common/RecyclerViewCallbacks.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/common/RecyclerViewCallbacks.kt
@@ -1,5 +1,6 @@
 package org.fossasia.openevent.general.common
 
+import android.widget.ImageView
 import org.fossasia.openevent.general.event.Event
 
 /**
@@ -10,9 +11,9 @@ interface EventClickListener {
      * The function to be invoked when an event item is clicked
      *
      * @param eventID The ID of the clicked event
-     * @param itemPosition The position of event object in the adapter
+     * @param imageView The Image View of event object in the adapter
      */
-    fun onClick(eventID: Long, itemPosition: Int)
+    fun onClick(eventID: Long, imageView: ImageView)
 }
 
 /**

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -13,6 +13,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
@@ -20,7 +21,6 @@ import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.Navigation.findNavController
-import androidx.navigation.Navigator
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -439,20 +439,10 @@ class EventDetailsFragment : Fragment() {
             })
 
         val eventClickListener: EventClickListener = object : EventClickListener {
-            override fun onClick(eventID: Long, itemPosition: Int) {
-                var extras: Navigator.Extras? = null
-                val itemEventViewHolder = rootView.similarEventsRecycler.findViewHolderForAdapterPosition(itemPosition)
-                itemEventViewHolder?.let {
-                    if (itemEventViewHolder is EventViewHolder) {
-                        extras = FragmentNavigatorExtras(
-                            itemEventViewHolder.itemView.eventImage to "eventDetailImage")
-                    }
-                }
-                extras?.let {
-                    findNavController(view)
-                        .navigate(EventDetailsFragmentDirections.actionSimilarEventsToEventDetails(eventID), it)
-                } ?: findNavController(view)
-                    .navigate(EventDetailsFragmentDirections.actionSimilarEventsToEventDetails(eventID))
+            override fun onClick(eventID: Long, imageView: ImageView) {
+                findNavController(rootView)
+                    .navigate(EventDetailsFragmentDirections.actionSimilarEventsToEventDetails(eventID),
+                        FragmentNavigatorExtras(imageView to "eventDetailImage"))
             }
         }
 

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventViewHolder.kt
@@ -93,7 +93,7 @@ class EventViewHolder(override val containerView: View) : RecyclerView.ViewHolde
         }
 
         containerView.setOnClickListener {
-            eventClickListener?.onClick(event.id, itemPosition)
+            eventClickListener?.onClick(event.id, containerView.eventImage)
                 ?: Timber.e("Event Click listener on ${this::class.java.canonicalName} is null")
         }
 

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -8,12 +8,12 @@ import android.view.ViewGroup
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
+import android.widget.ImageView
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.navigation.Navigation.findNavController
-import androidx.navigation.Navigator
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import kotlinx.android.synthetic.main.content_no_internet.view.noInternetCard
 import kotlinx.android.synthetic.main.content_no_internet.view.retry
@@ -27,7 +27,6 @@ import kotlinx.android.synthetic.main.fragment_events.view.swiperefresh
 import kotlinx.android.synthetic.main.fragment_events.view.eventsEmptyView
 import kotlinx.android.synthetic.main.fragment_events.view.emptyEventsText
 import kotlinx.android.synthetic.main.fragment_events.view.eventsNestedScrollView
-import kotlinx.android.synthetic.main.item_card_events.view.eventImage
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.ScrollToTop
 import org.fossasia.openevent.general.common.EventClickListener
@@ -168,18 +167,9 @@ class EventsFragment : Fragment(), ScrollToTop {
         }
 
         val eventClickListener: EventClickListener = object : EventClickListener {
-            override fun onClick(eventID: Long, itemPosition: Int) {
-                var extras: Navigator.Extras? = null
-                val itemEventViewHolder = rootView.eventsRecycler.findViewHolderForAdapterPosition(itemPosition)
-                itemEventViewHolder?.let {
-                    if (itemEventViewHolder is EventViewHolder) {
-                        extras = FragmentNavigatorExtras(
-                            itemEventViewHolder.itemView.eventImage to "eventDetailImage")
-                    }
-                }
-                extras?.let {
-                    findNavController(view).navigate(EventsFragmentDirections.actionEventsToEventsDetail(eventID), it)
-                } ?: findNavController(view).navigate(EventsFragmentDirections.actionEventsToEventsDetail(eventID))
+            override fun onClick(eventID: Long, imageView: ImageView) {
+                findNavController(rootView).navigate(EventsFragmentDirections.actionEventsToEventsDetail(eventID),
+                        FragmentNavigatorExtras(imageView to "eventDetailImage"))
             }
         }
 

--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
@@ -4,14 +4,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.navigation.Navigation.findNavController
-import androidx.navigation.Navigator
 import androidx.navigation.fragment.FragmentNavigatorExtras
-import kotlinx.android.synthetic.main.content_event.view.eventImage
 import kotlinx.android.synthetic.main.fragment_favorite.noLikedLL
 import kotlinx.android.synthetic.main.fragment_favorite.favoriteCoordinatorLayout
 import kotlinx.android.synthetic.main.fragment_favorite.view.favoriteEventsRecycler
@@ -27,7 +26,6 @@ import org.fossasia.openevent.general.common.EventClickListener
 import org.fossasia.openevent.general.common.EventsDiffCallback
 import org.fossasia.openevent.general.common.FavoriteFabClickListener
 import org.fossasia.openevent.general.data.Preference
-import org.fossasia.openevent.general.event.EventViewHolder
 import org.fossasia.openevent.general.search.SAVED_LOCATION
 import org.fossasia.openevent.general.utils.extensions.nonNull
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -106,21 +104,9 @@ class FavoriteFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         val eventClickListener: EventClickListener = object : EventClickListener {
-            override fun onClick(eventID: Long, itemPosition: Int) {
-                var extras: Navigator.Extras? = null
-                val itemEventViewHolder = rootView.favoriteEventsRecycler.findViewHolderForAdapterPosition(itemPosition)
-                itemEventViewHolder?.let {
-                    if (itemEventViewHolder is EventViewHolder) {
-                        extras = FragmentNavigatorExtras(
-                            itemEventViewHolder.itemView.eventImage to "eventDetailImage")
-                    }
-                }
-
-                extras?.let {
-                    findNavController(rootView)
-                        .navigate(FavoriteFragmentDirections.actionFavouriteToEventDetails(eventID), it)
-                } ?: findNavController(rootView)
-                    .navigate(FavoriteFragmentDirections.actionFavouriteToEventDetails(eventID))
+            override fun onClick(eventID: Long, imageView: ImageView) {
+                findNavController(rootView).navigate(FavoriteFragmentDirections.actionFavouriteToEventDetails(eventID),
+                        FragmentNavigatorExtras(imageView to "eventDetailImage"))
             }
         }
 

--- a/app/src/main/java/org/fossasia/openevent/general/order/OrderCompletedFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/order/OrderCompletedFragment.kt
@@ -9,15 +9,14 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.Navigation.findNavController
-import androidx.navigation.Navigator
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
-import kotlinx.android.synthetic.main.content_event.view.eventImage
 import kotlinx.android.synthetic.main.fragment_order_completed.view.similarEventsRecycler
 import kotlinx.android.synthetic.main.fragment_order_completed.view.similarEventLayout
 import kotlinx.android.synthetic.main.fragment_order_completed.view.shimmerSimilarEvents
@@ -33,7 +32,6 @@ import org.fossasia.openevent.general.common.EventsDiffCallback
 import org.fossasia.openevent.general.common.FavoriteFabClickListener
 import org.fossasia.openevent.general.event.EventUtils
 import org.fossasia.openevent.general.event.Event
-import org.fossasia.openevent.general.event.EventViewHolder
 import org.fossasia.openevent.general.event.EventsListAdapter
 import org.fossasia.openevent.general.event.EventLayoutType
 import org.fossasia.openevent.general.utils.extensions.nonNull
@@ -116,20 +114,10 @@ class OrderCompletedFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val eventClickListener: EventClickListener = object : EventClickListener {
-            override fun onClick(eventID: Long, itemPosition: Int) {
-                var extras: Navigator.Extras? = null
-                val itemEventViewHolder = rootView.similarEventsRecycler.findViewHolderForAdapterPosition(itemPosition)
-                itemEventViewHolder?.let {
-                    if (itemEventViewHolder is EventViewHolder) {
-                        extras = FragmentNavigatorExtras(
-                            itemEventViewHolder.itemView.eventImage to "eventDetailImage")
-                    }
-                }
-                extras?.let {
-                    findNavController(view)
-                        .navigate(OrderCompletedFragmentDirections.actionOrderCompletedToEventDetail(eventID), it)
-                } ?: findNavController(view)
-                    .navigate(OrderCompletedFragmentDirections.actionOrderCompletedToEventDetail(eventID))
+            override fun onClick(eventID: Long, imageView: ImageView) {
+                findNavController(rootView)
+                    .navigate(OrderCompletedFragmentDirections.actionOrderCompletedToEventDetail(eventID),
+                        FragmentNavigatorExtras(imageView to "eventDetailImage"))
             }
         }
 

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
@@ -9,6 +9,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.CompoundButton
+import android.widget.ImageView
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -38,10 +39,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 import timber.log.Timber
 import androidx.appcompat.view.ContextThemeWrapper
 import org.fossasia.openevent.general.common.EventsDiffCallback
-import androidx.navigation.Navigator
 import androidx.navigation.fragment.FragmentNavigatorExtras
-import kotlinx.android.synthetic.main.item_card_events.view.eventImage
-import org.fossasia.openevent.general.event.EventViewHolder
 import org.fossasia.openevent.general.utils.extensions.setPostponeSharedElementTransition
 import org.fossasia.openevent.general.utils.extensions.setStartPostponedEnterTransition
 
@@ -190,20 +188,10 @@ class SearchResultsFragment : Fragment(), CompoundButton.OnCheckedChangeListener
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val eventClickListener: EventClickListener = object : EventClickListener {
-            override fun onClick(eventID: Long, itemPosition: Int) {
-                var extras: Navigator.Extras? = null
-                val itemEventViewHolder = rootView.eventsRecycler.findViewHolderForAdapterPosition(itemPosition)
-                itemEventViewHolder?.let {
-                    if (itemEventViewHolder is EventViewHolder) {
-                        extras = FragmentNavigatorExtras(
-                            itemEventViewHolder.itemView.eventImage to "eventDetailImage")
-                    }
-                }
-                extras?.let {
-                    findNavController(view).navigate(SearchResultsFragmentDirections
-                        .actionSearchResultsToEventDetail(eventId = eventID), it)
-                } ?: findNavController(view)
-                    .navigate(SearchResultsFragmentDirections.actionSearchResultsToEventDetail(eventId = eventID))
+            override fun onClick(eventID: Long, imageView: ImageView) {
+                findNavController(rootView)
+                    .navigate(SearchResultsFragmentDirections.actionSearchResultsToEventDetail(eventID),
+                        FragmentNavigatorExtras(imageView to "eventDetailImage"))
             }
         }
         val favFabClickListener: FavoriteFabClickListener = object : FavoriteFabClickListener {

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -664,8 +664,10 @@
         <action
             android:id="@+id/action_order_completed_to_event_detail"
             app:destination="@id/eventDetailsFragment"
-            app:popUpTo="@id/eventsFragment"
-            app:popUpToInclusive="false" />
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"/>
 
         <argument
             android:name="eventId"


### PR DESCRIPTION
Details:
- Shorter implementation of shared element transition
- Remove pop fragments in the stack (followed Eventbrite navigation). Initially, the crash was due to shared element transition with transition containing pop fragments in backstack (this is what I guess, from the log I couldn't really find out the real problem). I checked the implementation in Eventbrite and they don't pop fragment in backstack for this, so I remove unnecessary options on navigation
```
<action
            android:id="@+id/action_order_completed_to_event_detail"
            app:destination="@id/eventDetailsFragment"
            app:popUpTo="@id/eventsFragment" // removed
            app:popUpToInclusive="false" /> // removed
```

Fixes: #1895
