### PR TITLE
fix: crash on sign up

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
@@ -70,6 +70,16 @@ class LoginFragment : Fragment() {
 
         if (safeArgs.email.isNotEmpty()) {
             rootView.email.text = SpannableStringBuilder(safeArgs.email)
+            rootView.email.addTextChangedListener(object : TextWatcher {
+                override fun afterTextChanged(s: Editable) {
+                    if (s.toString() != safeArgs.email)
+                        findNavController(rootView).navigate(LoginFragmentDirections
+                            .actionLoginToAuthPop(redirectedFrom = safeArgs.redirectedFrom, email = s.toString()))
+                }
+
+                override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) { /*Do Nothing*/ }
+                override fun onTextChanged(email: CharSequence, start: Int, before: Int, count: Int) { /*Do Nothing*/ }
+            })
         } else if (BuildConfig.FLAVOR == PLAY_STORE_BUILD_FLAVOR) {
 
             smartAuthViewModel.requestCredentials(SmartAuthUtil.getCredentialsClient(requireActivity()))
@@ -121,18 +131,6 @@ class LoginFragment : Fragment() {
             .observe(viewLifecycleOwner, Observer {
                 loginViewModel.fetchProfile()
             })
-
-        rootView.email.addTextChangedListener(object : TextWatcher {
-            override fun afterTextChanged(s: Editable) {
-                findNavController(rootView).navigate(LoginFragmentDirections
-                    .actionLoginToAuthPop(redirectedFrom = safeArgs.redirectedFrom, email = s.toString()))
-            }
-
-            override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
-
-            override fun onTextChanged(email: CharSequence, start: Int, before: Int, count: Int) {
-            }
-        })
 
         rootView.password.addTextChangedListener(object : TextWatcher {
             override fun afterTextChanged(s: Editable) {}

--- a/app/src/main/java/org/fossasia/openevent/general/auth/SignUpFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/SignUpFragment.kt
@@ -162,8 +162,9 @@ class SignUpFragment : Fragment() {
 
         rootView.emailSignUp.addTextChangedListener(object : TextWatcher {
             override fun afterTextChanged(text: Editable?) {
-                findNavController(rootView).navigate(SignUpFragmentDirections
-                    .actionSignupToAuthPop(redirectedFrom = safeArgs.redirectedFrom, email = text.toString()))
+                if (text.toString() != safeArgs.email)
+                    findNavController(rootView).navigate(SignUpFragmentDirections
+                        .actionSignupToAuthPop(redirectedFrom = safeArgs.redirectedFrom, email = text.toString()))
             }
 
             override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) { /*Implement here*/ }

--- a/app/src/main/res/layout/fragment_signup.xml
+++ b/app/src/main/res/layout/fragment_signup.xml
@@ -31,7 +31,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/padding_medium"
-            android:layout_marginTop="@dimen/padding_medium">
+            android:layout_marginTop="@dimen/padding_medium"
+            android:hint="@string/email">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/emailSignUp"
@@ -40,7 +41,6 @@
                 android:drawableLeft="@drawable/ic_email_black"
                 android:drawablePadding="@dimen/layout_margin_moderate"
                 android:drawableStart="@drawable/ic_email_black"
-                android:hint="@string/email"
                 android:inputType="textEmailAddress" />
         </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
Details:
- Move hint from TextInputEditText to TextInputLayout due to an Android bug that create a crash
- Add check so that when clicking on Google Auth in LoginFragment, it doesn't redirect back to AuthFragment

Related issue:
https://stackoverflow.com/questions/45898228/android-attempt-to-invoke-virtual-method-void-android-view-view-getboundsonsc

Fixes: #1923 
Fixes #1920 
