### PR TITLE
fix: wrong title name in fragments

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/favorite/FavoriteFragment.kt
@@ -53,7 +53,6 @@ class FavoriteFragment : Fragment() {
         rootView.favoriteEventsRecycler.layoutManager = LinearLayoutManager(activity)
         rootView.favoriteEventsRecycler.adapter = favoriteEventsRecyclerAdapter
         rootView.favoriteEventsRecycler.isNestedScrollingEnabled = false
-        setToolbar(activity, getString(R.string.likes), false)
         rootView.viewTreeObserver.addOnDrawListener {
             setStartPostponedEnterTransition()
         }
@@ -134,6 +133,11 @@ class FavoriteFragment : Fragment() {
             onEventClick = null
             onFavFabClick = null
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        setToolbar(activity, getString(R.string.likes), false)
     }
 
     private fun showEmptyMessage(itemCount: Int) {

--- a/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/SearchResultsFragment.kt
@@ -74,8 +74,6 @@ class SearchResultsFragment : Fragment(), CompoundButton.OnCheckedChangeListener
         setPostponeSharedElementTransition()
 
         setChips()
-        setToolbar(activity, getString(R.string.search_results))
-        setHasOptionsMenu(true)
 
         rootView.eventsRecycler.layoutManager = LinearLayoutManager(context)
 
@@ -183,6 +181,12 @@ class SearchResultsFragment : Fragment(), CompoundButton.OnCheckedChangeListener
         }
         chip.setOnCheckedChangeListener(this)
         rootView.chipGroup.addView(chip)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        setToolbar(activity, getString(R.string.search_results))
+        setHasOptionsMenu(true)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {


### PR DESCRIPTION
Details:
- This is just a dirty fix. The cause of the issue is due to methods (onCreate(), onCreateView(),...) of the fragment in backstack is somehow called. Discussed in #1896 comments section. Please give me some advices on this, I think this could probably be due to navigation component or memory leak (just a guess, I don't know tbh) @iamareebjamal 

Fixes: #1896