### PR TITLE
fix: events refresh

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -187,12 +187,13 @@ class EventsFragment : Fragment(), BottomIconDoubleClick {
     }
 
     override fun onDestroyView() {
-        super.onDestroyView()
+        rootView.swiperefresh.setOnRefreshListener(null)
         eventsListAdapter.apply {
             onEventClick = null
             onFavFabClick = null
             onHashtagClick = null
         }
+        super.onDestroyView()
     }
 
     private fun openSearch(hashTag: String) {
@@ -223,11 +224,6 @@ class EventsFragment : Fragment(), BottomIconDoubleClick {
         } else {
             rootView.eventsEmptyView.visibility = View.GONE
         }
-    }
-
-    override fun onStop() {
-        rootView.swiperefresh.setOnRefreshListener(null)
-        super.onStop()
     }
 
     override fun doubleClick() = rootView.scrollView.smoothScrollTo(0, 0)


### PR DESCRIPTION
Fixes #2015 

Changes:
 deleted onStop()
  set rootView.swiperefresh.setOnRefreshListener(null) in onDestroyView()
       