### PR TITLE
fix: app crashes navigating to AuthFragment from EventDetailsFragment

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/AuthFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/AuthFragment.kt
@@ -13,7 +13,6 @@ import androidx.lifecycle.Observer
 import androidx.navigation.Navigation.findNavController
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.navArgs
-import androidx.transition.TransitionInflater
 import kotlinx.android.synthetic.main.fragment_auth.view.getStartedButton
 import kotlinx.android.synthetic.main.fragment_auth.view.email
 import kotlinx.android.synthetic.main.fragment_auth.view.emailLayout
@@ -33,6 +32,7 @@ import org.fossasia.openevent.general.utils.Utils.show
 import org.fossasia.openevent.general.utils.Utils.progressDialog
 import org.fossasia.openevent.general.utils.Utils.setToolbar
 import org.fossasia.openevent.general.utils.extensions.nonNull
+import org.fossasia.openevent.general.utils.extensions.setSharedElementEnterTransition
 import org.fossasia.openevent.general.welcome.WELCOME_FRAGMENT
 import org.jetbrains.anko.design.longSnackbar
 import org.jetbrains.anko.design.snackbar
@@ -62,7 +62,7 @@ class AuthFragment : Fragment(), ComplexBackPressFragment {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         rootView = inflater.inflate(R.layout.fragment_auth, container, false)
-        sharedElementEnterTransition = TransitionInflater.from(context).inflateTransition(android.R.transition.move)
+        setSharedElementEnterTransition()
         setupToolbar()
 
         val progressDialog = progressDialog(context)

--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
@@ -12,7 +12,6 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.Navigation.findNavController
 import androidx.navigation.fragment.navArgs
-import androidx.transition.TransitionInflater
 import kotlinx.android.synthetic.main.fragment_login.email
 import kotlinx.android.synthetic.main.fragment_login.password
 import kotlinx.android.synthetic.main.fragment_login.loginButton
@@ -39,6 +38,7 @@ import org.fossasia.openevent.general.utils.Utils.showNoInternetDialog
 import org.fossasia.openevent.general.utils.Utils.hideSoftKeyboard
 import org.fossasia.openevent.general.utils.Utils.progressDialog
 import org.fossasia.openevent.general.utils.extensions.nonNull
+import org.fossasia.openevent.general.utils.extensions.setSharedElementEnterTransition
 import org.jetbrains.anko.design.longSnackbar
 import org.jetbrains.anko.design.snackbar
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
@@ -73,7 +73,7 @@ class LoginFragment : Fragment() {
         }
 
         if (safeArgs.email.isNotEmpty()) {
-            sharedElementEnterTransition = TransitionInflater.from(context).inflateTransition(android.R.transition.move)
+            setSharedElementEnterTransition()
             rootView.email.text = SpannableStringBuilder(safeArgs.email)
             rootView.email.addTextChangedListener(object : TextWatcher {
                 override fun afterTextChanged(s: Editable) {

--- a/app/src/main/java/org/fossasia/openevent/general/auth/SignUpFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/SignUpFragment.kt
@@ -33,13 +33,13 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 import android.text.SpannableStringBuilder
 import android.text.method.LinkMovementMethod
 import androidx.navigation.fragment.navArgs
-import androidx.transition.TransitionInflater
 import org.fossasia.openevent.general.utils.StringUtils.getTermsAndPolicyText
 import org.fossasia.openevent.general.event.EVENT_DETAIL_FRAGMENT
 import org.fossasia.openevent.general.notification.NOTIFICATION_FRAGMENT
 import org.fossasia.openevent.general.order.ORDERS_FRAGMENT
 import org.fossasia.openevent.general.speakercall.SPEAKERS_CALL_FRAGMENT
 import org.fossasia.openevent.general.ticket.TICKETS_FRAGMENT
+import org.fossasia.openevent.general.utils.extensions.setSharedElementEnterTransition
 import org.jetbrains.anko.design.longSnackbar
 import org.jetbrains.anko.design.snackbar
 
@@ -57,7 +57,7 @@ class SignUpFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         rootView = inflater.inflate(R.layout.fragment_signup, container, false)
-        sharedElementEnterTransition = TransitionInflater.from(context).inflateTransition(android.R.transition.move)
+        setSharedElementEnterTransition()
 
         val progressDialog = progressDialog(context)
         setToolbar(activity, show = false)

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -89,7 +89,7 @@ import org.fossasia.openevent.general.utils.extensions.setSharedElementEnterTran
 import org.jetbrains.anko.design.longSnackbar
 import org.jetbrains.anko.design.snackbar
 
-const val EVENT_DETAIL_FRAGMENT = "eventDetailFragment;"
+const val EVENT_DETAIL_FRAGMENT = "eventDetailFragment"
 
 class EventDetailsFragment : Fragment() {
     private val eventViewModel by viewModel<EventDetailsViewModel>()

--- a/app/src/main/java/org/fossasia/openevent/general/utils/extensions/FragmentExt.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/utils/extensions/FragmentExt.kt
@@ -1,7 +1,7 @@
 package org.fossasia.openevent.general.utils.extensions
 
 import android.os.Build
-import android.transition.TransitionInflater
+import androidx.transition.TransitionInflater
 import androidx.fragment.app.Fragment
 
 const val SUPPORTED_TRANSITION_VERSION = Build.VERSION_CODES.O


### PR DESCRIPTION
Details:
- Cause of the problem is because of the TransitionInflater imported in EventDetailsFragment is not compatible with AuthFragment. One use AndroidX and one use normal Android library

Fixes: #2029
